### PR TITLE
feat: rate-limiting hardening (5 phases)

### DIFF
--- a/apps/api/src/app.trust-proxy.test.ts
+++ b/apps/api/src/app.trust-proxy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import Fastify from "fastify";
+
+// Verifies Fastify's trustProxy semantics independently of the whole app —
+// if this test passes, a createApp() that sets `trustProxy: true` will
+// correctly report the real client IP behind Railway's proxy.
+describe("Fastify trustProxy", () => {
+  it("reports X-Forwarded-For as request.ip when trustProxy is true", async () => {
+    const app = Fastify({ trustProxy: true });
+    app.get("/whoami", async (req) => ({ ip: req.ip }));
+    const res = await app.inject({
+      method: "GET",
+      url: "/whoami",
+      headers: { "x-forwarded-for": "203.0.113.7" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ip: "203.0.113.7" });
+    await app.close();
+  });
+
+  it("ignores X-Forwarded-For when trustProxy is false (default)", async () => {
+    const app = Fastify();
+    app.get("/whoami", async (req) => ({ ip: req.ip }));
+    const res = await app.inject({
+      method: "GET",
+      url: "/whoami",
+      headers: { "x-forwarded-for": "203.0.113.7" },
+    });
+    expect(res.statusCode).toBe(200);
+    // Without trustProxy, the "real" IP is the socket peer, which in inject is "127.0.0.1".
+    expect(res.json().ip).not.toBe("203.0.113.7");
+    await app.close();
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,8 @@ import { healthRoutes } from "./routes/health.js";
 import { v1Routes } from "./routes/v1/index.js";
 import { createQueuePublisher } from "./services/queue.js";
 import { getRedis, closeRedis } from "./lib/redis.js";
+import { LLMQuotaError } from "./lib/llm-budget.js";
+import { EmailQuotaError } from "./lib/email-quota.js";
 
 export async function createApp() {
   const env = getApiEnv();
@@ -65,6 +67,31 @@ export async function createApp() {
         statusCode: 400,
         error: "Validation Error",
         message: messages.join(". ") + ".",
+      });
+    }
+    if (error instanceof LLMQuotaError) {
+      request.log.warn(
+        { scope: error.scope, limit: error.limit, url: request.url },
+        "llm quota rejected",
+      );
+      return reply.status(429).send({
+        statusCode: 429,
+        error: "Too Many Requests",
+        message:
+          error.scope === "tenant"
+            ? "Daily AI usage limit reached for this workspace. Please try again tomorrow."
+            : "Daily AI usage limit reached. Please try again shortly.",
+      });
+    }
+    if (error instanceof EmailQuotaError) {
+      request.log.warn(
+        { detail: error.detail, url: request.url },
+        "email quota rejected",
+      );
+      return reply.status(429).send({
+        statusCode: 429,
+        error: "Too Many Requests",
+        message: "Email send limit reached. Please try again later.",
       });
     }
     // Let Fastify handle everything else (including @fastify/sensible errors)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,4 @@
-import Fastify from "fastify";
+import Fastify, { type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
 import helmet from "@fastify/helmet";
 import rateLimit from "@fastify/rate-limit";
@@ -11,6 +11,7 @@ import { requestContextPlugin } from "./plugins/request-context.js";
 import { healthRoutes } from "./routes/health.js";
 import { v1Routes } from "./routes/v1/index.js";
 import { createQueuePublisher } from "./services/queue.js";
+import { getRedis, closeRedis } from "./lib/redis.js";
 
 export async function createApp() {
   const env = getApiEnv();
@@ -20,6 +21,9 @@ export async function createApp() {
       level: env.LOG_LEVEL,
     },
     bodyLimit: 10 * 1024 * 1024, // 10 MB — needed for base64-encoded binary file uploads
+    // Railway sits behind a proxy; honor X-Forwarded-For so IP-based rate limits
+    // target real clients instead of collapsing to the proxy's single IP.
+    trustProxy: true,
   });
 
   app.decorate("db", new Db(env.DATABASE_URL));
@@ -31,7 +35,19 @@ export async function createApp() {
   });
   await app.register(rateLimit, {
     global: false, // opt-in per route
-    redis: undefined, // in-memory store is fine for MVP demo
+    // Distributed store so limits hold across Railway instances. Redis is
+    // already a hard dep (BullMQ); if it's down the API is broken anyway.
+    // Flip RATE_LIMIT_REDIS_ENABLED=false to fall back to in-memory.
+    redis: env.RATE_LIMIT_REDIS_ENABLED ? getRedis() : undefined,
+    skipOnError: false,
+    nameSpace: "rl:",
+    // Test-only bypass: non-prod can pass a shared secret header to skip limits.
+    skip: (req: FastifyRequest) => {
+      if (env.NODE_ENV === "production") return false;
+      const secret = env.RATE_LIMIT_BYPASS_SECRET;
+      if (!secret) return false;
+      return req.headers["x-ratelimit-bypass"] === secret;
+    },
   });
   await app.register(cors, {
     origin: env.CORS_ORIGINS.split(",").map((origin) => origin.trim()),
@@ -81,6 +97,7 @@ export async function createApp() {
   app.addHook("onClose", async () => {
     await app.queue.close();
     await app.db.close();
+    await closeRedis();
   });
 
   return app;

--- a/apps/api/src/lib/email-quota.test.ts
+++ b/apps/api/src/lib/email-quota.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory fake for the bits of ioredis we use.
+class FakeRedis {
+  private store = new Map<string, string>();
+  private ttls = new Map<string, number>();
+
+  async incr(key: string): Promise<number> {
+    const next = Number(this.store.get(key) ?? 0) + 1;
+    this.store.set(key, String(next));
+    return next;
+  }
+  async decr(key: string): Promise<number> {
+    const next = Number(this.store.get(key) ?? 0) - 1;
+    this.store.set(key, String(next));
+    return next;
+  }
+  async expire(key: string, seconds: number): Promise<number> {
+    if (!this.store.has(key)) return 0;
+    this.ttls.set(key, seconds);
+    return 1;
+  }
+  async exists(key: string): Promise<number> {
+    return this.store.has(key) ? 1 : 0;
+  }
+  async set(key: string, value: string): Promise<"OK"> {
+    this.store.set(key, value);
+    return "OK";
+  }
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+  pipeline() {
+    const ops: Array<{ op: string; args: unknown[] }> = [];
+    const self = this;
+    const chain = {
+      incr(key: string) {
+        ops.push({ op: "incr", args: [key] });
+        return chain;
+      },
+      decr(key: string) {
+        ops.push({ op: "decr", args: [key] });
+        return chain;
+      },
+      expire(key: string, seconds: number) {
+        ops.push({ op: "expire", args: [key, seconds] });
+        return chain;
+      },
+      async exec(): Promise<Array<[Error | null, unknown]>> {
+        const results: Array<[Error | null, unknown]> = [];
+        for (const { op, args } of ops) {
+          try {
+            const result = await (self as unknown as Record<string, Function>)[op].apply(self, args);
+            results.push([null, result]);
+          } catch (e) {
+            results.push([e as Error, null]);
+          }
+        }
+        return results;
+      },
+    };
+    return chain;
+  }
+  peek(key: string): string | undefined {
+    return this.store.get(key);
+  }
+  reset() {
+    this.store.clear();
+    this.ttls.clear();
+  }
+}
+
+const fake = new FakeRedis();
+
+vi.mock("./redis.js", () => ({
+  getRedis: () => fake,
+  closeRedis: async () => {},
+}));
+
+// Stub @larry/config so EMAIL_QUOTA_ENABLED default is true.
+vi.mock("@larry/config", () => ({
+  getApiEnv: () => ({
+    EMAIL_QUOTA_ENABLED: true,
+    NODE_ENV: "test",
+  }),
+}));
+
+describe("email-quota", () => {
+  beforeEach(() => {
+    fake.reset();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("isSuppressed returns false for an unknown recipient", async () => {
+    const mod = await import("./email-quota.js");
+    expect(await mod.isSuppressed("unknown@example.com")).toBe(false);
+  });
+
+  it("addSuppression + isSuppressed work (case-insensitive)", async () => {
+    const mod = await import("./email-quota.js");
+    await mod.addSuppression("User@Example.com", "bounce");
+    expect(await mod.isSuppressed("user@example.com")).toBe(true);
+    expect(await mod.isSuppressed("USER@example.com")).toBe(true);
+  });
+
+  it("checkEmailQuota allows calls under the hourly cap", async () => {
+    const mod = await import("./email-quota.js");
+    // password_reset per-recipient hourly limit is 3
+    for (let i = 0; i < 3; i++) {
+      await mod.checkEmailQuota({ kind: "password_reset", recipient: "u@example.com" });
+    }
+  });
+
+  it("checkEmailQuota throws EmailQuotaError past the hourly recipient cap", async () => {
+    const mod = await import("./email-quota.js");
+    for (let i = 0; i < 3; i++) {
+      await mod.checkEmailQuota({ kind: "password_reset", recipient: "u@example.com" });
+    }
+    await expect(
+      mod.checkEmailQuota({ kind: "password_reset", recipient: "u@example.com" }),
+    ).rejects.toBeInstanceOf(mod.EmailQuotaError);
+  });
+
+  it("rollback on overshoot: a rejected call does not consume budget", async () => {
+    const mod = await import("./email-quota.js");
+    // Fill hourly cap (3) then attempt one more and verify the count did not grow to 5
+    for (let i = 0; i < 3; i++) {
+      await mod.checkEmailQuota({ kind: "password_reset", recipient: "u@example.com" });
+    }
+    await expect(
+      mod.checkEmailQuota({ kind: "password_reset", recipient: "u@example.com" }),
+    ).rejects.toBeInstanceOf(mod.EmailQuotaError);
+
+    // The recipient hourly key should still be at 3, not 4 or 5.
+    const now = new Date();
+    const hourKey = now.toISOString().slice(0, 13);
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256").update("u@example.com").digest("hex").slice(0, 16);
+    expect(fake.peek(`email:q:password_reset:r:${hash}:${hourKey}`)).toBe("3");
+  });
+
+  it("per-user limits apply when userId is supplied", async () => {
+    const mod = await import("./email-quota.js");
+    // verification hourly = 5
+    for (let i = 0; i < 5; i++) {
+      // vary recipient so per-recipient cap doesn't fire first
+      await mod.checkEmailQuota({
+        kind: "verification",
+        recipient: `u${i}@example.com`,
+        userId: "user-1",
+      });
+    }
+    await expect(
+      mod.checkEmailQuota({ kind: "verification", recipient: "u6@example.com", userId: "user-1" }),
+    ).rejects.toBeInstanceOf(mod.EmailQuotaError);
+  });
+
+  it("tenant daily cap applies across email kinds", async () => {
+    const mod = await import("./email-quota.js");
+    // Tenant daily cap is 200. We'll just assert it exists by checking a small excess
+    // with a targeted low override later; here, assert that the tenant key is incremented.
+    await mod.checkEmailQuota({
+      kind: "verification",
+      recipient: "a@example.com",
+      tenantId: "tenant-1",
+    });
+    const dayKey = new Date().toISOString().slice(0, 10);
+    expect(fake.peek(`email:q:any:t:tenant-1:${dayKey}`)).toBe("1");
+  });
+
+  it("member_invite enforces a per-tenant hourly cap (not per-user)", async () => {
+    const mod = await import("./email-quota.js");
+    // TENANT_INVITE_HOUR_LIMIT = 20
+    for (let i = 0; i < 20; i++) {
+      await mod.checkEmailQuota({
+        kind: "member_invite",
+        recipient: `invitee${i}@example.com`,
+        tenantId: "tenant-1",
+      });
+    }
+    await expect(
+      mod.checkEmailQuota({
+        kind: "member_invite",
+        recipient: "invitee21@example.com",
+        tenantId: "tenant-1",
+      }),
+    ).rejects.toBeInstanceOf(mod.EmailQuotaError);
+  });
+
+  it("global daily circuit breaker fires", async () => {
+    const mod = await import("./email-quota.js");
+    // Simulate 500 already consumed globally by pre-setting the key.
+    const dayKey = new Date().toISOString().slice(0, 10);
+    await fake.set(`email:q:any:global:${dayKey}`, "500");
+    await expect(
+      mod.checkEmailQuota({ kind: "verification", recipient: "new@example.com" }),
+    ).rejects.toBeInstanceOf(mod.EmailQuotaError);
+  });
+});

--- a/apps/api/src/lib/email-quota.ts
+++ b/apps/api/src/lib/email-quota.ts
@@ -1,0 +1,226 @@
+import { createHash } from "node:crypto";
+import { getApiEnv } from "@larry/config";
+import { getRedis } from "./redis.js";
+
+export type EmailKind =
+  | "password_reset"
+  | "verification"
+  | "email_change_confirm"
+  | "email_change_notify"
+  | "new_device_alert"
+  | "member_invite"
+  | "generic";
+
+export interface EmailQuotaContext {
+  kind: EmailKind;
+  recipient: string;
+  userId?: string;
+  tenantId?: string;
+}
+
+export interface EmailQuotaDetail {
+  scope: string;
+  limit: number;
+  window: "1h" | "1d";
+}
+
+export class EmailQuotaError extends Error {
+  readonly detail: EmailQuotaDetail;
+  constructor(detail: EmailQuotaDetail) {
+    super(`email quota exceeded: ${detail.scope} (limit=${detail.limit}, window=${detail.window})`);
+    this.name = "EmailQuotaError";
+    this.detail = detail;
+  }
+}
+
+export class EmailSuppressedError extends Error {
+  readonly recipientHash: string;
+  constructor(recipientHash: string) {
+    super("recipient is on the suppression list");
+    this.name = "EmailSuppressedError";
+    this.recipientHash = recipientHash;
+  }
+}
+
+// Per-recipient and per-user windowed caps. Member invites live on the tenant
+// bucket (see TENANT_INVITE_HOUR_LIMIT) — personal caps make no sense there.
+const LIMITS: Record<EmailKind, { hour: number; day: number }> = {
+  password_reset:       { hour: 3,  day: 10 },
+  verification:         { hour: 5,  day: 15 },
+  email_change_confirm: { hour: 3,  day: 10 },
+  email_change_notify:  { hour: 5,  day: 15 },
+  new_device_alert:     { hour: 10, day: 30 },
+  member_invite:        { hour: 0,  day: 0 },
+  generic:              { hour: 10, day: 30 },
+};
+
+const TENANT_INVITE_HOUR_LIMIT = 20;
+const TENANT_DAILY_LIMIT = 200;
+const GLOBAL_DAILY_LIMIT = 500;
+
+const SUPPRESSION_PREFIX = "email:suppressed:";
+const QUOTA_PREFIX = "email:q:";
+const HOUR_TTL_SEC = 60 * 60 + 60;       // 1h + small slop
+const DAY_TTL_SEC = 24 * 60 * 60 + 60;   // 24h + small slop
+
+function hashRecipient(recipient: string): string {
+  return createHash("sha256").update(recipient.toLowerCase().trim()).digest("hex").slice(0, 16);
+}
+
+function hourKey(d: Date): string {
+  return d.toISOString().slice(0, 13); // YYYY-MM-DDTHH
+}
+function dayKey(d: Date): string {
+  return d.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+export async function isSuppressed(recipient: string): Promise<boolean> {
+  const redis = getRedis();
+  const res = await redis.exists(`${SUPPRESSION_PREFIX}${hashRecipient(recipient)}`);
+  return Boolean(res);
+}
+
+export async function addSuppression(
+  recipient: string,
+  reason: "bounce" | "complaint",
+): Promise<void> {
+  const redis = getRedis();
+  const key = `${SUPPRESSION_PREFIX}${hashRecipient(recipient)}`;
+  // No TTL — suppression is permanent until manually cleared (by design).
+  await redis.set(key, reason);
+}
+
+interface QuotaCheck {
+  key: string;
+  ttl: number;
+  limit: number;
+  scope: string;
+  window: "1h" | "1d";
+}
+
+function buildChecks(ctx: EmailQuotaContext): QuotaCheck[] {
+  const now = new Date();
+  const h = hourKey(now);
+  const d = dayKey(now);
+  const recipHash = hashRecipient(ctx.recipient);
+  const kindLimits = LIMITS[ctx.kind];
+  const checks: QuotaCheck[] = [];
+
+  // Per-recipient (hashed) caps — primary defence against one address being
+  // flooded regardless of which user or tenant triggered it.
+  if (kindLimits.hour > 0) {
+    checks.push({
+      key: `${QUOTA_PREFIX}${ctx.kind}:r:${recipHash}:${h}`,
+      ttl: HOUR_TTL_SEC,
+      limit: kindLimits.hour,
+      scope: `${ctx.kind}/hour/recipient`,
+      window: "1h",
+    });
+  }
+  if (kindLimits.day > 0) {
+    checks.push({
+      key: `${QUOTA_PREFIX}${ctx.kind}:r:${recipHash}:${d}`,
+      ttl: DAY_TTL_SEC,
+      limit: kindLimits.day,
+      scope: `${ctx.kind}/day/recipient`,
+      window: "1d",
+    });
+  }
+
+  // Per-user (if authenticated) — catches a single attacker account hammering
+  // many distinct recipients.
+  if (ctx.userId && kindLimits.hour > 0) {
+    checks.push({
+      key: `${QUOTA_PREFIX}${ctx.kind}:u:${ctx.userId}:${h}`,
+      ttl: HOUR_TTL_SEC,
+      limit: kindLimits.hour,
+      scope: `${ctx.kind}/hour/user`,
+      window: "1h",
+    });
+  }
+
+  // Member invites are a tenant-level action, not a per-user one.
+  if (ctx.tenantId && ctx.kind === "member_invite") {
+    checks.push({
+      key: `${QUOTA_PREFIX}invite:t:${ctx.tenantId}:${h}`,
+      ttl: HOUR_TTL_SEC,
+      limit: TENANT_INVITE_HOUR_LIMIT,
+      scope: "member_invite/hour/tenant",
+      window: "1h",
+    });
+  }
+
+  // Per-tenant daily total across all kinds — catches a compromised admin.
+  if (ctx.tenantId) {
+    checks.push({
+      key: `${QUOTA_PREFIX}any:t:${ctx.tenantId}:${d}`,
+      ttl: DAY_TTL_SEC,
+      limit: TENANT_DAILY_LIMIT,
+      scope: "any/day/tenant",
+      window: "1d",
+    });
+  }
+
+  // Global circuit breaker across all tenants — final backstop for Resend
+  // quota / domain reputation.
+  checks.push({
+    key: `${QUOTA_PREFIX}any:global:${d}`,
+    ttl: DAY_TTL_SEC,
+    limit: GLOBAL_DAILY_LIMIT,
+    scope: "any/day/global",
+    window: "1d",
+  });
+
+  return checks;
+}
+
+/**
+ * Atomically increment every applicable quota counter, then check each
+ * against its limit. If any is over, rolls back all counters and throws.
+ *
+ * Increment-then-check avoids the check-then-increment race that would let
+ * two concurrent callers both pass a cap boundary.
+ */
+export async function checkEmailQuota(ctx: EmailQuotaContext): Promise<void> {
+  const env = getApiEnv();
+  if (env.EMAIL_QUOTA_ENABLED === false) return;
+
+  const redis = getRedis();
+  const checks = buildChecks(ctx);
+  if (checks.length === 0) return;
+
+  const incr = redis.pipeline();
+  for (const c of checks) {
+    incr.incr(c.key);
+    incr.expire(c.key, c.ttl);
+  }
+  const res = await incr.exec();
+  if (!res) throw new Error("redis pipeline failed (null result)");
+
+  // Results are interleaved: [incr, expire, incr, expire, ...]
+  const counts: number[] = [];
+  for (let i = 0; i < checks.length; i++) {
+    const [err, val] = res[i * 2];
+    if (err) throw err;
+    counts.push(Number(val));
+  }
+
+  const breaches = checks
+    .map((c, i) => ({ check: c, count: counts[i] }))
+    .filter(({ check, count }) => count > check.limit);
+
+  if (breaches.length > 0) {
+    // Roll back every key we touched so a rejected call doesn't permanently
+    // consume budget.
+    const rollback = redis.pipeline();
+    for (const c of checks) rollback.decr(c.key);
+    await rollback.exec();
+
+    const first = breaches[0];
+    throw new EmailQuotaError({
+      scope: first.check.scope,
+      limit: first.check.limit,
+      window: first.check.window,
+    });
+  }
+}

--- a/apps/api/src/lib/email.test.ts
+++ b/apps/api/src/lib/email.test.ts
@@ -8,6 +8,28 @@ vi.mock("resend", () => ({
   })),
 }));
 
+// Stub the email-quota guard so these tests don't need Redis. Quota behavior
+// is tested in email-quota.test.ts. Behaviour in email.ts we care about here:
+//   (a) suppressed recipients short-circuit before any send;
+//   (b) quota errors surface to the caller (they decide to swallow or not);
+//   (c) FROM mapping is correct per kind.
+const isSuppressedMock = vi.fn().mockResolvedValue(false);
+const checkEmailQuotaMock = vi.fn().mockResolvedValue(undefined);
+class FakeEmailQuotaError extends Error {
+  readonly detail: unknown;
+  constructor(detail: unknown) {
+    super("fake quota");
+    this.name = "EmailQuotaError";
+    this.detail = detail;
+  }
+}
+
+vi.mock("./email-quota.js", () => ({
+  isSuppressed: isSuppressedMock,
+  checkEmailQuota: checkEmailQuotaMock,
+  EmailQuotaError: FakeEmailQuotaError,
+}));
+
 const NOREPLY = "Larry <noreply@larry-pm.com>";
 const LARRY = "Larry <larry@larry-pm.com>";
 
@@ -16,6 +38,10 @@ describe("email.ts FROM mapping", () => {
     vi.resetModules();
     sendMock.mockReset();
     sendMock.mockResolvedValue({ data: { id: "test-id" }, error: null });
+    isSuppressedMock.mockReset();
+    isSuppressedMock.mockResolvedValue(false);
+    checkEmailQuotaMock.mockReset();
+    checkEmailQuotaMock.mockResolvedValue(undefined);
     process.env.RESEND_API_KEY = "re_test_key";
     process.env.RESEND_FROM_NOREPLY = NOREPLY;
     process.env.RESEND_FROM_LARRY = LARRY;
@@ -64,5 +90,68 @@ describe("email.ts FROM mapping", () => {
     const mod = await import("./email.js");
     await mod.sendMemberInviteEmail("u@example.com", "Anna");
     expect(sendMock.mock.calls[0][0].from).toBe(LARRY);
+  });
+});
+
+describe("email.ts suppression and quota", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({ data: { id: "test-id" }, error: null });
+    isSuppressedMock.mockReset();
+    isSuppressedMock.mockResolvedValue(false);
+    checkEmailQuotaMock.mockReset();
+    checkEmailQuotaMock.mockResolvedValue(undefined);
+    process.env.RESEND_API_KEY = "re_test_key";
+    process.env.RESEND_FROM_NOREPLY = NOREPLY;
+    process.env.RESEND_FROM_LARRY = LARRY;
+  });
+
+  afterEach(() => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.RESEND_FROM_NOREPLY;
+    delete process.env.RESEND_FROM_LARRY;
+  });
+
+  it("suppressed recipient results in silent no-op — Resend is not called", async () => {
+    isSuppressedMock.mockResolvedValue(true);
+    const mod = await import("./email.js");
+    await mod.sendPasswordResetEmail("bounced@example.com", "https://x/reset");
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("quota exceeded propagates as EmailQuotaError — Resend is not called", async () => {
+    checkEmailQuotaMock.mockRejectedValue(
+      new FakeEmailQuotaError({ scope: "password_reset/hour/recipient", limit: 3, window: "1h" }),
+    );
+    const mod = await import("./email.js");
+    await expect(
+      mod.sendPasswordResetEmail("u@example.com", "https://x/reset"),
+    ).rejects.toBeInstanceOf(FakeEmailQuotaError);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("quota guard receives user/tenant context when provided", async () => {
+    const mod = await import("./email.js");
+    await mod.sendVerificationEmail("u@example.com", "https://x/v", {
+      userId: "user-1",
+      tenantId: "tenant-1",
+    });
+    expect(checkEmailQuotaMock).toHaveBeenCalledWith({
+      kind: "verification",
+      recipient: "u@example.com",
+      userId: "user-1",
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("member invite quota is scoped by tenant", async () => {
+    const mod = await import("./email.js");
+    await mod.sendMemberInviteEmail("invitee@example.com", "Anna", { tenantId: "tenant-1" });
+    expect(checkEmailQuotaMock).toHaveBeenCalledWith({
+      kind: "member_invite",
+      recipient: "invitee@example.com",
+      tenantId: "tenant-1",
+    });
   });
 });

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,4 +1,10 @@
 import { Resend } from "resend";
+import {
+  checkEmailQuota,
+  isSuppressed,
+  type EmailQuotaContext,
+  type EmailKind,
+} from "./email-quota.js";
 
 const FROM_NOREPLY = process.env.RESEND_FROM_NOREPLY ?? "Larry <noreply@larry-pm.com>";
 const FROM_LARRY   = process.env.RESEND_FROM_LARRY   ?? "Larry <larry@larry-pm.com>";
@@ -30,6 +36,32 @@ function getFrontendUrl(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Abuse guard — suppression + per-kind quotas.
+// Every send path goes through this. Keeps the rate-limit contract in one
+// place so a new email function can't silently bypass the caps.
+// ---------------------------------------------------------------------------
+
+export interface EmailSendContext {
+  userId?: string;
+  tenantId?: string;
+}
+
+/**
+ * Returns true if the caller should proceed with the send.
+ * Returns false on suppression (silent no-op by design).
+ * Throws EmailQuotaError on quota exhaustion — callers decide whether to
+ * propagate (auth flows typically swallow to preserve enumeration-safe UX).
+ */
+async function guard(kind: EmailKind, to: string, ctx?: EmailSendContext): Promise<boolean> {
+  if (await isSuppressed(to)) return false;
+  const quotaCtx: EmailQuotaContext = { kind, recipient: to };
+  if (ctx?.userId) quotaCtx.userId = ctx.userId;
+  if (ctx?.tenantId) quotaCtx.tenantId = ctx.tenantId;
+  await checkEmailQuota(quotaCtx);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
 // Shared HTML wrapper
 // ---------------------------------------------------------------------------
 
@@ -55,11 +87,16 @@ function ctaButton(href: string, label: string): string {
 // Email functions
 // ---------------------------------------------------------------------------
 
-export async function sendPasswordResetEmail(to: string, resetUrl: string): Promise<void> {
+export async function sendPasswordResetEmail(
+  to: string,
+  resetUrl: string,
+  ctx?: EmailSendContext,
+): Promise<void> {
   if (!isResendConfigured()) {
     console.log("[email] RESEND_API_KEY not configured. Password reset URL for %s:\n  %s", to, resetUrl);
     return;
   }
+  if (!(await guard("password_reset", to, ctx))) return;
   const resend = getResend();
   const { error } = await resend.emails.send({
     from: FROM_NOREPLY,
@@ -82,11 +119,16 @@ export async function sendPasswordResetEmail(to: string, resetUrl: string): Prom
   }
 }
 
-export async function sendVerificationEmail(to: string, verifyUrl: string): Promise<void> {
+export async function sendVerificationEmail(
+  to: string,
+  verifyUrl: string,
+  ctx?: EmailSendContext,
+): Promise<void> {
   if (!isResendConfigured()) {
     console.log("[email] RESEND_API_KEY not configured. Verification URL for %s:\n  %s", to, verifyUrl);
     return;
   }
+  if (!(await guard("verification", to, ctx))) return;
   const resend = getResend();
   const { error } = await resend.emails.send({
     from: FROM_NOREPLY,
@@ -109,11 +151,16 @@ export async function sendVerificationEmail(to: string, verifyUrl: string): Prom
   }
 }
 
-export async function sendEmailChangeConfirmation(to: string, confirmUrl: string): Promise<void> {
+export async function sendEmailChangeConfirmation(
+  to: string,
+  confirmUrl: string,
+  ctx?: EmailSendContext,
+): Promise<void> {
   if (!isResendConfigured()) {
     console.log("[email] RESEND_API_KEY not configured. Email change confirm URL for %s:\n  %s", to, confirmUrl);
     return;
   }
+  if (!(await guard("email_change_confirm", to, ctx))) return;
   const resend = getResend();
   const { error } = await resend.emails.send({
     from: FROM_NOREPLY,
@@ -136,11 +183,15 @@ export async function sendEmailChangeConfirmation(to: string, confirmUrl: string
   }
 }
 
-export async function sendEmailChangeNotification(to: string): Promise<void> {
+export async function sendEmailChangeNotification(
+  to: string,
+  ctx?: EmailSendContext,
+): Promise<void> {
   if (!isResendConfigured()) {
     console.log("[email] RESEND_API_KEY not configured. Skipping email change notification for %s", to);
     return;
   }
+  if (!(await guard("email_change_notify", to, ctx))) return;
   const resend = getResend();
   const frontendUrl = getFrontendUrl();
   const { error } = await resend.emails.send({
@@ -171,11 +222,16 @@ export interface DeviceInfo {
   location?: string;
 }
 
-export async function sendNewDeviceAlert(to: string, deviceInfo: DeviceInfo): Promise<void> {
+export async function sendNewDeviceAlert(
+  to: string,
+  deviceInfo: DeviceInfo,
+  ctx?: EmailSendContext,
+): Promise<void> {
   if (!isResendConfigured()) {
     console.log("[email] RESEND_API_KEY not configured. Skipping new device alert for %s", to);
     return;
   }
+  if (!(await guard("new_device_alert", to, ctx))) return;
   const resend = getResend();
   const frontendUrl = getFrontendUrl();
   const details = [
@@ -213,11 +269,16 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
-export async function sendMemberInviteEmail(to: string, displayName: string): Promise<void> {
+export async function sendMemberInviteEmail(
+  to: string,
+  displayName: string,
+  ctx?: EmailSendContext,
+): Promise<void> {
   if (!isResendConfigured()) {
     console.log("[email] RESEND_API_KEY not configured. Invite email for %s skipped.", to);
     return;
   }
+  if (!(await guard("member_invite", to, ctx))) return;
   const resend = getResend();
   const frontendUrl = getFrontendUrl();
   const safeName = escapeHtml(displayName);
@@ -241,3 +302,6 @@ export async function sendMemberInviteEmail(to: string, displayName: string): Pr
     throw new Error(`Failed to send member invite email: ${error.message}`);
   }
 }
+
+// Re-export the quota error so callers can detect it for enumeration-safe flows.
+export { EmailQuotaError } from "./email-quota.js";

--- a/apps/api/src/lib/llm-budget.test.ts
+++ b/apps/api/src/lib/llm-budget.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  reserveTokens as reserveTokensCore,
+  reconcileTokens as reconcileTokensCore,
+  LLMQuotaError,
+  tenantKey,
+  globalKey,
+  type BudgetStore,
+} from "@larry/ai/budget";
+
+// In-memory stand-in for the BudgetStore interface. Exercises the pure
+// budget logic without needing Redis.
+class FakeStore implements BudgetStore {
+  counters = new Map<string, number>();
+  ttls = new Map<string, number>();
+  async incrBy(key: string, delta: number): Promise<number> {
+    const next = (this.counters.get(key) ?? 0) + delta;
+    this.counters.set(key, next);
+    return next;
+  }
+  async expire(key: string, seconds: number): Promise<void> {
+    this.ttls.set(key, seconds);
+  }
+}
+
+const cfg = {
+  enabled: true,
+  tenantDailyTokens: 1_000,
+  globalDailyTokens: 2_000,
+};
+
+describe("llm-budget — reserve/reconcile", () => {
+  let store: FakeStore;
+
+  beforeEach(() => {
+    store = new FakeStore();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("under tenant and global caps: reservation succeeds and counters move", async () => {
+    const r = await reserveTokensCore(store, cfg, {
+      tenantId: "t1",
+      provider: "groq",
+      estimatedTokens: 100,
+    });
+    expect(r.active).toBe(true);
+    expect(store.counters.get(r.tenantKey)).toBe(100);
+    expect(store.counters.get(r.globalKey)).toBe(100);
+  });
+
+  it("over tenant cap: LLMQuotaError('tenant') and tenant counter rolled back", async () => {
+    await reserveTokensCore(store, cfg, { tenantId: "t1", provider: "groq", estimatedTokens: 900 });
+    await expect(
+      reserveTokensCore(store, cfg, { tenantId: "t1", provider: "groq", estimatedTokens: 200 }),
+    ).rejects.toBeInstanceOf(LLMQuotaError);
+    // After rollback, tenant should still be at 900 — not 1100.
+    expect(store.counters.get(tenantKey("t1"))).toBe(900);
+    // Global must not have been touched on the failed reservation.
+    expect(store.counters.get(globalKey("groq"))).toBe(900);
+  });
+
+  it("over global cap: both tenant and global counters rolled back", async () => {
+    // Fill global to 1900 via two tenants.
+    await reserveTokensCore(store, cfg, { tenantId: "t1", provider: "groq", estimatedTokens: 900 });
+    await reserveTokensCore(store, cfg, { tenantId: "t2", provider: "groq", estimatedTokens: 900 });
+    expect(store.counters.get(globalKey("groq"))).toBe(1_800);
+
+    // t3 pushes global to 2100 — over the 2000 cap.
+    await expect(
+      reserveTokensCore(store, cfg, { tenantId: "t3", provider: "groq", estimatedTokens: 300 }),
+    ).rejects.toBeInstanceOf(LLMQuotaError);
+
+    // Both keys rolled back to pre-attempt state.
+    expect(store.counters.get(tenantKey("t3"))).toBe(0);
+    expect(store.counters.get(globalKey("groq"))).toBe(1_800);
+  });
+
+  it("disabled budget: reservation is inert and reconcile is a no-op", async () => {
+    const r = await reserveTokensCore(store, { ...cfg, enabled: false }, {
+      tenantId: "t1",
+      provider: "groq",
+      estimatedTokens: 500,
+    });
+    expect(r.active).toBe(false);
+    expect(store.counters.size).toBe(0);
+    await reconcileTokensCore(store, r, 1_000);
+    expect(store.counters.size).toBe(0);
+  });
+
+  it("reconcile increments when actual > estimate", async () => {
+    const r = await reserveTokensCore(store, cfg, {
+      tenantId: "t1",
+      provider: "groq",
+      estimatedTokens: 100,
+    });
+    await reconcileTokensCore(store, r, 150);
+    expect(store.counters.get(r.tenantKey)).toBe(150);
+    expect(store.counters.get(r.globalKey)).toBe(150);
+  });
+
+  it("reconcile decrements when actual < estimate (negative delta)", async () => {
+    const r = await reserveTokensCore(store, cfg, {
+      tenantId: "t1",
+      provider: "groq",
+      estimatedTokens: 200,
+    });
+    await reconcileTokensCore(store, r, 50);
+    expect(store.counters.get(r.tenantKey)).toBe(50);
+    expect(store.counters.get(r.globalKey)).toBe(50);
+  });
+
+  it("reconcile exact match: no extra writes", async () => {
+    const r = await reserveTokensCore(store, cfg, {
+      tenantId: "t1",
+      provider: "groq",
+      estimatedTokens: 100,
+    });
+    const before = new Map(store.counters);
+    await reconcileTokensCore(store, r, 100);
+    expect(store.counters).toEqual(before);
+  });
+
+  it("key namespace is provider-scoped (gemini and groq do not share budget)", async () => {
+    await reserveTokensCore(store, cfg, { tenantId: "t1", provider: "groq", estimatedTokens: 100 });
+    await reserveTokensCore(store, cfg, { tenantId: "t1", provider: "gemini", estimatedTokens: 100 });
+    expect(store.counters.get(globalKey("groq"))).toBe(100);
+    expect(store.counters.get(globalKey("gemini"))).toBe(100);
+    // Tenant is shared across providers — one tenant's budget is a single number.
+    expect(store.counters.get(tenantKey("t1"))).toBe(200);
+  });
+
+  it("rejects non-positive estimated tokens", async () => {
+    await expect(
+      reserveTokensCore(store, cfg, { tenantId: "t1", provider: "groq", estimatedTokens: 0 }),
+    ).rejects.toThrow(/positive/);
+  });
+
+  it("TTL is set on every write", async () => {
+    const r = await reserveTokensCore(store, cfg, {
+      tenantId: "t1",
+      provider: "groq",
+      estimatedTokens: 100,
+    });
+    expect(store.ttls.get(r.tenantKey)).toBeGreaterThan(60 * 60);
+    expect(store.ttls.get(r.globalKey)).toBeGreaterThan(60 * 60);
+  });
+});

--- a/apps/api/src/lib/llm-budget.ts
+++ b/apps/api/src/lib/llm-budget.ts
@@ -1,0 +1,34 @@
+import { getApiEnv } from "@larry/config";
+import {
+  reserveTokens as reserveTokensCore,
+  reconcileTokens as reconcileTokensCore,
+  type BudgetStore,
+  type ReserveParams,
+  type TokenReservation,
+} from "@larry/ai/budget";
+import { getRedis } from "./redis.js";
+
+export { LLMQuotaError, type TokenReservation } from "@larry/ai/budget";
+
+function store(): BudgetStore {
+  const redis = getRedis();
+  return {
+    incrBy: (key, delta) => redis.incrby(key, delta),
+    expire: async (key, seconds) => {
+      await redis.expire(key, seconds);
+    },
+  };
+}
+
+export async function reserveTokens(params: ReserveParams): Promise<TokenReservation> {
+  const env = getApiEnv();
+  return reserveTokensCore(store(), {
+    enabled: env.LLM_BUDGET_ENABLED,
+    tenantDailyTokens: env.LLM_TENANT_DAILY_TOKENS,
+    globalDailyTokens: env.LLM_GLOBAL_DAILY_TOKENS,
+  }, params);
+}
+
+export async function reconcileTokens(reservation: TokenReservation, actualTokens: number): Promise<void> {
+  return reconcileTokensCore(store(), reservation, actualTokens);
+}

--- a/apps/api/src/lib/oauth-state.test.ts
+++ b/apps/api/src/lib/oauth-state.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class FakeRedis {
+  private store = new Map<string, { value: string; expires: number }>();
+  async set(
+    key: string,
+    value: string,
+    _ex: "EX",
+    seconds: number,
+    _nx: "NX",
+  ): Promise<"OK" | null> {
+    const existing = this.store.get(key);
+    if (existing && existing.expires > Date.now()) return null;
+    this.store.set(key, { value, expires: Date.now() + seconds * 1000 });
+    return "OK";
+  }
+  reset() {
+    this.store.clear();
+  }
+}
+
+const fake = new FakeRedis();
+
+vi.mock("./redis.js", () => ({
+  getRedis: () => fake,
+  closeRedis: async () => {},
+}));
+
+let envFlag = true;
+vi.mock("@larry/config", () => ({
+  getApiEnv: () => ({ OAUTH_STATE_SINGLE_USE_ENABLED: envFlag }),
+}));
+
+describe("oauth-state.claimStateToken", () => {
+  beforeEach(() => {
+    fake.reset();
+    envFlag = true;
+    vi.resetModules();
+  });
+
+  afterEach(() => {});
+
+  it("returns true on first claim, false on replay", async () => {
+    const { claimStateToken } = await import("./oauth-state.js");
+    expect(await claimStateToken("jti-1", 600)).toBe(true);
+    expect(await claimStateToken("jti-1", 600)).toBe(false);
+  });
+
+  it("a different jti is independent", async () => {
+    const { claimStateToken } = await import("./oauth-state.js");
+    expect(await claimStateToken("jti-a", 600)).toBe(true);
+    expect(await claimStateToken("jti-b", 600)).toBe(true);
+  });
+
+  it("missing jti is accepted (rollout safety — old tokens have no jti)", async () => {
+    const { claimStateToken } = await import("./oauth-state.js");
+    expect(await claimStateToken("", 600)).toBe(true);
+  });
+
+  it("flag-off short-circuits to true", async () => {
+    envFlag = false;
+    const { claimStateToken } = await import("./oauth-state.js");
+    expect(await claimStateToken("jti-x", 600)).toBe(true);
+    expect(await claimStateToken("jti-x", 600)).toBe(true);
+  });
+
+  it("clamps very small TTLs to a 60-second floor (defensive)", async () => {
+    const setSpy = vi.spyOn(fake, "set");
+    const { claimStateToken } = await import("./oauth-state.js");
+    await claimStateToken("jti-tiny", 5);
+    expect(setSpy).toHaveBeenCalledWith("oauth:state:jti-tiny", "1", "EX", 60, "NX");
+  });
+});

--- a/apps/api/src/lib/oauth-state.ts
+++ b/apps/api/src/lib/oauth-state.ts
@@ -1,0 +1,30 @@
+import { getApiEnv } from "@larry/config";
+import { getRedis } from "./redis.js";
+
+const KEY_PREFIX = "oauth:state:";
+
+/**
+ * Atomically mark an OAuth state token's jti as consumed.
+ * Returns true if this is the first redemption, false if it's a replay.
+ *
+ * Uses Redis SET NX with a TTL matching the state JWT's own lifetime so
+ * expired state tokens don't linger in Redis forever.
+ *
+ * Signature + expiry checks already happen on the token itself; this
+ * closes the last gap: a leaked-but-unexpired state token would otherwise
+ * be replayable until the TTL ran out.
+ */
+export async function claimStateToken(jti: string, ttlSeconds: number): Promise<boolean> {
+  const env = getApiEnv();
+  if (!env.OAUTH_STATE_SINGLE_USE_ENABLED) return true; // flag-off → no enforcement
+  if (!jti) return true; // tokens issued before this change won't have jti — accept once during rollout
+  const redis = getRedis();
+  const result = await redis.set(
+    `${KEY_PREFIX}${jti}`,
+    "1",
+    "EX",
+    Math.max(60, Math.floor(ttlSeconds)),
+    "NX",
+  );
+  return result === "OK";
+}

--- a/apps/api/src/lib/redis.test.ts
+++ b/apps/api/src/lib/redis.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Minimal ioredis mock — we only need to verify singleton wiring, not protocol.
+const quitMock = vi.fn().mockResolvedValue("OK");
+const onMock = vi.fn();
+const RedisCtor = vi.fn().mockImplementation(() => ({
+  quit: quitMock,
+  on: onMock,
+}));
+
+vi.mock("ioredis", () => ({ default: RedisCtor, Redis: RedisCtor }));
+
+describe("redis singleton", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    RedisCtor.mockClear();
+    quitMock.mockClear();
+    onMock.mockClear();
+    process.env.REDIS_URL = "redis://localhost:6379";
+    // Full minimal ApiEnv — getApiEnv() validates strictly.
+    process.env.DATABASE_URL = "postgresql://u:p@localhost:5432/x";
+    process.env.JWT_ACCESS_SECRET = "x".repeat(40);
+    process.env.JWT_REFRESH_SECRET = "y".repeat(40);
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(async () => {
+    const mod = await import("./redis.js");
+    await mod.closeRedis();
+  });
+
+  it("returns the same client on repeated calls", async () => {
+    const mod = await import("./redis.js");
+    const a = mod.getRedis();
+    const b = mod.getRedis();
+    expect(a).toBe(b);
+    expect(RedisCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it("constructs with REDIS_URL and sensible retry options", async () => {
+    const mod = await import("./redis.js");
+    mod.getRedis();
+    expect(RedisCtor).toHaveBeenCalledTimes(1);
+    const [url, opts] = RedisCtor.mock.calls[0];
+    expect(url).toBe("redis://localhost:6379");
+    expect(opts).toMatchObject({ maxRetriesPerRequest: expect.any(Number) });
+  });
+
+  it("registers an error handler so connection errors don't crash the process", async () => {
+    const mod = await import("./redis.js");
+    mod.getRedis();
+    expect(onMock).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  it("closeRedis releases the singleton so it can be re-created", async () => {
+    const mod = await import("./redis.js");
+    const first = mod.getRedis();
+    await mod.closeRedis();
+    expect(quitMock).toHaveBeenCalledTimes(1);
+    const second = mod.getRedis();
+    expect(second).not.toBe(first);
+    expect(RedisCtor).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/lib/redis.ts
+++ b/apps/api/src/lib/redis.ts
@@ -1,0 +1,30 @@
+import { Redis } from "ioredis";
+import { getApiEnv } from "@larry/config";
+
+let client: Redis | null = null;
+
+export function getRedis(): Redis {
+  if (client) return client;
+  const env = getApiEnv();
+  const instance = new Redis(env.REDIS_URL, {
+    maxRetriesPerRequest: 3,
+    enableReadyCheck: true,
+    lazyConnect: false,
+  });
+  instance.on("error", (err: Error) => {
+    // Surface to stderr so Railway logs capture it — structured logging
+    // happens at the consumer layer (Fastify logger).
+    console.error("[redis] connection error:", err.message);
+  });
+  client = instance;
+  return client;
+}
+
+export async function closeRedis(): Promise<void> {
+  if (!client) return;
+  try {
+    await client.quit();
+  } finally {
+    client = null;
+  }
+}

--- a/apps/api/src/routes/v1/auth-account.ts
+++ b/apps/api/src/routes/v1/auth-account.ts
@@ -238,7 +238,7 @@ export const authAccountRoutes: FastifyPluginAsync = async (fastify) => {
 
       // Send confirmation to NEW email
       try {
-        await sendEmailChangeConfirmation(body.newEmail, confirmUrl);
+        await sendEmailChangeConfirmation(body.newEmail, confirmUrl, { userId });
       } catch (err) {
         request.log.error(
           { err, userId },
@@ -248,7 +248,7 @@ export const authAccountRoutes: FastifyPluginAsync = async (fastify) => {
 
       // Send notification to OLD email (best-effort)
       try {
-        await sendEmailChangeNotification(user.email);
+        await sendEmailChangeNotification(user.email, { userId });
       } catch (err) {
         request.log.error(
           { err, userId },

--- a/apps/api/src/routes/v1/auth-google.ts
+++ b/apps/api/src/routes/v1/auth-google.ts
@@ -3,6 +3,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { issueAccessToken, issueRefreshToken } from "../../lib/auth.js";
 import { writeAuditLog } from "../../lib/audit.js";
+import { claimStateToken } from "../../lib/oauth-state.js";
 import {
   createSignedStateToken,
   verifySignedStateToken,
@@ -142,7 +143,18 @@ export const authGoogleRoutes: FastifyPluginAsync = async (fastify) => {
   // ─────────────────────────────────────────────────────────────────
   // GET /google/callback — Handle Google redirect
   // ─────────────────────────────────────────────────────────────────
-  fastify.get("/google/callback", async (request, reply) => {
+  fastify.get("/google/callback", {
+    config: {
+      // Rate-limit by client IP. State JWT + single-use jti guard the auth
+      // flow; this limit caps probing attempts that churn through state
+      // tokens from the same origin.
+      rateLimit: {
+        max: 10,
+        timeWindow: "1 minute",
+        keyGenerator: (req: import("fastify").FastifyRequest) => req.ip,
+      },
+    },
+  }, async (request, reply) => {
     const oauth = requireGoogleAuthConfig(fastify);
     const query = GoogleCallbackQuerySchema.parse(request.query);
 
@@ -161,14 +173,25 @@ export const authGoogleRoutes: FastifyPluginAsync = async (fastify) => {
 
     // Verify state
     let oauthState: z.infer<typeof GoogleStateSchema>;
+    let decodedJti: string | undefined;
     try {
       const decoded = verifySignedStateToken(
         query.state,
         fastify.config.JWT_ACCESS_SECRET
       );
+      decodedJti = typeof decoded.jti === "string" ? decoded.jti : undefined;
       oauthState = GoogleStateSchema.parse(decoded);
     } catch {
       return reply.redirect(`${frontendUrl}/login?error=google_invalid_state`);
+    }
+
+    // Single-use enforcement — a state token that's valid in signature and
+    // within TTL is still rejected on its second redemption. Without this,
+    // a leaked state is replayable until the TTL runs out.
+    const stateTtl = fastify.config.GOOGLE_OAUTH_STATE_TTL_SECONDS;
+    if (decodedJti && !(await claimStateToken(decodedJti, stateTtl))) {
+      request.log.warn({ jti: decodedJti }, "google/callback: state replay rejected");
+      return reply.redirect(`${frontendUrl}/login?error=google_state_replay`);
     }
 
     // Exchange code for tokens
@@ -405,7 +428,17 @@ export const authGoogleRoutes: FastifyPluginAsync = async (fastify) => {
   // ─────────────────────────────────────────────────────────────────
   fastify.post(
     "/google/link",
-    { preHandler: [fastify.authenticate] },
+    {
+      preHandler: [fastify.authenticate],
+      config: {
+        rateLimit: {
+          max: 10,
+          timeWindow: "1 hour",
+          keyGenerator: (req: import("fastify").FastifyRequest) =>
+            `google-link:${req.user?.userId ?? req.ip}`,
+        },
+      },
+    },
     async (request, reply) => {
       const body = GoogleLinkBodySchema.parse(request.body);
       const user = request.user;
@@ -467,7 +500,17 @@ export const authGoogleRoutes: FastifyPluginAsync = async (fastify) => {
   // ─────────────────────────────────────────────────────────────────
   fastify.post(
     "/google/unlink",
-    { preHandler: [fastify.authenticate] },
+    {
+      preHandler: [fastify.authenticate],
+      config: {
+        rateLimit: {
+          max: 10,
+          timeWindow: "1 hour",
+          keyGenerator: (req: import("fastify").FastifyRequest) =>
+            `google-unlink:${req.user?.userId ?? req.ip}`,
+        },
+      },
+    },
     async (request, reply) => {
       const user = request.user;
 

--- a/apps/api/src/routes/v1/auth-password-reset.ts
+++ b/apps/api/src/routes/v1/auth-password-reset.ts
@@ -79,9 +79,11 @@ export const authPasswordResetRoutes: FastifyPluginAsync = async (fastify) => {
     ).replace(/\/+$/, "");
     const resetUrl = `${frontendUrl}/reset-password?token=${encodeURIComponent(raw)}`;
 
-    // Send email (best-effort — don't fail the request)
+    // Send email (best-effort — don't fail the request). EmailQuotaError /
+    // EmailSuppressedError are caught here too so forgot-password always
+    // returns the generic success response (enumeration-safe).
     try {
-      await sendPasswordResetEmail(user.email, resetUrl);
+      await sendPasswordResetEmail(user.email, resetUrl, { userId: user.id });
     } catch (err) {
       request.log.error({ err, userId: user.id }, "Failed to send password reset email");
     }

--- a/apps/api/src/routes/v1/auth-verification.ts
+++ b/apps/api/src/routes/v1/auth-verification.ts
@@ -61,7 +61,7 @@ export const authVerificationRoutes: FastifyPluginAsync = async (fastify) => {
 
     // Send email (best-effort)
     try {
-      await sendVerificationEmail(email!, verifyUrl);
+      await sendVerificationEmail(email!, verifyUrl, { userId });
     } catch (err) {
       request.log.error({ err, userId }, "Failed to send verification email");
     }

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -134,7 +134,10 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
       ).replace(/\/+$/, "");
       const verifyUrl = `${frontendUrl}/verify-email?token=${encodeURIComponent(raw)}`;
 
-      await sendVerificationEmail(newUser.email, verifyUrl);
+      await sendVerificationEmail(newUser.email, verifyUrl, {
+        userId: newUser.id,
+        tenantId,
+      });
     } catch (err) {
       request.log.error({ err, userId: newUser.id }, "Failed to send verification email on signup");
     }
@@ -292,7 +295,11 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
         const ua = request.headers["user-agent"] ?? "Unknown device";
         const uaShort = ua.length > 100 ? ua.substring(0, 100) + "..." : ua;
         const { sendNewDeviceAlert } = await import("../../lib/email.js");
-        await sendNewDeviceAlert(user.email, { browser: uaShort, ip: request.ip }).catch(() => {});
+        await sendNewDeviceAlert(
+          user.email,
+          { browser: uaShort, ip: request.ip },
+          { userId: user.id, tenantId: user.tenant_id },
+        ).catch(() => {});
       }
     } catch { /* non-fatal */ }
 
@@ -532,9 +539,11 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
           [tenantId, userId, body.role]
         );
 
-        // Send invite email (graceful — don't fail the invite if email fails)
+        // Send invite email (graceful — don't fail the invite if email fails).
+        // tenantId drives the per-tenant invite cap (20/hour) and the daily
+        // 200/tenant global cap.
         try {
-          await sendMemberInviteEmail(body.email, displayName);
+          await sendMemberInviteEmail(body.email, displayName, { tenantId });
         } catch (emailErr) {
           console.error("[invite] Failed to send invite email:", emailErr);
         }

--- a/apps/api/src/routes/v1/connectors-slack.ts
+++ b/apps/api/src/routes/v1/connectors-slack.ts
@@ -12,6 +12,7 @@ import {
 } from "../../services/connectors/slack.js";
 import { ingestCanonicalEvent } from "../../services/ingest/pipeline.js";
 import { writeAuditLog } from "../../lib/audit.js";
+import { claimStateToken } from "../../lib/oauth-state.js";
 
 const SlackOauthStateSchema = z.object({
   kind: z.literal("slack_oauth_state"),
@@ -132,7 +133,15 @@ export const slackConnectorRoutes: FastifyPluginAsync = async (fastify) => {
     };
   });
 
-  fastify.get("/callback", async (request, reply) => {
+  fastify.get("/callback", {
+    config: {
+      rateLimit: {
+        max: 10,
+        timeWindow: "1 minute",
+        keyGenerator: (req: import("fastify").FastifyRequest) => req.ip,
+      },
+    },
+  }, async (request, reply) => {
     const oauth = requireSlackOauthConfig(fastify);
     const query = SlackCallbackQuerySchema.parse(request.query);
 
@@ -144,8 +153,10 @@ export const slackConnectorRoutes: FastifyPluginAsync = async (fastify) => {
     }
 
     let oauthState: z.infer<typeof SlackOauthStateSchema>;
+    let decodedJti: string | undefined;
     try {
       const decoded = verifySignedStateToken(query.state, fastify.config.JWT_ACCESS_SECRET);
+      decodedJti = typeof decoded.jti === "string" ? decoded.jti : undefined;
       oauthState = SlackOauthStateSchema.parse(decoded);
     } catch (error) {
       const reason = error instanceof Error ? error.message : "unknown";
@@ -153,6 +164,12 @@ export const slackConnectorRoutes: FastifyPluginAsync = async (fastify) => {
         throw fastify.httpErrors.badRequest(`Invalid or expired Slack OAuth state (${reason}).`);
       }
       throw fastify.httpErrors.badRequest("Invalid or expired Slack OAuth state.");
+    }
+
+    // Single-use enforcement to defeat state replay (see lib/oauth-state.ts).
+    if (decodedJti && !(await claimStateToken(decodedJti, fastify.config.SLACK_OAUTH_STATE_TTL_SECONDS))) {
+      request.log.warn({ jti: decodedJti }, "slack/callback: state replay rejected");
+      throw fastify.httpErrors.badRequest("OAuth state already used.");
     }
 
     const oauthResult = await exchangeSlackOauthCode({

--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -35,6 +35,15 @@ import type {
 } from "@larry/shared";
 import { writeAuditLog } from "../../lib/audit.js";
 import { buildPendingClause } from "../../lib/intelligence-hints.js";
+import { reserveTokens } from "../../lib/llm-budget.js";
+
+// Conservative pre-call estimates. runIntelligence empirically lands around
+// 9k tokens on our test tenant; streamLarryChat turns are typically 2-3k.
+// Over-estimating slightly is intentional — a pre-reserved call that ends
+// up cheaper is safer than the reverse. Reconciliation to actuals is a
+// follow-up step (current AI SDK call paths don't surface usage yet).
+const RUN_INTELLIGENCE_ESTIMATED_TOKENS = 9_500;
+const STREAM_CHAT_ESTIMATED_TOKENS = 3_000;
 import {
   ACTIVE_PROJECT_STATUS,
   ProjectStatusFilterSchema,
@@ -614,6 +623,11 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       project: (typeof globalProjects)[number]
     ): Promise<GlobalProjectIntelligenceResult> => {
       try {
+        await reserveTokens({
+          tenantId: input.tenantId,
+          provider: config.provider,
+          estimatedTokens: RUN_INTELLIGENCE_ESTIMATED_TOKENS,
+        });
         const snapshot = await getProjectSnapshot(fastify.db, input.tenantId, project.id);
         const pendingTexts = await getPendingSuggestionTexts(fastify.db, input.tenantId, project.id).catch(
           () => [] as string[]
@@ -2755,6 +2769,11 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       const config = buildIntelligenceConfig(fastify.config);
+      await reserveTokens({
+        tenantId,
+        provider: config.provider,
+        estimatedTokens: RUN_INTELLIGENCE_ESTIMATED_TOKENS,
+      });
       let result;
       try {
         result = await runIntelligence(
@@ -3407,6 +3426,13 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       };
 
       // ── Stream ────────────────────────────────────────────────────────────
+      // Reserve budget before opening the stream. If quota is exhausted the
+      // global error handler will return 429 before any SSE frames are sent.
+      await reserveTokens({
+        tenantId,
+        provider: config.provider,
+        estimatedTokens: STREAM_CHAT_ESTIMATED_TOKENS,
+      });
       try {
         for await (const event of streamLarryChat({
           config,

--- a/apps/api/src/routes/v1/webhooks-resend.ts
+++ b/apps/api/src/routes/v1/webhooks-resend.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { FastifyPluginAsync } from "fastify";
+import { addSuppression } from "../../lib/email-quota.js";
 
 /**
  * Resend webhook receiver.
@@ -70,15 +71,34 @@ export const resendWebhookRoutes: FastifyPluginAsync = async (fastify) => {
       return reply.code(400).send({ error: "Invalid JSON" });
     }
 
-    // Log interesting events. Future: insert into email_events table.
+    // Log interesting events and auto-suppress on hard bounces and complaints
+    // so we stop burning Resend quota / domain reputation on known-bad recipients.
     const to = extractTo(event);
     const type = event.type ?? "unknown";
     switch (type) {
-      case "email.bounced":
-        request.log.warn({ svixId, type, to, data: event.data }, "[webhook-resend] bounce");
+      case "email.bounced": {
+        const bounceType = extractBounceType(event);
+        request.log.warn({ svixId, type, to, bounceType, data: event.data }, "[webhook-resend] bounce");
+        // Only suppress hard bounces — soft bounces (mailbox full, temporary
+        // outage) are transient and the address may recover.
+        if (to && bounceType === "hard") {
+          try {
+            await addSuppression(to, "bounce");
+          } catch (err) {
+            request.log.error({ err, to }, "[webhook-resend] failed to add bounce suppression");
+          }
+        }
         break;
+      }
       case "email.complained":
         request.log.warn({ svixId, type, to, data: event.data }, "[webhook-resend] complaint");
+        if (to) {
+          try {
+            await addSuppression(to, "complaint");
+          } catch (err) {
+            request.log.error({ err, to }, "[webhook-resend] failed to add complaint suppression");
+          }
+        }
         break;
       case "email.delivery_delayed":
         request.log.info({ svixId, type, to }, "[webhook-resend] delivery delayed");
@@ -122,6 +142,21 @@ function extractTo(event: ResendEvent): string | undefined {
   const to = event.data?.to;
   if (Array.isArray(to)) return to[0];
   if (typeof to === "string") return to;
+  return undefined;
+}
+
+function extractBounceType(event: ResendEvent): "hard" | "soft" | undefined {
+  // Resend shapes the bounce payload as either a `bounce` object with a
+  // `type` field, or the type is nested under `bounce_type`. Be defensive.
+  const data = event.data as Record<string, unknown> | undefined;
+  if (!data) return undefined;
+  const direct = data["bounce_type"];
+  if (direct === "hard" || direct === "soft") return direct;
+  const nested = data["bounce"] as { type?: unknown } | undefined;
+  if (nested && typeof nested === "object") {
+    const t = nested.type;
+    if (t === "hard" || t === "soft") return t;
+  }
   return undefined;
 }
 

--- a/apps/api/src/services/connectors/slack.ts
+++ b/apps/api/src/services/connectors/slack.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
 
 const SlackOauthSuccessSchema = z.object({
@@ -139,7 +139,10 @@ export function createSignedStateToken(
   ttlSeconds = 600
 ): string {
   const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
-  const encodedPayload = Buffer.from(JSON.stringify({ ...payload, exp })).toString("base64url");
+  // jti enables single-use enforcement at the callback. Random 128-bit id
+  // is collision-free in practice and base-10-safe for easy Redis keys.
+  const jti = randomBytes(16).toString("hex");
+  const encodedPayload = Buffer.from(JSON.stringify({ ...payload, exp, jti })).toString("base64url");
   const signature = createHmac("sha256", secret).update(encodedPayload).digest("base64url");
   return `${encodedPayload}.${signature}`;
 }

--- a/apps/api/tests/larry-chat.test.ts
+++ b/apps/api/tests/larry-chat.test.ts
@@ -36,6 +36,23 @@ vi.mock("../src/lib/audit.js", () => ({
   writeAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
+// LLM budget writes to Redis; these tests don't exercise it. Keep the
+// reservation inert so chat flows behave as they did pre-Phase-3.
+vi.mock("../src/lib/llm-budget.js", () => ({
+  reserveTokens: vi.fn().mockResolvedValue({ active: false }),
+  reconcileTokens: vi.fn().mockResolvedValue(undefined),
+  LLMQuotaError: class LLMQuotaError extends Error {
+    readonly scope: "tenant" | "global";
+    readonly limit: number;
+    constructor(scope: "tenant" | "global", limit: number) {
+      super("fake llm quota");
+      this.name = "LLMQuotaError";
+      this.scope = scope;
+      this.limit = limit;
+    }
+  },
+}));
+
 vi.mock("../src/services/larry-briefing.js", () => ({
   getOrGenerateBriefing: vi.fn(),
 }));

--- a/apps/api/tests/webhooks-resend.test.ts
+++ b/apps/api/tests/webhooks-resend.test.ts
@@ -1,7 +1,19 @@
 import { createHmac } from "node:crypto";
 import Fastify, { FastifyInstance } from "fastify";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resendWebhookRoutes, verifySvixSignature } from "../src/routes/v1/webhooks-resend.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock email-quota so webhook tests don't need a real Redis. Behavior of
+// addSuppression itself is covered by email-quota.test.ts; here we only care
+// that the webhook calls it with the right arguments on hard bounce /
+// complaint events and does NOT call it for soft bounces or delivered events.
+const addSuppressionMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("../src/lib/email-quota.js", () => ({
+  addSuppression: addSuppressionMock,
+}));
+
+const { resendWebhookRoutes, verifySvixSignature } = await import(
+  "../src/routes/v1/webhooks-resend.js"
+);
 
 /**
  * Tests cover both the unit of the signature verifier (pure function)
@@ -67,6 +79,7 @@ describe("POST /webhooks/resend", () => {
 
   beforeEach(async () => {
     process.env.RESEND_WEBHOOK_SECRET = FULL_SECRET;
+    addSuppressionMock.mockClear();
     app = Fastify({ logger: false });
     await app.register(resendWebhookRoutes, { prefix: "/webhooks" });
     await app.ready();
@@ -187,5 +200,86 @@ describe("POST /webhooks/resend", () => {
       payload: body,
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  async function postEvent(event: Record<string, unknown>): Promise<number> {
+    const svixId = "msg_" + Math.random().toString(36).slice(2);
+    const svixTs = freshTs();
+    const body = JSON.stringify(event);
+    const res = await app.inject({
+      method: "POST",
+      url: "/webhooks/resend",
+      headers: {
+        "content-type": "application/json",
+        "svix-id": svixId,
+        "svix-timestamp": svixTs,
+        "svix-signature": signSvix(svixId, svixTs, body),
+      },
+      payload: body,
+    });
+    return res.statusCode;
+  }
+
+  it("adds suppression on hard bounce (bounce_type field)", async () => {
+    const status = await postEvent({
+      type: "email.bounced",
+      data: { to: ["hard@example.com"], bounce_type: "hard" },
+    });
+    expect(status).toBe(200);
+    expect(addSuppressionMock).toHaveBeenCalledWith("hard@example.com", "bounce");
+  });
+
+  it("adds suppression on hard bounce (nested bounce.type shape)", async () => {
+    const status = await postEvent({
+      type: "email.bounced",
+      data: { to: ["hard2@example.com"], bounce: { type: "hard" } },
+    });
+    expect(status).toBe(200);
+    expect(addSuppressionMock).toHaveBeenCalledWith("hard2@example.com", "bounce");
+  });
+
+  it("does NOT suppress soft bounces", async () => {
+    const status = await postEvent({
+      type: "email.bounced",
+      data: { to: ["soft@example.com"], bounce_type: "soft" },
+    });
+    expect(status).toBe(200);
+    expect(addSuppressionMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT suppress when bounce type is absent (unknown → treat as soft)", async () => {
+    const status = await postEvent({
+      type: "email.bounced",
+      data: { to: ["unknown@example.com"] },
+    });
+    expect(status).toBe(200);
+    expect(addSuppressionMock).not.toHaveBeenCalled();
+  });
+
+  it("adds suppression on complaint events", async () => {
+    const status = await postEvent({
+      type: "email.complained",
+      data: { to: ["spam@example.com"] },
+    });
+    expect(status).toBe(200);
+    expect(addSuppressionMock).toHaveBeenCalledWith("spam@example.com", "complaint");
+  });
+
+  it("ignores delivered / opened / clicked events (no suppression)", async () => {
+    for (const type of ["email.delivered", "email.opened", "email.clicked", "email.sent"]) {
+      await postEvent({ type, data: { to: ["ok@example.com"] } });
+    }
+    expect(addSuppressionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 even if addSuppression throws (don't NACK the webhook)", async () => {
+    addSuppressionMock.mockRejectedValueOnce(new Error("redis down"));
+    const status = await postEvent({
+      type: "email.bounced",
+      data: { to: ["transient@example.com"], bounce_type: "hard" },
+    });
+    // We logged the error but still returned 200 so Resend doesn't retry
+    // indefinitely on a transient Redis blip.
+    expect(status).toBe(200);
   });
 });

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -4,11 +4,31 @@ const MAX_ATTEMPTS = 5;
 const WINDOW_SECS = 15 * 60; // 15 minutes
 
 // --- Redis client (Vercel Node.js serverless — not Edge) ---
+//
+// This module is a UX nicety. The Larry API (Railway) is the source of
+// truth for auth rate limits — see apps/api/src/routes/v1/auth.ts. The
+// purpose of the web-side check is to short-circuit obvious abuse at
+// the edge so the browser sees a friendly 429 quickly instead of a
+// proxied API response.
+//
+// Without Redis we cannot enforce a distributed limit on Vercel
+// (in-memory state is per-invocation), and the previous in-memory
+// fallback gave a false sense of safety. We now no-op silently —
+// the API still rejects abuse, just one network hop later.
 
 let _redis: Redis | null = null;
+let warnedNoRedis = false;
 
 function getRedis(): Redis | null {
-  if (!process.env.REDIS_URL) return null;
+  if (!process.env.REDIS_URL) {
+    if (!warnedNoRedis) {
+      warnedNoRedis = true;
+      console.warn(
+        "[web/rate-limit] REDIS_URL is not set — web-side login throttle is disabled. The API still enforces limits.",
+      );
+    }
+    return null;
+  }
   if (!_redis) {
     _redis = new Redis(process.env.REDIS_URL, {
       maxRetriesPerRequest: 1,
@@ -21,43 +41,21 @@ function getRedis(): Redis | null {
   return _redis;
 }
 
-// --- In-memory fallback ---
-// WARNING: Vercel serverless functions are stateless — the in-memory store is NOT
-// shared across concurrent function invocations. This fallback is acceptable for
-// local dev and low-traffic deploys but does not enforce limits at scale.
-// Set REDIS_URL in Vercel env vars to enable distributed rate limiting.
-
-const memStore = new Map<string, { count: number; windowStart: number }>();
-
-function checkMemory(ip: string): { limited: boolean } {
-  const now = Date.now();
-  const entry = memStore.get(ip);
-  if (!entry || now - entry.windowStart > WINDOW_SECS * 1000) {
-    memStore.set(ip, { count: 1, windowStart: now });
-    return { limited: false };
-  }
-  entry.count += 1;
-  return { limited: entry.count > MAX_ATTEMPTS };
-}
-
 // --- Public API ---
-
-// checkRateLimit both checks AND records the attempt atomically.
-// The separate recordLoginAttempt export is kept for API compatibility but is a no-op.
 
 export async function checkRateLimit(ip: string): Promise<{ limited: boolean }> {
   const r = getRedis();
-  if (r) {
-    try {
-      const key = `ratelimit:login:${ip}`;
-      const count = await r.incr(key);
-      if (count === 1) await r.expire(key, WINDOW_SECS);
-      return { limited: count > MAX_ATTEMPTS };
-    } catch {
-      // Redis unavailable — fall through to in-memory
-    }
+  if (!r) return { limited: false };
+  try {
+    const key = `ratelimit:login:${ip}`;
+    const count = await r.incr(key);
+    if (count === 1) await r.expire(key, WINDOW_SECS);
+    return { limited: count > MAX_ATTEMPTS };
+  } catch {
+    // Redis unreachable — fall through to a permit. The Larry API will
+    // still reject the request via its own (Redis-backed) limiter.
+    return { limited: false };
   }
-  return checkMemory(ip);
 }
 
 // no-op: attempt counting is now handled atomically inside checkRateLimit

--- a/apps/worker/src/larry-scan.ts
+++ b/apps/worker/src/larry-scan.ts
@@ -3,6 +3,13 @@ import { getProjectSnapshot, runAutoActions, storeSuggestions, updateProjectLarr
 import { runIntelligence } from "@larry/ai";
 import { db } from "./context.js";
 import { buildWorkerIntelligenceConfig } from "./intelligence-config.js";
+import { reserveTokens, LLMQuotaError } from "./llm-budget.js";
+
+// Per-project estimated token cost for runIntelligence. Empirically ~9k
+// post-N-9. We over-estimate slightly so the budget debits a number close
+// to reality without a post-call reconcile step (runIntelligence doesn't
+// surface usage today; see future work in the rate-limit hardening spec).
+const SCAN_ESTIMATED_TOKENS = 9_500;
 
 // N-11: dropped from 5 → 1 to keep the scan within the Groq free-tier
 // 12k-TPM bucket. Per-project runIntelligence cost is ~9k tokens post-N-9;
@@ -85,6 +92,27 @@ export async function runLarryScan(): Promise<void> {
       if (!row) break;
       const { id: projectId, tenant_id: tenantId } = row;
       try {
+        // Reserve LLM budget before the scan. If the tenant or the provider's
+        // global daily cap is exhausted we skip this project — the next cron
+        // tick will retry once the day rolls over. This is the last line of
+        // defence against a runaway tenant burning the Groq free-tier TPD.
+        try {
+          await reserveTokens({
+            tenantId,
+            provider: config.provider,
+            estimatedTokens: SCAN_ESTIMATED_TOKENS,
+          });
+        } catch (err) {
+          if (err instanceof LLMQuotaError) {
+            console.warn(
+              `[larry-scan] quota exceeded (${err.scope}), skipping project ${projectId} (tenant ${tenantId})`
+            );
+            // Don't count this as a "failed" scan — quota skips are expected.
+            continue;
+          }
+          throw err;
+        }
+
         const snapshot = await getProjectSnapshot(db, tenantId, projectId);
         const result = await runIntelligence(config, snapshot, "scheduled health scan");
         const ledgerContext = { sourceKind: "project_review", sourceRecordId: randomUUID() } as const;

--- a/apps/worker/src/llm-budget.ts
+++ b/apps/worker/src/llm-budget.ts
@@ -1,0 +1,34 @@
+import { getWorkerEnv } from "@larry/config";
+import {
+  reserveTokens as reserveTokensCore,
+  reconcileTokens as reconcileTokensCore,
+  type BudgetStore,
+  type ReserveParams,
+  type TokenReservation,
+} from "@larry/ai/budget";
+import { getRedis } from "./redis.js";
+
+export { LLMQuotaError, type TokenReservation } from "@larry/ai/budget";
+
+function store(): BudgetStore {
+  const redis = getRedis();
+  return {
+    incrBy: (key, delta) => redis.incrby(key, delta),
+    expire: async (key, seconds) => {
+      await redis.expire(key, seconds);
+    },
+  };
+}
+
+export async function reserveTokens(params: ReserveParams): Promise<TokenReservation> {
+  const env = getWorkerEnv();
+  return reserveTokensCore(store(), {
+    enabled: env.LLM_BUDGET_ENABLED,
+    tenantDailyTokens: env.LLM_TENANT_DAILY_TOKENS,
+    globalDailyTokens: env.LLM_GLOBAL_DAILY_TOKENS,
+  }, params);
+}
+
+export async function reconcileTokens(reservation: TokenReservation, actualTokens: number): Promise<void> {
+  return reconcileTokensCore(store(), reservation, actualTokens);
+}

--- a/apps/worker/src/redis.ts
+++ b/apps/worker/src/redis.ts
@@ -1,0 +1,28 @@
+import { Redis } from "ioredis";
+import { getWorkerEnv } from "@larry/config";
+
+let client: Redis | null = null;
+
+export function getRedis(): Redis {
+  if (client) return client;
+  const env = getWorkerEnv();
+  const instance = new Redis(env.REDIS_URL, {
+    maxRetriesPerRequest: 3,
+    enableReadyCheck: true,
+    lazyConnect: false,
+  });
+  instance.on("error", (err: Error) => {
+    console.error("[worker-redis] connection error:", err.message);
+  });
+  client = instance;
+  return client;
+}
+
+export async function closeRedis(): Promise<void> {
+  if (!client) return;
+  try {
+    await client.quit();
+  } finally {
+    client = null;
+  }
+}

--- a/docs/superpowers/plans/2026-04-15-rate-limiting-hardening-plan.md
+++ b/docs/superpowers/plans/2026-04-15-rate-limiting-hardening-plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan — Rate Limiting Hardening
+
+**Spec:** `docs/superpowers/specs/2026-04-15-rate-limiting-hardening-design.md`
+**Branch:** `feat/rate-limiting-hardening`
+
+Each phase lands as its own commit. After each: `npm --workspace apps/api test`, push, wait for Railway deploy, smoke test.
+
+---
+
+## Phase 1 — Redis-backed rate limiter + trustProxy
+
+### Files
+- **New**: `apps/api/src/lib/redis.ts` — singleton client
+- **New**: `apps/api/src/lib/redis.test.ts` — singleton behavior
+- **Edit**: `apps/api/src/app.ts` — wire Redis to `@fastify/rate-limit`, `trustProxy: true`, `skipOnError: false`, `onClose` closes client
+- **New**: `apps/api/src/app.test.ts` (or add to existing) — trustProxy wired, rate-limit has Redis store
+
+### Tests (TDD, write first)
+1. `getRedis()` returns same instance on repeat calls
+2. `closeRedis()` allows re-init
+3. With `trustProxy: true`, a request with `X-Forwarded-For: 1.2.3.4` reports `request.ip === "1.2.3.4"`
+4. Rate-limit exceeded across "two instances" (simulated by clearing in-process state but sharing Redis) still returns 429
+
+### Commands
+```
+cd apps/api
+npm test -- src/lib/redis.test.ts
+npm test -- src/app.test.ts
+```
+
+### Risk & rollback
+- Risk: Redis misconfig causes 500s on every rate-limited route.
+- Rollback: env `RATE_LIMIT_REDIS_ENABLED=false` → app.ts branch falls back to `redis: undefined`.
+
+### Smoke test after deploy
+```
+# Hammer /v1/auth/login from same IP 11 times; expect the 11th to be 429
+for i in {1..11}; do curl -sS -o /dev/null -w '%{http_code}\n' \
+  https://larry-site-production.up.railway.app/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"nobody@example.com","password":"x"}'; done
+# Expect 10x (401|400) then 429
+```
+
+---
+
+## Phase 2 — Email quota + suppression
+
+### Files
+- **New**: `apps/api/src/lib/email-quota.ts` — checkEmailQuota, isSuppressed, addSuppression, errors
+- **New**: `apps/api/src/lib/email-quota.test.ts`
+- **Edit**: `apps/api/src/lib/email.ts` — wrap each send with suppression check + quota check
+- **Edit**: `apps/api/src/lib/email.test.ts` — add cases for quota exhaustion & suppression no-op
+- **Edit**: `apps/api/src/routes/v1/webhooks-resend.ts` — on bounce/complaint call `addSuppression`
+- **Edit**: `apps/api/src/routes/v1/webhooks-resend.test.ts` — assert suppression side-effect
+
+### Tests (TDD)
+1. `checkEmailQuota` allows under limit (returns void)
+2. `checkEmailQuota` throws `EmailQuotaError` at hour limit
+3. `checkEmailQuota` throws `EmailQuotaError` at day limit even if hour resets
+4. Tenant daily cap applies across kinds
+5. Global daily circuit breaker fires at 500
+6. `isSuppressed` returns true after `addSuppression`
+7. `sendPasswordResetEmail` is a no-op (does not call resend) when recipient is suppressed
+8. `sendPasswordResetEmail` throws `EmailQuotaError` past limit; forgot-password route catches and still returns generic 200
+9. Resend webhook `email.bounced` (hard) adds suppression
+10. Resend webhook `email.complained` adds suppression
+11. Soft bounces do NOT suppress
+
+### Commands
+```
+npm test -- src/lib/email-quota.test.ts
+npm test -- src/lib/email.test.ts
+npm test -- src/routes/v1/webhooks-resend.test.ts
+```
+
+### Risk & rollback
+- Risk: legit users hit quota (bad defaults). Logs every 429 at warn — Railway logs will show it.
+- Rollback: env `EMAIL_QUOTA_ENABLED=false` → guards become no-ops.
+
+### Smoke test after deploy
+Manual: request password reset 4 times via UI within 1h. 4th should silently no-op (server 429, UI shows generic "check your email").
+
+---
+
+## Phase 3 — LLM token budget
+
+### Files
+- **New**: `packages/ai/src/budget.ts` — reserveTokens, reconcileTokens, LLMQuotaError
+- **New**: `packages/ai/src/budget.test.ts`
+- **Edit**: `packages/ai/src/provider.ts` OR introduce `packages/ai/src/run.ts` wrapper — depends on current provider shape; will inspect at implementation time
+- **Edit**: `apps/worker/src/larry-scan.ts` — wrap provider call, handle `LLMQuotaError` → log + skip
+- **Edit**: `apps/api/src/routes/v1/larry.ts` — wrap chat/stream/transcript provider calls, `LLMQuotaError` → 429 with friendly message
+- **Edit**: `packages/config/src/index.ts` — add `LLM_TENANT_DAILY_TOKENS`, `LLM_GLOBAL_DAILY_TOKENS`, `LLM_BUDGET_ENABLED`
+
+### Tests (TDD)
+1. `reserveTokens` under budget → ok, INCRs both keys
+2. `reserveTokens` over tenant budget → rollback, throws `LLMQuotaError("tenant", ...)`
+3. `reserveTokens` over global budget → rollback both keys, throws `LLMQuotaError("global", ...)`
+4. `reconcileTokens` with positive delta → INCRs further
+5. `reconcileTokens` with negative delta → DECRs
+6. Keys expire 48h (check TTL)
+7. Scan handler catches `LLMQuotaError` and does not re-queue infinitely
+8. Chat endpoint returns 429 on `LLMQuotaError`
+
+### Risk & rollback
+- Risk: bad estimate causes false rejections. Logged for tuning.
+- Risk: reconcile missed (e.g., process crash) → slight over-accounting, favors safety. Acceptable.
+- Rollback: `LLM_BUDGET_ENABLED=false`.
+
+### Smoke test
+Verify budget counters exist in Redis after a chat call:
+```
+redis-cli KEYS 'llm:tok:*'
+redis-cli GET 'llm:tok:tenant:<test-tid>:2026-04-15'
+```
+
+---
+
+## Phase 4 — OAuth gaps
+
+### Files
+- **Edit**: `apps/api/src/routes/v1/auth-google.ts` — rate-limit on `/link`, `/unlink`, `/callback`; state jti + single-use SET NX
+- **Edit**: `apps/api/src/routes/v1/connectors-slack.ts` — state jti + single-use; IP limit on `/callback`
+- **Edit**: both test files — replay attempt rejected
+
+### Tests (TDD)
+1. Google state signed with jti; reuse of same state → 400 "state already used"
+2. Slack state signed with jti; reuse → 400
+3. `/google/link` rate limited by userId at 10/hour
+4. `/google/unlink` same
+5. `/google/callback` rate limited by IP at 10/min
+
+---
+
+## Phase 5 — Web layer cleanup
+
+### Files
+- **Edit**: `apps/web/src/lib/rate-limit.ts` — remove in-memory fallback, turn into Redis-or-noop with clear comment
+- **Edit**: any consumers to confirm they still behave
+
+### Tests (TDD)
+1. Without `REDIS_URL`: `checkRateLimit` returns `{ ok: true }` and logs a warning once
+2. With Redis: enforces limit
+
+---
+
+## Verification checklist per phase
+
+- [ ] TDD: failing test written first, confirmed failing, then implementation
+- [ ] `npm test` green in affected workspaces
+- [ ] `npm run build` green across monorepo (no TS errors)
+- [ ] Commit with spec-referenced message
+- [ ] Push to `feat/rate-limiting-hardening`
+- [ ] Wait for Railway deploy (apps/api auto-deploys from branch? confirm; else merge to master at end)
+- [ ] Smoke test against deployed URL
+- [ ] Self-reflect: did anything surprise me? any skipped edge case? update spec if so
+- [ ] Mark task completed, move to next
+
+## Final merge
+After all 5 phases verified: open PR `feat/rate-limiting-hardening` → `master` for the full body of work, not per phase. This keeps review coherent.

--- a/docs/superpowers/specs/2026-04-15-rate-limiting-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-15-rate-limiting-hardening-design.md
@@ -1,0 +1,303 @@
+# Rate Limiting & Abuse Protection Hardening
+
+**Date:** 2026-04-15
+**Author:** Fergus + Claude (Opus 4.6)
+**Status:** Approved, in implementation
+
+## Problem
+
+The public audit of the Larry API exposed several rate-limiting gaps that, while the repo was briefly public, could have been enumerated by an attacker:
+
+1. `@fastify/rate-limit` uses an in-memory store — limits are per-instance, not global. Railway multi-instance bypasses them.
+2. `trustProxy` is not set. Behind Railway's load balancer, `request.ip` is the proxy IP, so IP-based limits effectively collapse to a single bucket for all clients.
+3. Resend email sends have no per-user/per-tenant caps. A compromised account (or bug) can drain the Resend quota and poison domain reputation.
+4. LLM calls (Gemini/Groq) have per-minute route limits but no daily token budget. Groq free tier is 100k TPD; one tenant can exhaust the entire cap.
+5. Google OAuth `link`/`unlink` endpoints are unprotected.
+6. OAuth state JWTs are stateless — signature + TTL only, no single-use guard.
+7. Web-layer (`apps/web/src/lib/rate-limit.ts`) falls back to in-memory on Vercel serverless, which is effectively no limit.
+
+JWT access secret has already been rotated, so credential forgery from the leak is dead. This spec covers the structural fixes to ensure future exposure (or just scale) doesn't recreate the risk.
+
+## Goals
+
+- Distributed rate limiting that holds under multi-instance deploy.
+- Correct client identity behind Railway proxy.
+- Hard caps on outbound email per user/tenant to prevent email bombing.
+- Daily LLM token budgets (per-tenant + global provider) to prevent cost/quota exhaustion.
+- Close small OAuth gaps (link/unlink, state replay).
+- Remove deceptive in-memory fallback on the web layer.
+
+## Non-goals (YAGNI)
+
+- Tiered plans with per-plan quotas (no plans table yet).
+- Dollar cost tracking (tokens only).
+- Alerting dashboard UI (Railway logs suffice for now).
+- Cloudflare/WAF layer.
+- Auto-refilling token bucket (fixed daily window is fine).
+
+## Architecture
+
+### Shared infrastructure — `apps/api/src/lib/redis.ts`
+
+Single ioredis client, lazy-initialized, reused by:
+- `@fastify/rate-limit` store
+- Email quota guard
+- Email suppression set
+- LLM token budget accounting
+- OAuth state single-use dedupe
+
+ioredis v5 is already installed in `apps/api`. BullMQ uses the same `REDIS_URL`; one shared TCP connection is fine.
+
+```ts
+// apps/api/src/lib/redis.ts
+import Redis from "ioredis";
+import { getApiEnv } from "@larry/config";
+
+let client: Redis | null = null;
+
+export function getRedis(): Redis {
+  if (client) return client;
+  const env = getApiEnv();
+  client = new Redis(env.REDIS_URL, {
+    maxRetriesPerRequest: 3,
+    enableReadyCheck: true,
+    lazyConnect: false,
+  });
+  client.on("error", (err) => {
+    // Logged here; don't silently swallow. Fastify logger picks this up.
+    console.error("[redis] connection error:", err.message);
+  });
+  return client;
+}
+
+export async function closeRedis(): Promise<void> {
+  if (client) {
+    await client.quit();
+    client = null;
+  }
+}
+```
+
+Closed in the existing `onClose` hook alongside the queue and DB.
+
+### Phase 1 — Fastify rate-limit + trustProxy
+
+Edits to `apps/api/src/app.ts`:
+
+```ts
+const app = Fastify({
+  logger: { level: env.LOG_LEVEL },
+  bodyLimit: 10 * 1024 * 1024,
+  trustProxy: true, // Railway sits behind a proxy; X-Forwarded-For must be honored
+});
+
+await app.register(rateLimit, {
+  global: false,          // preserve opt-in per-route contract
+  redis: getRedis(),      // distributed store
+  skipOnError: false,     // fail-closed; Redis is already a hard dep (BullMQ)
+  nameSpace: "rl:",       // namespace keys to avoid collisions
+});
+```
+
+Per-route limit configs in existing handlers stay as-is.
+
+### Phase 2 — Email send caps + suppression
+
+New module: `apps/api/src/lib/email-quota.ts`.
+
+```ts
+export type EmailKind =
+  | "password_reset"
+  | "verification"
+  | "email_change_confirm"
+  | "email_change_notify"
+  | "new_device_alert"
+  | "member_invite"
+  | "generic";
+
+export interface EmailQuotaContext {
+  kind: EmailKind;
+  recipient: string;     // raw; hashed before logging/keying
+  userId?: string;       // optional for anonymous flows like forgot-password
+  tenantId?: string;
+}
+
+export class EmailQuotaError extends Error {
+  constructor(public readonly detail: { scope: string; limit: number; window: string }) {
+    super(`email quota exceeded: ${detail.scope}`);
+    this.name = "EmailQuotaError";
+  }
+}
+
+export class EmailSuppressedError extends Error {
+  constructor(public readonly recipientHash: string) {
+    super("recipient suppressed");
+    this.name = "EmailSuppressedError";
+  }
+}
+
+export async function checkEmailQuota(ctx: EmailQuotaContext): Promise<void>;
+export async function addSuppression(recipient: string, reason: "bounce" | "complaint"): Promise<void>;
+export async function isSuppressed(recipient: string): Promise<boolean>;
+```
+
+**Keys:**
+- `email:suppressed:<sha256(recipient.toLowerCase())>` — Redis SET (actually a simple string "1" with no TTL; entries are forever until manual removal).
+- `email:q:<kind>:user:<userId>:h` (1h window)
+- `email:q:<kind>:user:<userId>:d` (1d window)
+- `email:q:tenant:<tid>:d` (1d window, all kinds)
+- `email:q:global:d` (1d circuit breaker)
+
+**Limits (initial; env-tunable):**
+
+| Kind                   | Per-user/hour | Per-user/day |
+| ---------------------- | ------------- | ------------ |
+| password_reset         | 3             | 10           |
+| verification           | 5             | 15           |
+| email_change_confirm   | 3             | 10           |
+| email_change_notify    | 5             | 15           |
+| new_device_alert       | 10            | 30           |
+| member_invite          | n/a (tenant)  | n/a (tenant) |
+| generic                | 10            | 30           |
+
+Plus:
+- `member_invite`: 20/hour/tenant
+- Any kind: 200/day/tenant (global cap)
+- Any kind: 500/day across all tenants (Resend circuit breaker)
+
+**Flow** (inside `email.ts` at the top of each send function):
+
+```ts
+if (await isSuppressed(to)) return; // silent no-op; don't count
+await checkEmailQuota({ kind: "password_reset", recipient: to, userId });
+const { error } = await resend.emails.send({ ... });
+```
+
+**Failure handling:**
+- `EmailQuotaError` → caller decides: auth flows return same generic success (enumeration-safe); internal flows log + swallow.
+- `EmailSuppressedError` is implicit — the send is a no-op.
+
+**Suppression wiring:**
+Extend `apps/api/src/routes/v1/webhooks-resend.ts`:
+- On `email.bounced` with type=hard → `addSuppression(email, "bounce")`.
+- On `email.complained` → `addSuppression(email, "complaint")`.
+- Soft bounces are logged only, no suppression.
+
+### Phase 3 — LLM token budget
+
+New module: `packages/ai/src/budget.ts`.
+
+```ts
+export interface TokenBudgetContext {
+  tenantId: string;
+  provider: "groq" | "google" | "anthropic" | "openai";
+  estimatedTokens: number;  // pre-call estimate
+}
+
+export class LLMQuotaError extends Error {
+  constructor(public readonly scope: "tenant" | "global", public readonly limit: number) {
+    super(`llm quota exceeded: ${scope}`);
+    this.name = "LLMQuotaError";
+  }
+}
+
+export async function reserveTokens(ctx: TokenBudgetContext): Promise<TokenReservation>;
+export async function reconcileTokens(reservation: TokenReservation, actualTokens: number): Promise<void>;
+```
+
+**Keys (48h TTL):**
+- `llm:tok:tenant:<tid>:<YYYY-MM-DD>` — tenant's daily cumulative tokens
+- `llm:tok:global:<provider>:<YYYY-MM-DD>` — provider global cumulative tokens
+
+**Budgets (env-tunable):**
+- `LLM_TENANT_DAILY_TOKENS` default 30000
+- `LLM_GLOBAL_DAILY_TOKENS` (Groq) default 80000 (20% safety margin under 100k free-tier TPD)
+
+**Flow:**
+1. Estimate tokens (scan = 9000, chat turn = 3000, transcript = 5000 — all overridable).
+2. `INCRBY` tenant key by estimate; if result > budget → `DECRBY` rollback → throw `LLMQuotaError("tenant", limit)`.
+3. `INCRBY` global key; if over → rollback both keys → throw `LLMQuotaError("global", limit)`.
+4. Do the call. Track actual token usage from provider response.
+5. `INCRBY` by `(actual - estimated)`. Can be negative; Redis handles signed deltas.
+
+**Integration points:**
+- Wrap the single provider invocation point in `packages/ai/src/provider.ts` (need to confirm exact shape — likely a `generate()` or `chat()` helper). If provider invocations happen in multiple places, introduce a `runWithBudget()` helper and migrate call sites.
+- `apps/worker/src/larry-scan.ts`: the scan already has `SCAN_CONCURRENCY=1` for Groq safety; `reserveTokens` adds the budget layer on top. On `LLMQuotaError` the scan should log and skip (next cron tick retries).
+- `apps/api/src/routes/v1/larry.ts` chat/stream/transcript: on `LLMQuotaError` return 429 with a friendly message about daily quota.
+
+### Phase 4 — OAuth and Google gaps
+
+- `POST /v1/auth/google/link` + `POST /v1/auth/google/unlink`: add `config.rateLimit: { max: 10, timeWindow: '1 hour', keyGenerator: req => req.user.id }`.
+- OAuth state single-use:
+  - Before signing the state JWT, include a `jti` claim (UUID).
+  - In callback handlers (Google + Slack), after verifying the state JWT, do `SET NX oauth:state:<jti> 1 EX <ttl>`. If the SET fails (already present) → reject as replay with 400.
+- `GET /v1/auth/google/callback` + `GET /v1/connectors/slack/callback`: add `config.rateLimit: { max: 10, timeWindow: '1 minute', keyGenerator: req => req.ip }`.
+
+### Phase 5 — Web-layer cleanup
+
+`apps/web/src/lib/rate-limit.ts`:
+- Remove the in-memory fallback branch.
+- If `REDIS_URL` is unset → fail-closed (throw on check) OR export a no-op that the caller explicitly opts into. The API is the source of truth; the web layer is a UX nicety.
+- Decision: treat as UX nicety. If Redis is not configured, `checkRateLimit` returns `{ ok: true }` silently (the API will still 429). Document this in a comment.
+
+## Cross-cutting concerns
+
+### Fail-closed on Redis outage
+Redis is already a hard dep (BullMQ). If Redis is down, the API is already unable to queue scans. Fail-closed on rate limits is consistent with the existing posture.
+
+### Test bypass
+Reserved header `X-RateLimit-Bypass: <RATE_LIMIT_BYPASS_SECRET>` honored only when `NODE_ENV !== 'production'`. `@fastify/rate-limit` supports `skip` function — we pass one that checks this header. Secret comes from env; if unset, bypass is disabled entirely.
+
+### Feature flags
+Each phase guarded by an env boolean so we can flip off in Railway without redeploy:
+- `RATE_LIMIT_REDIS_ENABLED` (default true)
+- `EMAIL_QUOTA_ENABLED` (default true)
+- `LLM_BUDGET_ENABLED` (default true)
+- `OAUTH_STATE_SINGLE_USE_ENABLED` (default true)
+
+### Logging
+Every 429 or quota rejection logged at `warn` with `{kind, keyHash, limit, window}`. No raw PII (recipient emails are sha256'd before keying, same for log fields).
+
+### Rollback plan
+- Phase 1: flip `RATE_LIMIT_REDIS_ENABLED=false` → reverts to in-memory. Limits degraded but API still runs.
+- Phase 2: flip `EMAIL_QUOTA_ENABLED=false` → sends go through unchecked. Emergency-only.
+- Phase 3: flip `LLM_BUDGET_ENABLED=false` → LLM calls unchecked. Emergency-only.
+- Phase 4: flip `OAUTH_STATE_SINGLE_USE_ENABLED=false` → stateless validation only. Risk returns to baseline.
+
+### Testing
+- Each phase: unit tests with mocked Redis (ioredis-mock or manual mock), integration test against docker-compose Redis.
+- Vitest is the test runner (confirmed in `apps/api/package.json`).
+- Post-deploy: a smoke test script against the Railway URL verifying 429 fires on a dedicated throwaway route.
+
+### Deployment order
+1. Phase 1 first — foundation. Small, low-risk.
+2. Phase 2 next — defensive on emails.
+3. Phase 3 — cost protection (the expensive one, but the biggest risk reduction).
+4. Phase 4 — close gaps.
+5. Phase 5 — cleanup.
+
+Each phase is its own commit on `feat/rate-limiting-hardening`, pushed after tests pass, deploy verified on Railway before starting the next phase.
+
+## Edge cases addressed
+
+| Edge case                                   | Handling                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------- |
+| Multi-instance deploy                       | Redis store (Phase 1)                                               |
+| Client IP behind Railway proxy              | `trustProxy: true` (Phase 1)                                        |
+| NAT / shared IP unfair punishment           | Auth routes use userId keyGen; unauth routes use IP + log            |
+| Fixed-window burst at boundary              | `@fastify/rate-limit` uses sliding window internally                |
+| Race in INCR/check                          | INCR is atomic; rollback on overshoot                               |
+| Redis down                                  | Fail-closed; API already needs Redis for queue                      |
+| Test runs hitting limits                    | `X-RateLimit-Bypass` header with env secret, non-prod only          |
+| LLM actual tokens differ from estimate      | Post-call reconciliation with signed INCRBY delta                   |
+| Bounced email re-send amplification         | Suppression set checked first, never burns quota or Resend reputation |
+| Replayed OAuth state                        | SET NX on JTI (Phase 4)                                             |
+| Legitimate user retrying password reset     | 3/hour is generous enough; limits logged so we can tune             |
+| Internal alert floods (new device, etc.)    | Per-kind + per-user + per-tenant + global caps stack                 |
+| Email enumeration via forgot-password       | Already mitigated (generic 200 response); quota key is email-based  |
+| PII in logs                                 | Emails sha256'd before keying and logging                           |
+| Worker sending email                        | Confirmed: worker does not call Resend directly (no landmine)       |
+
+## Open questions
+
+None. All defaults chosen and documented above. Env vars allow runtime tuning without code changes.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./budget": {
+      "types": "./dist/budget.d.ts",
+      "default": "./dist/budget.js"
     }
   },
   "scripts": {

--- a/packages/ai/src/budget.ts
+++ b/packages/ai/src/budget.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-tenant and per-provider LLM token budgets.
+ *
+ * Pure logic — the consuming app supplies a BudgetStore bound to whatever
+ * Redis connection it already has. Keeps this package free of a Redis
+ * dependency while still letting apps/api and apps/worker share the same
+ * accounting rules (same keys, same TTLs, same reservation semantics).
+ *
+ * Flow (per LLM call):
+ *   1. reserveTokens() atomically INCRs estimated tokens against both a
+ *      per-tenant daily counter and a per-provider global daily counter.
+ *      Over either limit → DECR rollback → throw LLMQuotaError.
+ *   2. Caller runs the LLM request.
+ *   3. reconcileTokens() INCRs by (actual - estimated); delta may be
+ *      negative and Redis handles signed deltas.
+ *
+ * If a process crashes between (1) and (3) the estimate stays counted —
+ * errs on the safe side (slight over-accounting > quota overshoot).
+ */
+
+export interface BudgetStore {
+  /** Atomically increment the counter at `key` by `delta` (may be negative). Returns the new value. */
+  incrBy(key: string, delta: number): Promise<number>;
+  /** Set TTL on the key in whole seconds. Idempotent; safe to call every write. */
+  expire(key: string, seconds: number): Promise<void>;
+}
+
+export interface TokenBudgetConfig {
+  enabled: boolean;
+  tenantDailyTokens: number;
+  /** Global across all tenants, per provider (e.g. Groq free-tier 100k TPD). */
+  globalDailyTokens: number;
+}
+
+export interface ReserveParams {
+  tenantId: string;
+  provider: string;
+  estimatedTokens: number;
+}
+
+export interface TokenReservation {
+  tenantKey: string;
+  globalKey: string;
+  reservedTokens: number;
+  provider: string;
+  tenantId: string;
+  /** When false, reconcile is a no-op (budget was disabled at reserve time). */
+  active: boolean;
+}
+
+export class LLMQuotaError extends Error {
+  readonly scope: "tenant" | "global";
+  readonly limit: number;
+  constructor(scope: "tenant" | "global", limit: number) {
+    super(`llm quota exceeded: ${scope} (limit=${limit})`);
+    this.name = "LLMQuotaError";
+    this.scope = scope;
+    this.limit = limit;
+  }
+}
+
+const KEY_TTL_SEC = 48 * 60 * 60; // 48h — a single day key lives through the next day for audit.
+
+function dayKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export function tenantKey(tenantId: string, now: Date = new Date()): string {
+  return `llm:tok:tenant:${tenantId}:${dayKey(now)}`;
+}
+
+export function globalKey(provider: string, now: Date = new Date()): string {
+  return `llm:tok:global:${provider}:${dayKey(now)}`;
+}
+
+export async function reserveTokens(
+  store: BudgetStore,
+  config: TokenBudgetConfig,
+  params: ReserveParams,
+): Promise<TokenReservation> {
+  if (!config.enabled) {
+    return {
+      tenantKey: "",
+      globalKey: "",
+      reservedTokens: 0,
+      provider: params.provider,
+      tenantId: params.tenantId,
+      active: false,
+    };
+  }
+  if (params.estimatedTokens <= 0) {
+    throw new Error("reserveTokens: estimatedTokens must be positive");
+  }
+
+  const tKey = tenantKey(params.tenantId);
+  const gKey = globalKey(params.provider);
+
+  const tenantTotal = await store.incrBy(tKey, params.estimatedTokens);
+  await store.expire(tKey, KEY_TTL_SEC);
+  if (tenantTotal > config.tenantDailyTokens) {
+    // Roll back our increment. Don't touch global — we haven't incremented it yet.
+    await store.incrBy(tKey, -params.estimatedTokens);
+    throw new LLMQuotaError("tenant", config.tenantDailyTokens);
+  }
+
+  const globalTotal = await store.incrBy(gKey, params.estimatedTokens);
+  await store.expire(gKey, KEY_TTL_SEC);
+  if (globalTotal > config.globalDailyTokens) {
+    // Roll back BOTH keys.
+    await store.incrBy(tKey, -params.estimatedTokens);
+    await store.incrBy(gKey, -params.estimatedTokens);
+    throw new LLMQuotaError("global", config.globalDailyTokens);
+  }
+
+  return {
+    tenantKey: tKey,
+    globalKey: gKey,
+    reservedTokens: params.estimatedTokens,
+    provider: params.provider,
+    tenantId: params.tenantId,
+    active: true,
+  };
+}
+
+export async function reconcileTokens(
+  store: BudgetStore,
+  reservation: TokenReservation,
+  actualTokens: number,
+): Promise<void> {
+  if (!reservation.active) return;
+  const delta = Math.round(actualTokens) - reservation.reservedTokens;
+  if (delta === 0) return;
+  await store.incrBy(reservation.tenantKey, delta);
+  await store.incrBy(reservation.globalKey, delta);
+  // TTL was already set at reserve time — no need to re-expire.
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -79,6 +79,10 @@ const ApiSchema = SharedSchema.extend({
     .transform((v) => v !== "false"),
   LLM_TENANT_DAILY_TOKENS: z.coerce.number().int().positive().default(30_000),
   LLM_GLOBAL_DAILY_TOKENS: z.coerce.number().int().positive().default(80_000),
+  OAUTH_STATE_SINGLE_USE_ENABLED: z
+    .string()
+    .default("true")
+    .transform((v) => v !== "false"),
 });
 
 const WorkerSchema = SharedSchema.extend({

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -69,6 +69,10 @@ const ApiSchema = SharedSchema.extend({
     .default("true")
     .transform((v) => v !== "false"),
   RATE_LIMIT_BYPASS_SECRET: z.string().optional(),
+  EMAIL_QUOTA_ENABLED: z
+    .string()
+    .default("true")
+    .transform((v) => v !== "false"),
 });
 
 const WorkerSchema = SharedSchema.extend({

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -73,6 +73,12 @@ const ApiSchema = SharedSchema.extend({
     .string()
     .default("true")
     .transform((v) => v !== "false"),
+  LLM_BUDGET_ENABLED: z
+    .string()
+    .default("true")
+    .transform((v) => v !== "false"),
+  LLM_TENANT_DAILY_TOKENS: z.coerce.number().int().positive().default(30_000),
+  LLM_GLOBAL_DAILY_TOKENS: z.coerce.number().int().positive().default(80_000),
 });
 
 const WorkerSchema = SharedSchema.extend({
@@ -84,6 +90,12 @@ const WorkerSchema = SharedSchema.extend({
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   GOOGLE_CALENDAR_WEBHOOK_URL: z.string().url().optional(),
   JWT_ACCESS_SECRET: z.string().min(32).optional(),
+  LLM_BUDGET_ENABLED: z
+    .string()
+    .default("true")
+    .transform((v) => v !== "false"),
+  LLM_TENANT_DAILY_TOKENS: z.coerce.number().int().positive().default(30_000),
+  LLM_GLOBAL_DAILY_TOKENS: z.coerce.number().int().positive().default(80_000),
 });
 
 export type ApiEnv = z.infer<typeof ApiSchema>;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -62,6 +62,13 @@ const ApiSchema = SharedSchema.extend({
   RESEND_FROM_LARRY: z.string().default("Larry <larry@larry-pm.com>"),
   RESEND_WEBHOOK_SECRET: z.string().optional(),
   FRONTEND_URL: z.string().url().optional(),
+  // Rate-limiting hardening (2026-04-15). Flags default to enabled;
+  // flip to "false" in Railway to roll back a phase without redeploying.
+  RATE_LIMIT_REDIS_ENABLED: z
+    .string()
+    .default("true")
+    .transform((v) => v !== "false"),
+  RATE_LIMIT_BYPASS_SECRET: z.string().optional(),
 });
 
 const WorkerSchema = SharedSchema.extend({


### PR DESCRIPTION
## Summary

Closes the rate-limiting and abuse gaps identified in the 2026-04-15 audit after the repo was briefly public. Phased rollout, each phase flag-gated for emergency rollback without redeploy.

- **Phase 1** — Redis-backed \`@fastify/rate-limit\` + \`trustProxy: true\` (the silent bug: every IP limit was collapsing to Railway's proxy IP)
- **Phase 2** — email send caps (per-recipient / user / tenant / global) + auto-suppression populated from Resend bounce/complaint webhooks
- **Phase 3** — per-tenant + per-provider daily LLM token budget (Groq free-tier TPD protection); wired into worker scan + 3 chat paths
- **Phase 4** — Google \`/link\`+\`/unlink\` rate limits; single-use \`jti\` on OAuth state for Google + Slack callbacks (replay defence)
- **Phase 5** — web-layer rate-limit cleanup: removed in-memory fallback that gave false safety on Vercel serverless

Spec: \`docs/superpowers/specs/2026-04-15-rate-limiting-hardening-design.md\`
Plan: \`docs/superpowers/plans/2026-04-15-rate-limiting-hardening-plan.md\`

## Env flags (all default true — flip to \`false\` in Railway to roll back a phase)

- \`RATE_LIMIT_REDIS_ENABLED\` — Phase 1
- \`EMAIL_QUOTA_ENABLED\` — Phase 2 (suppression keeps working independently)
- \`LLM_BUDGET_ENABLED\` — Phase 3
- \`OAUTH_STATE_SINGLE_USE_ENABLED\` — Phase 4

Tunable: \`LLM_TENANT_DAILY_TOKENS\` (30000), \`LLM_GLOBAL_DAILY_TOKENS\` (80000 — 20% safety under Groq's 100k TPD). Non-prod test bypass via \`RATE_LIMIT_BYPASS_SECRET\` header.

## Test plan

- [x] Local: \`npm test\` — 403 tests pass across 54 files (+22 new)
- [x] Local: \`npm run build\` green in api, worker, web
- [ ] After Railway deploys: hammer \`/v1/auth/login\` 12x from same IP, expect 10x 401 then 429. If every attempt returns 401 with no 429, \`trustProxy\` is misbehaving — investigate before merge.
- [ ] In Resend dashboard: add webhook \`https://larry-site-production.up.railway.app/v1/webhooks/resend\` subscribed to \`email.bounced\` + \`email.complained\` (so the suppression set populates).
- [ ] Verify an oauth flow (Google login) still works end-to-end — state token now carries \`jti\` and is single-use.
- [ ] Check Railway logs after deploy for any \`[redis] connection error\` or \`unhandled 500\` spikes.

## Follow-ups (explicitly out of scope)

- LLM usage reconciliation (current \`runIntelligence\` + \`streamLarryChat\` paths don't surface token actuals — we over-reserve on the safe side for now).
- Migrate remaining lower-volume \`runIntelligence\` / \`generateObject\` call sites (briefing service, intelligence service) to the budget wrapper.
- Dashboard/alerting UI for quota events — today we rely on Railway logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)