### PR TITLE
feat(api): Resend webhook receiver for bounce/complaint events

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -61,4 +61,7 @@ REQUIRE_TENANT_HEADER=false
 RESEND_API_KEY=
 RESEND_FROM_NOREPLY=Larry <noreply@larry-pm.com>
 RESEND_FROM_LARRY=Larry <larry@larry-pm.com>
+# Optional — enables POST /v1/webhooks/resend for bounce/complaint events.
+# Obtain from Resend dashboard → Webhooks → (endpoint) → Signing secret.
+RESEND_WEBHOOK_SECRET=
 FRONTEND_URL=http://localhost:3000

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -20,6 +20,7 @@ import { folderRoutes } from "./folders.js";
 import { settingsRoutes } from "./settings.js";
 import { searchRoutes } from "./search.js";
 import { adminRoutes } from "./admin.js";
+import { resendWebhookRoutes } from "./webhooks-resend.js";
 
 export const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(authRoutes, { prefix: "/auth" });
@@ -43,4 +44,5 @@ export const v1Routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(settingsRoutes, { prefix: "/settings" });
   await fastify.register(searchRoutes);
   await fastify.register(adminRoutes, { prefix: "/admin" });
+  await fastify.register(resendWebhookRoutes, { prefix: "/webhooks" });
 };

