### PR TITLE
Resend email integration on larry-pm.com

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -57,6 +57,8 @@ EMAIL_CONNECTOR_OAUTH_STATE_TTL_SECONDS=3600
 CORS_ORIGINS=http://localhost:3000
 REQUIRE_TENANT_HEADER=false
 
-# Email sending (Resend)
+# Email sending (Resend) — verified domain: larry-site.com
 RESEND_API_KEY=
+RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
+RESEND_FROM_LARRY=Larry <larry@larry-site.com>
 FRONTEND_URL=http://localhost:3000

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -57,8 +57,8 @@ EMAIL_CONNECTOR_OAUTH_STATE_TTL_SECONDS=3600
 CORS_ORIGINS=http://localhost:3000
 REQUIRE_TENANT_HEADER=false
 
-# Email sending (Resend) — verified domain: larry-site.com
+# Email sending (Resend) — verified domain: larry-pm.com
 RESEND_API_KEY=
-RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
-RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
+RESEND_FROM_LARRY=Larry <larry@larry-pm.com>
 FRONTEND_URL=http://localhost:3000

--- a/apps/api/src/lib/email.test.ts
+++ b/apps/api/src/lib/email.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMock = vi.fn();
+
+vi.mock("resend", () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: { send: sendMock },
+  })),
+}));
+
+const NOREPLY = "Larry <noreply@larry-site.com>";
+const LARRY = "Larry <larry@larry-site.com>";
+
+describe("email.ts FROM mapping", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({ data: { id: "test-id" }, error: null });
+    process.env.RESEND_API_KEY = "re_test_key";
+    process.env.RESEND_FROM_NOREPLY = NOREPLY;
+    process.env.RESEND_FROM_LARRY = LARRY;
+    process.env.FRONTEND_URL = "https://app.example.com";
+  });
+
+  afterEach(() => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.RESEND_FROM_NOREPLY;
+    delete process.env.RESEND_FROM_LARRY;
+    delete process.env.FRONTEND_URL;
+  });
+
+  it("sendPasswordResetEmail uses noreply sender", async () => {
+    const mod = await import("./email");
+    await mod.sendPasswordResetEmail("u@example.com", "https://x/reset");
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
+  });
+
+  it("sendVerificationEmail uses noreply sender", async () => {
+    const mod = await import("./email");
+    await mod.sendVerificationEmail("u@example.com", "https://x/verify");
+    expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
+  });
+
+  it("sendEmailChangeConfirmation uses noreply sender", async () => {
+    const mod = await import("./email");
+    await mod.sendEmailChangeConfirmation("u@example.com", "https://x/confirm");
+    expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
+  });
+
+  it("sendEmailChangeNotification uses noreply sender", async () => {
+    const mod = await import("./email");
+    await mod.sendEmailChangeNotification("u@example.com");
+    expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
+  });
+
+  it("sendNewDeviceAlert uses noreply sender", async () => {
+    const mod = await import("./email");
+    await mod.sendNewDeviceAlert("u@example.com", { browser: "Chrome", os: "macOS" });
+    expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
+  });
+
+  it("sendMemberInviteEmail uses larry sender", async () => {
+    const mod = await import("./email");
+    await mod.sendMemberInviteEmail("u@example.com", "Anna");
+    expect(sendMock.mock.calls[0][0].from).toBe(LARRY);
+  });
+});

--- a/apps/api/src/lib/email.test.ts
+++ b/apps/api/src/lib/email.test.ts
@@ -8,8 +8,8 @@ vi.mock("resend", () => ({
   })),
 }));
 
-const NOREPLY = "Larry <noreply@larry-site.com>";
-const LARRY = "Larry <larry@larry-site.com>";
+const NOREPLY = "Larry <noreply@larry-pm.com>";
+const LARRY = "Larry <larry@larry-pm.com>";
 
 describe("email.ts FROM mapping", () => {
   beforeEach(() => {

--- a/apps/api/src/lib/email.test.ts
+++ b/apps/api/src/lib/email.test.ts
@@ -30,38 +30,38 @@ describe("email.ts FROM mapping", () => {
   });
 
   it("sendPasswordResetEmail uses noreply sender", async () => {
-    const mod = await import("./email");
+    const mod = await import("./email.js");
     await mod.sendPasswordResetEmail("u@example.com", "https://x/reset");
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
   });
 
   it("sendVerificationEmail uses noreply sender", async () => {
-    const mod = await import("./email");
+    const mod = await import("./email.js");
     await mod.sendVerificationEmail("u@example.com", "https://x/verify");
     expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
   });
 
   it("sendEmailChangeConfirmation uses noreply sender", async () => {
-    const mod = await import("./email");
+    const mod = await import("./email.js");
     await mod.sendEmailChangeConfirmation("u@example.com", "https://x/confirm");
     expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
   });
 
   it("sendEmailChangeNotification uses noreply sender", async () => {
-    const mod = await import("./email");
+    const mod = await import("./email.js");
     await mod.sendEmailChangeNotification("u@example.com");
     expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
   });
 
   it("sendNewDeviceAlert uses noreply sender", async () => {
-    const mod = await import("./email");
+    const mod = await import("./email.js");
     await mod.sendNewDeviceAlert("u@example.com", { browser: "Chrome", os: "macOS" });
     expect(sendMock.mock.calls[0][0].from).toBe(NOREPLY);
   });
 
   it("sendMemberInviteEmail uses larry sender", async () => {
-    const mod = await import("./email");
+    const mod = await import("./email.js");
     await mod.sendMemberInviteEmail("u@example.com", "Anna");
     expect(sendMock.mock.calls[0][0].from).toBe(LARRY);
   });

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,6 +1,7 @@
 import { Resend } from "resend";
 
-const FROM = "Larry <noreply@larry.app>";
+const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-site.com>";
+const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-site.com>";
 
 let resendInstance: Resend | null = null;
 
@@ -61,7 +62,7 @@ export async function sendPasswordResetEmail(to: string, resetUrl: string): Prom
   }
   const resend = getResend();
   const { error } = await resend.emails.send({
-    from: FROM,
+    from: FROM_NOREPLY,
     to,
     subject: "Reset your password",
     html: wrapHtml(`
@@ -88,7 +89,7 @@ export async function sendVerificationEmail(to: string, verifyUrl: string): Prom
   }
   const resend = getResend();
   const { error } = await resend.emails.send({
-    from: FROM,
+    from: FROM_NOREPLY,
     to,
     subject: "Verify your email address",
     html: wrapHtml(`
@@ -115,7 +116,7 @@ export async function sendEmailChangeConfirmation(to: string, confirmUrl: string
   }
   const resend = getResend();
   const { error } = await resend.emails.send({
-    from: FROM,
+    from: FROM_NOREPLY,
     to,
     subject: "Confirm your new email address",
     html: wrapHtml(`
@@ -143,7 +144,7 @@ export async function sendEmailChangeNotification(to: string): Promise<void> {
   const resend = getResend();
   const frontendUrl = getFrontendUrl();
   const { error } = await resend.emails.send({
-    from: FROM,
+    from: FROM_NOREPLY,
     to,
     subject: "Your email address is being changed",
     html: wrapHtml(`
@@ -187,7 +188,7 @@ export async function sendNewDeviceAlert(to: string, deviceInfo: DeviceInfo): Pr
     .join("");
 
   const { error } = await resend.emails.send({
-    from: FROM,
+    from: FROM_NOREPLY,
     to,
     subject: "New sign-in to your Larry account",
     html: wrapHtml(`
@@ -221,7 +222,7 @@ export async function sendMemberInviteEmail(to: string, displayName: string): Pr
   const frontendUrl = getFrontendUrl();
   const safeName = escapeHtml(displayName);
   const { error } = await resend.emails.send({
-    from: FROM,
+    from: FROM_LARRY,
     to,
     subject: "You've been invited to Larry",
     html: wrapHtml(`

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,7 +1,7 @@
 import { Resend } from "resend";
 
-const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-site.com>";
-const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-site.com>";
+const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-pm.com>";
+const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-pm.com>";
 
 let resendInstance: Resend | null = null;
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,10 +4,10 @@ ADMIN_SECRET=
 # Shared with API — used to verify Google OAuth one-time codes
 JWT_ACCESS_SECRET=
 
-# Email sending (Resend) — verified domain: larry-site.com
+# Email sending (Resend) — verified domain: larry-pm.com
 RESEND_API_KEY=
-RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
-RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
+RESEND_FROM_LARRY=Larry <larry@larry-pm.com>
 
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,7 +3,12 @@ ADMIN_SECRET=
 
 # Shared with API — used to verify Google OAuth one-time codes
 JWT_ACCESS_SECRET=
+
+# Email sending (Resend) — verified domain: larry-site.com
 RESEND_API_KEY=
+RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
+RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 # Redis — used for login rate limiting across all function instances.

--- a/apps/web/src/app/api/referral/route.ts
+++ b/apps/web/src/app/api/referral/route.ts
@@ -60,7 +60,7 @@ export async function POST(req: NextRequest) {
   const resend = new Resend(resendKey);
 
   const { error } = await resend.emails.send({
-    from: "Larry <noreply@larry-site.vercel.app>",
+    from: process.env.RESEND_FROM_LARRY ?? "Larry <larry@larry-site.com>",
     to: friendEmail,
     subject: `${referrerEmail} invited you to join Larry`,
     html: `

--- a/apps/web/src/app/api/referral/route.ts
+++ b/apps/web/src/app/api/referral/route.ts
@@ -60,7 +60,7 @@ export async function POST(req: NextRequest) {
   const resend = new Resend(resendKey);
 
   const { error } = await resend.emails.send({
-    from: process.env.RESEND_FROM_LARRY ?? "Larry <larry@larry-site.com>",
+    from: process.env.RESEND_FROM_LARRY ?? "Larry <larry@larry-pm.com>",
     to: friendEmail,
     subject: `${referrerEmail} invited you to join Larry`,
     html: `

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -24,7 +24,7 @@ GEMINI_MODEL=gemini-1.5-flash
 
 # Email delivery for escalation notifications (optional)
 # Get a key at https://resend.com — free tier sends 100 emails/day
-# Verified domain: larry-site.com
+# Verified domain: larry-pm.com
 RESEND_API_KEY=
-RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
-RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
+RESEND_FROM_LARRY=Larry <larry@larry-pm.com>

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -24,5 +24,7 @@ GEMINI_MODEL=gemini-1.5-flash
 
 # Email delivery for escalation notifications (optional)
 # Get a key at https://resend.com — free tier sends 100 emails/day
+# Verified domain: larry-site.com
 RESEND_API_KEY=
-RESEND_FROM=Larry <noreply@yourdomain.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
+RESEND_FROM_LARRY=Larry <larry@larry-site.com>

--- a/apps/worker/src/escalation.ts
+++ b/apps/worker/src/escalation.ts
@@ -220,7 +220,7 @@ export async function runEscalationScan(): Promise<void> {
                 "Content-Type": "application/json",
               },
               body: JSON.stringify({
-                from: env.RESEND_FROM,
+                from: env.RESEND_FROM_LARRY,
                 to: [userEmail],
                 subject: notif.subject,
                 text: notif.body,

--- a/docs/superpowers/plans/2026-04-14-resend-email-integration.md
+++ b/docs/superpowers/plans/2026-04-14-resend-email-integration.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Wire up production Resend email delivery using verified domain `larry-site.com` with two senders (`noreply@` for security, `larry@` for product), shared `RESEND_API_KEY` across Vercel (web) + Railway (api + worker), with TDD coverage on the FROM mapping.
+**Goal:** Wire up production Resend email delivery using verified domain `larry-pm.com` with two senders (`noreply@` for security, `larry@` for product), shared `RESEND_API_KEY` across Vercel (web) + Railway (api + worker), with TDD coverage on the FROM mapping.
 
 **Architecture:** Replace the single hardcoded `FROM` in `apps/api/src/lib/email.ts` and the single `RESEND_FROM` env var with a pair: `RESEND_FROM_NOREPLY` and `RESEND_FROM_LARRY`. Each of the 6 transactional functions, the worker escalation, and the web referral route maps to the appropriate sender. Existing `isResendConfigured()` console-log fallback is preserved as a kill switch.
 
@@ -40,8 +40,8 @@
 **This entire plan blocks on the user completing Phase A from the spec.** Before starting Task 1, the user must:
 
 1. Sign up at resend.com using GitHub `led1299`.
-2. Add `larry-site.com` as a domain in Resend, configure DNS (SPF/DKIM/DMARC), wait for all 3 records to verify green.
-3. Create an API key named `larry-prod`, scoped to `larry-site.com`, with `Sending access` permission.
+2. Add `larry-pm.com` as a domain in Resend, configure DNS (SPF/DKIM/DMARC), wait for all 3 records to verify green.
+3. Create an API key named `larry-prod`, scoped to `larry-pm.com`, with `Sending access` permission.
 4. Provide the API key to the executor (paste in chat OR write to `apps/api/.env.local`).
 
 **Code tasks (1–6) can begin in parallel with Phase A** — they don't need the API key. **Tasks 7+ require the key in hand.**
@@ -91,8 +91,8 @@ Replace it with:
 
 ```ts
 RESEND_API_KEY: z.string().optional(),
-RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-site.com>"),
-RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-site.com>"),
+RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-pm.com>"),
+RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-pm.com>"),
 ```
 
 - [ ] **Step 2: Update WorkerSchema — replace RESEND_FROM with the two new vars**
@@ -108,8 +108,8 @@ Replace with:
 
 ```ts
 RESEND_API_KEY: z.string().optional(),
-RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-site.com>"),
-RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-site.com>"),
+RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-pm.com>"),
+RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-pm.com>"),
 ```
 
 - [ ] **Step 3: Type-check the package**
@@ -126,7 +126,7 @@ git add packages/config/src/index.ts && \
 git commit -m "feat(config): add RESEND_FROM_NOREPLY and RESEND_FROM_LARRY env vars
 
 Replaces single RESEND_FROM with a noreply/larry pair so security and
-product emails can be sent from distinct addresses on larry-site.com."
+product emails can be sent from distinct addresses on larry-pm.com."
 ```
 
 ---
@@ -151,8 +151,8 @@ vi.mock("resend", () => ({
   })),
 }));
 
-const NOREPLY = "Larry <noreply@larry-site.com>";
-const LARRY = "Larry <larry@larry-site.com>";
+const NOREPLY = "Larry <noreply@larry-pm.com>";
+const LARRY = "Larry <larry@larry-pm.com>";
 
 describe("email.ts FROM mapping", () => {
   beforeEach(() => {
@@ -217,7 +217,7 @@ Run: `cd /c/Dev/larry/site-deploys/larry-site/apps/api && npx vitest run src/lib
 
 Expected: All 6 tests fail with assertions like:
 ```
-AssertionError: expected 'Larry <noreply@larry.app>' to be 'Larry <noreply@larry-site.com>'
+AssertionError: expected 'Larry <noreply@larry.app>' to be 'Larry <noreply@larry-pm.com>'
 ```
 
 If tests pass, the test file is wrong — fix it before continuing. The whole point is that the tests assert the NEW behaviour against the OLD code.
@@ -240,8 +240,8 @@ const FROM = "Larry <noreply@larry.app>";
 Replace with:
 
 ```ts
-const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-site.com>";
-const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-site.com>";
+const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-pm.com>";
+const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-pm.com>";
 ```
 
 - [ ] **Step 2: Update each `from: FROM` to the correct constant**
@@ -280,8 +280,8 @@ git add apps/api/src/lib/email.ts apps/api/src/lib/email.test.ts && \
 git commit -m "feat(email): split FROM into noreply/larry pair with mapping tests
 
 Auth/security emails (password reset, verification, email change,
-new-device alert) use noreply@larry-site.com. Workspace invites use
-larry@larry-site.com. Adds vitest coverage asserting each function
+new-device alert) use noreply@larry-pm.com. Workspace invites use
+larry@larry-pm.com. Adds vitest coverage asserting each function
 calls Resend with the correct from address."
 ```
 
@@ -353,7 +353,7 @@ from: "Larry <noreply@larry-site.vercel.app>",
 Replace with:
 
 ```ts
-from: process.env.RESEND_FROM_LARRY ?? "Larry <larry@larry-site.com>",
+from: process.env.RESEND_FROM_LARRY ?? "Larry <larry@larry-pm.com>",
 ```
 
 - [ ] **Step 2: Type-check the web app**
@@ -367,7 +367,7 @@ Run:
 ```bash
 cd /c/Dev/larry/site-deploys/larry-site && \
 git add apps/web/src/app/api/referral/route.ts && \
-git commit -m "fix(web): use larry@larry-site.com for referral emails
+git commit -m "fix(web): use larry@larry-pm.com for referral emails
 
 Previous hardcoded sender was noreply@larry-site.vercel.app — a Vercel
 preview hostname that cannot be SPF-aligned, so referral emails would
@@ -393,8 +393,8 @@ RESEND_API_KEY=
 Replace with:
 ```
 RESEND_API_KEY=
-RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
-RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
+RESEND_FROM_LARRY=Larry <larry@larry-pm.com>
 ```
 
 - [ ] **Step 2: Update apps/web/.env.example**
@@ -407,8 +407,8 @@ RESEND_API_KEY=
 Replace with:
 ```
 RESEND_API_KEY=
-RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
-RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
+RESEND_FROM_LARRY=Larry <larry@larry-pm.com>
 ```
 
 - [ ] **Step 3: Update apps/worker/.env.example**
@@ -422,8 +422,8 @@ RESEND_FROM=Larry <noreply@yourdomain.com>
 Replace with:
 ```
 RESEND_API_KEY=
-RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
-RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
+RESEND_FROM_LARRY=Larry <larry@larry-pm.com>
 ```
 
 - [ ] **Step 4: Commit**
@@ -450,7 +450,7 @@ Run: `cd /c/Dev/larry/site-deploys/larry-site && grep -nE "RESEND_FROM|larry\.ap
 - [ ] **Step 2: Update each match**
 
 For each line found, judge case-by-case:
-- If it describes the email **FROM address** (e.g., "emails sent from `noreply@larry.app`"), update to `larry-site.com`.
+- If it describes the email **FROM address** (e.g., "emails sent from `noreply@larry.app`"), update to `larry-pm.com`.
 - If it references `larry.app` as a URL, marketing domain, or unrelated context, **leave it alone**.
 - If it mentions `RESEND_FROM` env var, update to mention the new pair `RESEND_FROM_NOREPLY` + `RESEND_FROM_LARRY`.
 
@@ -461,7 +461,7 @@ If no changes needed, skip. Otherwise:
 ```bash
 cd /c/Dev/larry/site-deploys/larry-site && \
 git add docs/CONNECTORS.md SECURITY-REVIEW.md && \
-git commit -m "docs: update Resend references to larry-site.com domain"
+git commit -m "docs: update Resend references to larry-pm.com domain"
 ```
 
 ---
@@ -484,8 +484,8 @@ Wait until the latest "Backend CI" run shows `completed success`. If it fails, i
 
 Before continuing, the user must confirm:
 - ✓ Resend account created via GitHub `led1299`
-- ✓ Domain `larry-site.com` verified (all 3 DNS records green in Resend dashboard)
-- ✓ API key `larry-prod` created with sending access scoped to `larry-site.com`
+- ✓ Domain `larry-pm.com` verified (all 3 DNS records green in Resend dashboard)
+- ✓ API key `larry-prod` created with sending access scoped to `larry-pm.com`
 - ✓ API key in hand (pasted in chat OR written to `apps/api/.env.local`)
 
 If any of the above isn't true, STOP and surface the gap to the user.
@@ -506,8 +506,8 @@ Expected: confirms link to `loouuiis-projects/ailarry`.
 For each of these three vars, run `vercel env add <NAME> production` and paste the value when prompted:
 
 - `RESEND_API_KEY` → the key from Resend dashboard
-- `RESEND_FROM_NOREPLY` → `Larry <noreply@larry-site.com>`
-- `RESEND_FROM_LARRY` → `Larry <larry@larry-site.com>`
+- `RESEND_FROM_NOREPLY` → `Larry <noreply@larry-pm.com>`
+- `RESEND_FROM_LARRY` → `Larry <larry@larry-pm.com>`
 
 - [ ] **Step 3: Add vars to Vercel — preview env**
 
@@ -528,8 +528,8 @@ Expected: shows linked project and service. If not, run `railway link` and selec
 Run:
 ```bash
 railway variables --set "RESEND_API_KEY=<KEY>" \
-  --set "RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>" \
-  --set "RESEND_FROM_LARRY=Larry <larry@larry-site.com>"
+  --set "RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>" \
+  --set "RESEND_FROM_LARRY=Larry <larry@larry-pm.com>"
 ```
 
 - [ ] **Step 7: Switch to worker service and set vars**
@@ -539,8 +539,8 @@ Run: `railway service` → select worker service.
 Then:
 ```bash
 railway variables --set "RESEND_API_KEY=<KEY>" \
-  --set "RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>" \
-  --set "RESEND_FROM_LARRY=Larry <larry@larry-site.com>"
+  --set "RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>" \
+  --set "RESEND_FROM_LARRY=Larry <larry@larry-pm.com>"
 ```
 
 - [ ] **Step 8: Verify Railway vars on both services**
@@ -585,13 +585,13 @@ if (!TO) {
 
 async function run() {
   console.log("→ password reset");
-  await sendPasswordResetEmail(TO, "https://larry-site.com/reset?token=test");
+  await sendPasswordResetEmail(TO, "https://larry-pm.com/reset?token=test");
 
   console.log("→ verification");
-  await sendVerificationEmail(TO, "https://larry-site.com/verify?token=test");
+  await sendVerificationEmail(TO, "https://larry-pm.com/verify?token=test");
 
   console.log("→ email change confirm");
-  await sendEmailChangeConfirmation(TO, "https://larry-site.com/confirm-email?token=test");
+  await sendEmailChangeConfirmation(TO, "https://larry-pm.com/confirm-email?token=test");
 
   console.log("→ email change notification");
   await sendEmailChangeNotification(TO);
@@ -624,9 +624,9 @@ Expected: 6 lines of `→ ...` output and `All 6 sent.`
 
 Open the test inbox. Confirm:
 - All 6 emails arrived (not in spam).
-- 5 are from `Larry <noreply@larry-site.com>`; 1 (member invite) from `Larry <larry@larry-site.com>`.
+- 5 are from `Larry <noreply@larry-pm.com>`; 1 (member invite) from `Larry <larry@larry-pm.com>`.
 - HTML renders correctly with the purple Larry "L" badge.
-- Links in CTAs point to `https://larry-site.com/...`.
+- Links in CTAs point to `https://larry-pm.com/...`.
 
 If any are in spam: mark as "Not spam," let inbox provider learn. If still landing in spam after multiple sends, investigate DMARC/SPF alignment in Resend dashboard before continuing.
 
@@ -659,7 +659,7 @@ gh pr create --base master --head feat/resend-integration \
   --title "Resend email integration (production rollout)" \
   --body "$(cat <<'EOF'
 ## Summary
-- Replace single hardcoded FROM with a NOREPLY / LARRY env var pair for distinct sender personas on `larry-site.com`.
+- Replace single hardcoded FROM with a NOREPLY / LARRY env var pair for distinct sender personas on `larry-pm.com`.
 - Map auth/security emails to `noreply@`; workspace invites, escalations, and referrals to `larry@`.
 - Fix referral route's broken FROM (was unalignable Vercel preview hostname).
 - Add vitest coverage on FROM mapping for all 6 transactional emails.
@@ -706,19 +706,19 @@ Railway: Run `railway status` for both api and worker services. Wait until both 
 
 In a private/incognito browser, go to the production frontend. Sign up with a fresh email address (use `+resend-smoke-1@yourdomain.com` style alias).
 
-Expected: signup completes; verification email arrives within 30 seconds; from = `Larry <noreply@larry-site.com>`; clicking the link verifies the address; redirect to dashboard succeeds.
+Expected: signup completes; verification email arrives within 30 seconds; from = `Larry <noreply@larry-pm.com>`; clicking the link verifies the address; redirect to dashboard succeeds.
 
 - [ ] **Step 2: Forgot password → reset email**
 
 Sign out. Click "Forgot password" → enter the email from Step 1.
 
-Expected: reset email arrives; from = `noreply@larry-site.com`; clicking the link allows password change; new password works for sign-in.
+Expected: reset email arrives; from = `noreply@larry-pm.com`; clicking the link allows password change; new password works for sign-in.
 
 - [ ] **Step 3: Workspace invite → larry@ email**
 
 Sign in as the original test account. Invite a fresh email to your workspace.
 
-Expected: invite email arrives; from = `Larry <larry@larry-site.com>` (the friendly sender); subject = "You've been invited to Larry."
+Expected: invite email arrives; from = `Larry <larry@larry-pm.com>` (the friendly sender); subject = "You've been invited to Larry."
 
 - [ ] **Step 4: Confirm Resend dashboard shows production sends**
 
@@ -767,7 +767,7 @@ git commit -m "docs(spec): record inbox matrix results from production smoke tes
 
 - [ ] **Step 5: Done**
 
-Update memory: add a note that Larry's transactional email is live on Resend with verified `larry-site.com` domain, dual senders (`noreply@` + `larry@`), and the `isResendConfigured()` kill switch is the rollback path.
+Update memory: add a note that Larry's transactional email is live on Resend with verified `larry-pm.com` domain, dual senders (`noreply@` + `larry@`), and the `isResendConfigured()` kill switch is the rollback path.
 
 ---
 
@@ -778,4 +778,4 @@ Update memory: add a note that Larry's transactional email is live on Resend wit
 - Type-checks before commits in Tasks 2, 5, 6.
 - Rollback path explicit in Task 13.
 - No placeholders: every code change shows the exact before/after content.
-- Domain: `larry-site.com`. Senders: `noreply@` and `larry@`. Env vars: `RESEND_API_KEY`, `RESEND_FROM_NOREPLY`, `RESEND_FROM_LARRY` (these names are stable across all tasks).
+- Domain: `larry-pm.com`. Senders: `noreply@` and `larry@`. Env vars: `RESEND_API_KEY`, `RESEND_FROM_NOREPLY`, `RESEND_FROM_LARRY` (these names are stable across all tasks).

--- a/docs/superpowers/specs/2026-04-06-production-auth-system-design.md
+++ b/docs/superpowers/specs/2026-04-06-production-auth-system-design.md
@@ -115,7 +115,7 @@ No RLS — table is accessed by the API service role only, not tenant-scoped.
 
 ### Email Template
 
-- From: `Larry <noreply@larry-site.com>` (updated 2026-04-14 — see `2026-04-14-resend-email-integration-design.md`)
+- From: `Larry <noreply@larry-pm.com>` (updated 2026-04-14 — see `2026-04-14-resend-email-integration-design.md`)
 - Subject: "Reset your Larry password"
 - Body: Branded Larry email with single CTA button linking to `{FRONTEND_URL}/reset-password?token={rawToken}`
 - Plain text fallback included
@@ -207,7 +207,7 @@ Checked in the web middleware (`middleware.ts`) and/or workspace layout:
 
 ### Email Template
 
-- From: `Larry <noreply@larry-site.com>` (updated 2026-04-14 — see `2026-04-14-resend-email-integration-design.md`)
+- From: `Larry <noreply@larry-pm.com>` (updated 2026-04-14 — see `2026-04-14-resend-email-integration-design.md`)
 - Subject: "Verify your email for Larry"
 - Body: Branded Larry email with CTA button to `{FRONTEND_URL}/verify-email?token={rawToken}`
 - Footer: "If you didn't create a Larry account, ignore this email."

--- a/docs/superpowers/specs/2026-04-06-production-auth-system-design.md
+++ b/docs/superpowers/specs/2026-04-06-production-auth-system-design.md
@@ -115,7 +115,7 @@ No RLS — table is accessed by the API service role only, not tenant-scoped.
 
 ### Email Template
 
-- From: `Larry <noreply@larry.app>`
+- From: `Larry <noreply@larry-site.com>` (updated 2026-04-14 — see `2026-04-14-resend-email-integration-design.md`)
 - Subject: "Reset your Larry password"
 - Body: Branded Larry email with single CTA button linking to `{FRONTEND_URL}/reset-password?token={rawToken}`
 - Plain text fallback included
@@ -207,7 +207,7 @@ Checked in the web middleware (`middleware.ts`) and/or workspace layout:
 
 ### Email Template
 
-- From: `Larry <noreply@larry.app>`
+- From: `Larry <noreply@larry-site.com>` (updated 2026-04-14 — see `2026-04-14-resend-email-integration-design.md`)
 - Subject: "Verify your email for Larry"
 - Body: Branded Larry email with CTA button to `{FRONTEND_URL}/verify-email?token={rawToken}`
 - Footer: "If you didn't create a Larry account, ignore this email."

--- a/docs/superpowers/specs/2026-04-14-resend-email-integration-design.md
+++ b/docs/superpowers/specs/2026-04-14-resend-email-integration-design.md
@@ -32,14 +32,14 @@ This spec covers the production rollout: domain, sender strategy, env provisioni
 
 ### Domain & senders
 
-Single verified domain: **`larry-site.com`** (Louis confirmed ownership; verification still required at registrar).
+Single verified domain: **`larry-pm.com`** (Louis confirmed ownership; verification still required at registrar).
 
 Two senders on that domain:
 
 | Sender | Purpose | Voice |
 |---|---|---|
-| `Larry <noreply@larry-site.com>` | Security/transactional. Replies ignored. | Impersonal, automated. |
-| `Larry <larry@larry-site.com>` | Product communications. Personifies the product. | Friendly, in-character. |
+| `Larry <noreply@larry-pm.com>` | Security/transactional. Replies ignored. | Impersonal, automated. |
+| `Larry <larry@larry-pm.com>` | Product communications. Personifies the product. | Friendly, in-character. |
 
 Both are verified by verifying the **domain** in Resend; no per-address verification needed.
 
@@ -50,8 +50,8 @@ Replaces the existing single `RESEND_FROM` env var with a pair:
 | Variable | Value | Notes |
 |---|---|---|
 | `RESEND_API_KEY` | (from Resend dashboard) | Same key on Vercel + Railway api + Railway worker. |
-| `RESEND_FROM_NOREPLY` | `Larry <noreply@larry-site.com>` | Default in code matches this. |
-| `RESEND_FROM_LARRY` | `Larry <larry@larry-site.com>` | Default in code matches this. |
+| `RESEND_FROM_NOREPLY` | `Larry <noreply@larry-pm.com>` | Default in code matches this. |
+| `RESEND_FROM_LARRY` | `Larry <larry@larry-pm.com>` | Default in code matches this. |
 
 The schema in `packages/config/src/index.ts` makes `RESEND_API_KEY` optional (preserving the kill-switch / dev fallback) and provides hardcoded defaults for the two FROM vars so a missing env doesn't break boot.
 
@@ -72,8 +72,8 @@ The schema in `packages/config/src/index.ts` makes `RESEND_API_KEY` optional (pr
 
 ### Reply handling
 
-- `noreply@larry-site.com` — drop silently for v1. Optional follow-up: configure auto-responder pointing users to the in-app contact channel.
-- `larry@larry-site.com` — forward to Louis's inbox via registrar/email host; out of scope for this spec but should be set up before any volume hits.
+- `noreply@larry-pm.com` — drop silently for v1. Optional follow-up: configure auto-responder pointing users to the in-app contact channel.
+- `larry@larry-pm.com` — forward to Louis's inbox via registrar/email host; out of scope for this spec but should be set up before any volume hits.
 
 ## Code changes
 
@@ -85,8 +85,8 @@ Both the api schema and worker schema:
 
 ```ts
 RESEND_API_KEY: z.string().optional(),
-RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-site.com>"),
-RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-site.com>"),
+RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-pm.com>"),
+RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-pm.com>"),
 ```
 
 Remove the existing `RESEND_FROM` line in the worker schema.
@@ -96,8 +96,8 @@ Remove the existing `RESEND_FROM` line in the worker schema.
 Replace the hardcoded `const FROM = "Larry <noreply@larry.app>"` with:
 
 ```ts
-const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-site.com>";
-const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-site.com>";
+const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-pm.com>";
+const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-pm.com>";
 ```
 
 Per-function changes (swap `from: FROM` → the right constant):
@@ -123,8 +123,8 @@ Switch its `from` to use `RESEND_FROM_LARRY` (read from `process.env`, with the 
 
 ```
 RESEND_API_KEY=
-RESEND_FROM_NOREPLY=Larry <noreply@larry-site.com>
-RESEND_FROM_LARRY=Larry <larry@larry-site.com>
+RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
+RESEND_FROM_LARRY=Larry <larry@larry-pm.com>
 ```
 
 ### 6. Tests
@@ -142,10 +142,10 @@ RESEND_FROM_LARRY=Larry <larry@larry-site.com>
 ### Phase A — Resend account & domain (Louis, ~10 min)
 
 1. Sign up at resend.com using "Sign in with GitHub" (account `led1299`).
-2. Dashboard → **Domains** → add `larry-site.com`.
-3. Add the 3 DNS records (SPF/TXT, DKIM/CNAME ×2 or TXT, DMARC/TXT) at the registrar for `larry-site.com`.
+2. Dashboard → **Domains** → add `larry-pm.com`.
+3. Add the 3 DNS records (SPF/TXT, DKIM/CNAME ×2 or TXT, DMARC/TXT) at the registrar for `larry-pm.com`.
 4. Click **Verify** in Resend until all 3 records show green.
-5. **API Keys** → New → name `larry-prod`, permission `Sending access`, scoped to `larry-site.com`. Copy the key.
+5. **API Keys** → New → name `larry-prod`, permission `Sending access`, scoped to `larry-pm.com`. Copy the key.
 6. Hand the key to Claude. Acceptable channels: paste in chat (key is never persisted to disk by Claude), or write to `apps/api/.env.local` and tell Claude. Do NOT commit the key. Do NOT email it.
 
 ### Phase B — env injection (Claude, ~2 min)

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -58,16 +58,16 @@ const ApiSchema = SharedSchema.extend({
   GMAIL_REDIRECT_URI: z.string().url().optional(),
   GMAIL_SCOPES: z.string().default("https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/userinfo.email"),
   RESEND_API_KEY: z.string().optional(),
-  RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-site.com>"),
-  RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-site.com>"),
+  RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-pm.com>"),
+  RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-pm.com>"),
   FRONTEND_URL: z.string().url().optional(),
 });
 
 const WorkerSchema = SharedSchema.extend({
   WORKER_CONCURRENCY: z.coerce.number().int().positive().default(5),
   RESEND_API_KEY: z.string().optional(),
-  RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-site.com>"),
-  RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-site.com>"),
+  RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-pm.com>"),
+  RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-pm.com>"),
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   GOOGLE_CALENDAR_WEBHOOK_URL: z.string().url().optional(),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -58,13 +58,16 @@ const ApiSchema = SharedSchema.extend({
   GMAIL_REDIRECT_URI: z.string().url().optional(),
   GMAIL_SCOPES: z.string().default("https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/userinfo.email"),
   RESEND_API_KEY: z.string().optional(),
+  RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-site.com>"),
+  RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-site.com>"),
   FRONTEND_URL: z.string().url().optional(),
 });
 
 const WorkerSchema = SharedSchema.extend({
   WORKER_CONCURRENCY: z.coerce.number().int().positive().default(5),
   RESEND_API_KEY: z.string().optional(),
-  RESEND_FROM: z.string().default("Larry <noreply@larry.app>"),
+  RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-site.com>"),
+  RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-site.com>"),
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   GOOGLE_CALENDAR_WEBHOOK_URL: z.string().url().optional(),


### PR DESCRIPTION
## Summary
- Wires up production Resend email delivery for Larry's 6 existing transactional email functions plus the worker escalation and web referral route.
- Verified sending domain: `larry-pm.com` via subdomain verification (`send.larry-pm.com`) — zero conflict with the existing Zoho Mail records at root.
- Two senders: `Larry <noreply@larry-pm.com>` (security/auth) and `Larry <larry@larry-pm.com>` (product comms).
- Replaces the single hardcoded `FROM` with a `RESEND_FROM_NOREPLY` / `RESEND_FROM_LARRY` pair driven by env vars.
- Fixes a latent bug in the web referral route (was using `noreply@larry-site.vercel.app` — an unalignable Vercel preview hostname that would have bounced every referral email).
- TDD: `apps/api/src/lib/email.test.ts` mocks Resend and asserts each function sends with the correct FROM.

## Test plan
- [x] Unit tests pass (vitest: 6/6 in email.test.ts)
- [x] Full api + worker test suites pass (320 + 21, no regressions)
- [x] CI green on the branch
- [x] Local integration test: all 6 email functions sent real emails via production Resend key to `oreillfe@tcd.ie`. All landed in TCD Exchange **inbox** (not junk) on first send. Resend dashboard: all `Delivered`, SPF/DKIM/DMARC all green.
- [x] Env vars injected on Vercel (production) and Railway (api + worker services)
- [ ] Post-merge: production smoke test (real signup → verify → reset → invite flows)
- [ ] Post-merge: inbox provider matrix (Gmail + Outlook + corporate Exchange)

## Rollout notes
- `isResendConfigured()` guard preserved → setting `RESEND_API_KEY=""` on Railway is a zero-downtime kill switch.
- Vercel preview env vars not set (CLI quirk with `--value` + non-interactive); not blocking because the guard means preview deploys log to console instead of crashing. Follow-up to add later if needed.

## References
- Spec: `docs/superpowers/specs/2026-04-14-resend-email-integration-design.md`
- Plan: `docs/superpowers/plans/2026-04-14-resend-email-integration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)