--- a/apps/api/src/routes/v1/webhooks-resend.ts
+++ b/apps/api/src/routes/v1/webhooks-resend.ts
@@ -1,0 +1,171 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { FastifyPluginAsync } from "fastify";
+
+/**
+ * Resend webhook receiver.
+ *
+ * Resend signs webhook requests using Svix's signature scheme:
+ *   signed_content = `${svix-id}.${svix-timestamp}.${raw-body}`
+ *   signature      = HMAC-SHA256(base64-decoded-secret, signed_content)
+ *   header value   = `v1,<base64(signature)>` (whitespace-separated if multiple)
+ *
+ * The secret stored in Resend → Webhooks looks like `whsec_<base64>`. We strip
+ * the prefix, base64-decode, and use the resulting bytes as the HMAC key.
+ *
+ * For v1 we log events to the Fastify logger (Railway picks them up). Future
+ * extensions: persist to an `email_events` table, auto-suppress hard-bounced
+ * and complained addresses, expose a dashboard.
+ */
+export const resendWebhookRoutes: FastifyPluginAsync = async (fastify) => {
+  // Scoped raw-body parser — only affects routes registered inside this plugin.
+  // We need the unmodified UTF-8 bytes for Svix signature verification;
+  // JSON.stringify of a reparsed object would not match the signature.
+  fastify.addContentTypeParser(
+    "application/json",
+    { parseAs: "string" },
+    (_req, body, done) => {
+      done(null, body);
+    },
+  );
+
+  fastify.post("/resend", async (request, reply) => {
+    const secret = process.env.RESEND_WEBHOOK_SECRET;
+    if (!secret) {
+      request.log.error("[webhook-resend] RESEND_WEBHOOK_SECRET not configured");
+      return reply.code(503).send({ error: "Webhook secret not configured" });
+    }
+
+    const svixId = firstHeader(request.headers["svix-id"]);
+    const svixTs = firstHeader(request.headers["svix-timestamp"]);
+    const svixSigHeader = firstHeader(request.headers["svix-signature"]);
+
+    if (!svixId || !svixTs || !svixSigHeader) {
+      return reply.code(400).send({ error: "Missing Svix headers" });
+    }
+
+    // Timestamp check — reject requests older than 5 minutes (replay defence).
+    const tsNum = Number(svixTs);
+    if (!Number.isFinite(tsNum)) {
+      return reply.code(400).send({ error: "Invalid svix-timestamp" });
+    }
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (Math.abs(nowSec - tsNum) > 5 * 60) {
+      return reply.code(400).send({ error: "svix-timestamp outside tolerance" });
+    }
+
+    const rawBody = typeof request.body === "string" ? request.body : "";
+    if (!rawBody) {
+      return reply.code(400).send({ error: "Empty body" });
+    }
+
+    if (!verifySvixSignature(secret, svixId, svixTs, rawBody, svixSigHeader)) {
+      request.log.warn({ svixId }, "[webhook-resend] signature mismatch");
+      return reply.code(401).send({ error: "Invalid signature" });
+    }
+
+    let event: ResendEvent;
+    try {
+      event = JSON.parse(rawBody) as ResendEvent;
+    } catch {
+      return reply.code(400).send({ error: "Invalid JSON" });
+    }
+
+    // Log interesting events. Future: insert into email_events table.
+    const to = extractTo(event);
+    const type = event.type ?? "unknown";
+    switch (type) {
+      case "email.bounced":
+        request.log.warn({ svixId, type, to, data: event.data }, "[webhook-resend] bounce");
+        break;
+      case "email.complained":
+        request.log.warn({ svixId, type, to, data: event.data }, "[webhook-resend] complaint");
+        break;
+      case "email.delivery_delayed":
+        request.log.info({ svixId, type, to }, "[webhook-resend] delivery delayed");
+        break;
+      case "email.delivered":
+      case "email.sent":
+      case "email.opened":
+      case "email.clicked":
+        // Low-signal events — log at debug only.
+        request.log.debug({ svixId, type, to }, "[webhook-resend] event");
+        break;
+      default:
+        request.log.info({ svixId, type, to }, "[webhook-resend] unknown event type");
+    }
+
+    return reply.code(200).send({ ok: true });
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ResendEvent = {
+  type?: string;
+  data?: {
+    email_id?: string;
+    to?: string[] | string;
+    from?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+function firstHeader(v: string | string[] | undefined): string | undefined {
+  if (Array.isArray(v)) return v[0];
+  return v;
+}
+
+function extractTo(event: ResendEvent): string | undefined {
+  const to = event.data?.to;
+  if (Array.isArray(to)) return to[0];
+  if (typeof to === "string") return to;
+  return undefined;
+}
+
+/**
+ * Verify a Svix-format signature header.
+ *
+ * `svixSigHeader` is one or more space-separated `v1,<base64>` pairs.
+ * Returns true if ANY of them match the expected signature computed from the
+ * provided secret / id / timestamp / body.
+ */
+export function verifySvixSignature(
+  secret: string,
+  svixId: string,
+  svixTs: string,
+  rawBody: string,
+  svixSigHeader: string,
+): boolean {
+  const secretBytes = decodeSecret(secret);
+  if (!secretBytes) return false;
+
+  const signedContent = `${svixId}.${svixTs}.${rawBody}`;
+  const expected = createHmac("sha256", secretBytes).update(signedContent).digest();
+
+  for (const part of svixSigHeader.split(/\s+/)) {
+    const [version, sig] = part.split(",");
+    if (version !== "v1" || !sig) continue;
+    let provided: Buffer;
+    try {
+      provided = Buffer.from(sig, "base64");
+    } catch {
+      continue;
+    }
+    if (provided.length !== expected.length) continue;
+    if (timingSafeEqual(provided, expected)) return true;
+  }
+  return false;
+}
+
+function decodeSecret(secret: string): Buffer | null {
+  // Resend secrets come as `whsec_<base64>`. Strip the prefix if present.
+  const raw = secret.startsWith("whsec_") ? secret.slice("whsec_".length) : secret;
+  try {
+    return Buffer.from(raw, "base64");
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/tests/webhooks-resend.test.ts
+++ b/apps/api/tests/webhooks-resend.test.ts
@@ -1,0 +1,191 @@
+import { createHmac } from "node:crypto";
+import Fastify, { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resendWebhookRoutes, verifySvixSignature } from "../src/routes/v1/webhooks-resend.js";
+
+/**
+ * Tests cover both the unit of the signature verifier (pure function)
+ * and the full Fastify route wiring (bad-signature → 401, good → 200,
+ * malformed bodies / headers / timestamps → 400s, missing secret → 503).
+ *
+ * Secret format mirrors Resend's production format: `whsec_<base64>`.
+ * We encode the raw bytes "test-secret-32-bytes-long-here!!" as base64.
+ */
+
+const RAW_SECRET = Buffer.from("test-secret-32-bytes-long-here!!");
+const FULL_SECRET = `whsec_${RAW_SECRET.toString("base64")}`;
+
+function signSvix(svixId: string, svixTs: string, body: string): string {
+  const signed = `${svixId}.${svixTs}.${body}`;
+  const sig = createHmac("sha256", RAW_SECRET).update(signed).digest("base64");
+  return `v1,${sig}`;
+}
+
+describe("verifySvixSignature (pure)", () => {
+  const svixId = "msg_test_123";
+  const svixTs = "1700000000";
+  const body = '{"type":"email.delivered","data":{"to":["x@example.com"]}}';
+
+  it("accepts a correct signature", () => {
+    const header = signSvix(svixId, svixTs, body);
+    expect(verifySvixSignature(FULL_SECRET, svixId, svixTs, body, header)).toBe(true);
+  });
+
+  it("rejects a wrong signature", () => {
+    const header = "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    expect(verifySvixSignature(FULL_SECRET, svixId, svixTs, body, header)).toBe(false);
+  });
+
+  it("rejects when the body changed after signing", () => {
+    const header = signSvix(svixId, svixTs, body);
+    const tamperedBody = body.replace("delivered", "bounced");
+    expect(verifySvixSignature(FULL_SECRET, svixId, svixTs, tamperedBody, header)).toBe(false);
+  });
+
+  it("accepts if at least one signature in a space-separated list is valid", () => {
+    const good = signSvix(svixId, svixTs, body);
+    const bad = "v1,AAAA=";
+    const header = `${bad} ${good}`;
+    expect(verifySvixSignature(FULL_SECRET, svixId, svixTs, body, header)).toBe(true);
+  });
+
+  it("ignores non-v1 signature versions", () => {
+    const good = signSvix(svixId, svixTs, body);
+    const v2 = good.replace("v1,", "v2,");
+    expect(verifySvixSignature(FULL_SECRET, svixId, svixTs, body, v2)).toBe(false);
+  });
+
+  it("accepts secret without the whsec_ prefix", () => {
+    const bareSecret = RAW_SECRET.toString("base64");
+    const header = signSvix(svixId, svixTs, body);
+    expect(verifySvixSignature(bareSecret, svixId, svixTs, body, header)).toBe(true);
+  });
+});
+
+describe("POST /webhooks/resend", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    process.env.RESEND_WEBHOOK_SECRET = FULL_SECRET;
+    app = Fastify({ logger: false });
+    await app.register(resendWebhookRoutes, { prefix: "/webhooks" });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    delete process.env.RESEND_WEBHOOK_SECRET;
+  });
+
+  function freshTs(): string {
+    return String(Math.floor(Date.now() / 1000));
+  }
+
+  it("returns 200 on a valid bounce event", async () => {
+    const svixId = "msg_abc";
+    const svixTs = freshTs();
+    const body = JSON.stringify({
+      type: "email.bounced",
+      data: {
+        email_id: "eid_1",
+        to: ["bounce@example.com"],
+        from: "Larry <noreply@larry-pm.com>",
+      },
+    });
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: {
+        "content-type": "application/json",
+        "svix-id": svixId,
+        "svix-timestamp": svixTs,
+        "svix-signature": signSvix(svixId, svixTs, body),
+      },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+  });
+
+  it("returns 401 on signature mismatch", async () => {
+    const svixId = "msg_bad";
+    const svixTs = freshTs();
+    const body = JSON.stringify({ type: "email.delivered", data: {} });
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: {
+        "content-type": "application/json",
+        "svix-id": svixId,
+        "svix-timestamp": svixTs,
+        "svix-signature": "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 when svix-timestamp is outside 5-minute tolerance", async () => {
+    const svixId = "msg_old";
+    const svixTs = String(Math.floor(Date.now() / 1000) - 10 * 60);
+    const body = JSON.stringify({ type: "email.delivered", data: {} });
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: {
+        "content-type": "application/json",
+        "svix-id": svixId,
+        "svix-timestamp": svixTs,
+        "svix-signature": signSvix(svixId, svixTs, body),
+      },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when Svix headers are missing", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: { "content-type": "application/json" },
+      payload: "{}",
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 503 when RESEND_WEBHOOK_SECRET is not configured", async () => {
+    delete process.env.RESEND_WEBHOOK_SECRET;
+    const svixId = "msg_nosec";
+    const svixTs = freshTs();
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: {
+        "content-type": "application/json",
+        "svix-id": svixId,
+        "svix-timestamp": svixTs,
+        "svix-signature": "v1,AAAA=",
+      },
+      payload: "{}",
+    });
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("returns 400 on invalid JSON body (but valid signature)", async () => {
+    const svixId = "msg_junk";
+    const svixTs = freshTs();
+    const body = "{not-json}";
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: {
+        "content-type": "application/json",
+        "svix-id": svixId,
+        "svix-timestamp": svixTs,
+        "svix-signature": signSvix(svixId, svixTs, body),
+      },
+      payload: body,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -60,6 +60,7 @@ const ApiSchema = SharedSchema.extend({
   RESEND_API_KEY: z.string().optional(),
   RESEND_FROM_NOREPLY: z.string().default("Larry <noreply@larry-pm.com>"),
   RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-pm.com>"),
+  RESEND_WEBHOOK_SECRET: z.string().optional(),
   FRONTEND_URL: z.string().url().optional(),
 });
 


### PR DESCRIPTION
## Summary
Adds `POST /v1/webhooks/resend` — an endpoint Resend can POST to when emails bounce, get marked as spam, are delayed, etc. Verifies Svix-scheme signatures with a 5-minute replay window. Logs interesting events (bounce, complaint, delayed) to the Fastify logger so they show up in Railway logs.

## Why
Manually watching the Resend dashboard for bounces is unsustainable, and silent deliverability damage on a fresh domain is the #1 failure mode. Server-side events give us observability without tab-watching, and lay the foundation for future auto-suppression.

## Implementation notes
- Raw-body parser is scoped to the webhook plugin (doesn't affect other routes). Re-stringifying a parsed body would break the HMAC because JSON key order / whitespace can differ.
- Timing-safe signature comparison via `crypto.timingSafeEqual`.
- Supports multi-signature headers for secret rotation (Resend's Svix format uses space-separated `v1,<sig>` pairs).

## Test plan
- [x] 12 vitest cases — signature verification (pure), full route (200/400/401/503 paths), replay defence, multi-sig headers, bare secrets
- [x] Full api suite: 362/362 passing
- [ ] Post-merge: set `RESEND_WEBHOOK_SECRET` on Railway Api service
- [ ] Post-merge: configure webhook in Resend dashboard pointing at `https://larry-site-production.up.railway.app/v1/webhooks/resend`
- [ ] Post-merge: send a Resend test event → confirm 200 + log line in Railway

## Out of scope (deliberate)
- DB persistence of events (logs-only v1). Future: `email_events` table.
- Auto-suppression of hard-bounced recipients.
- Alerting on complaint spikes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)