### PR TITLE
fix(web): empty-state for missing project descriptions

### DIFF
--- a/apps/web/src/app/workspace/WorkspaceHome.tsx
+++ b/apps/web/src/app/workspace/WorkspaceHome.tsx
@@ -34,7 +34,7 @@ interface AuthMePayload {
 interface ProjectCardModel {
   id: string;
   name: string;
-  description: string;
+  description: string | null;
   status: string;
   riskLevel: string;
   targetDate: string | null | undefined;
@@ -129,9 +129,7 @@ function buildProjectCard(
   return {
     id: project.id,
     name: project.name,
-    description:
-      project.description?.trim() ||
-      (projectTasks.length > 0 ? "Live workspace with active delivery signals." : "Ready for the first task and meeting signal."),
+    description: project.description?.trim() || null,
     status: project.status,
     riskLevel: project.riskLevel ?? "low",
     targetDate: project.targetDate,
@@ -223,7 +221,7 @@ export function WorkspaceHome({ viewerEmail: _viewerEmail }: { viewerEmail?: str
     if (!searchQuery.trim()) return projectCards;
     const q = searchQuery.toLowerCase();
     return projectCards.filter(
-      (p) => p.name.toLowerCase().includes(q) || p.description.toLowerCase().includes(q),
+      (p) => p.name.toLowerCase().includes(q) || (p.description?.toLowerCase().includes(q) ?? false),
     );
   }, [projectCards, searchQuery]);
 
@@ -231,7 +229,7 @@ export function WorkspaceHome({ viewerEmail: _viewerEmail }: { viewerEmail?: str
     if (!searchQuery.trim()) return archivedCards;
     const q = searchQuery.toLowerCase();
     return archivedCards.filter(
-      (p) => p.name.toLowerCase().includes(q) || p.description.toLowerCase().includes(q),
+      (p) => p.name.toLowerCase().includes(q) || (p.description?.toLowerCase().includes(q) ?? false),
     );
   }, [archivedCards, searchQuery]);
 
@@ -533,8 +531,9 @@ export function WorkspaceHome({ viewerEmail: _viewerEmail }: { viewerEmail?: str
                 {/* Description — 1 line truncated */}
                 <p
                   className="text-body-sm mt-1 truncate"
+                  style={project.description ? undefined : { color: "var(--text-muted)", fontStyle: "italic" }}
                 >
-                  {project.description}
+                  {project.description ?? "No description"}
                 </p>
 
                 {/* Progress bar */}
@@ -620,7 +619,12 @@ export function WorkspaceHome({ viewerEmail: _viewerEmail }: { viewerEmail?: str
                         Archived
                       </span>
                     </div>
-                    <p className="text-body-sm mt-1 truncate">{project.description}</p>
+                    <p
+                      className="text-body-sm mt-1 truncate"
+                      style={project.description ? undefined : { color: "var(--text-muted)", fontStyle: "italic" }}
+                    >
+                      {project.description ?? "No description"}
+                    </p>
                     <div className="mt-3 flex items-center justify-between">
                       <span className="text-body-sm">
                         Updated {formatRelativeTime(project.updatedAt)}


### PR DESCRIPTION
## Summary

Projects with no description rendered faux-descriptions (\"Live workspace with active delivery signals.\" / \"Ready for the first task and meeting signal.\") which masked the real state of seed data and user-created projects.

- `ProjectCardModel.description` is now `string | null`.
- `buildProjectCard` returns `null` when the project has no trimmed description.
- Both card render sites (grid + archived) now show a muted italic \"No description\" when null.
- Search filters are null-safe.

No backfill — the fallback itself was the bug.

## Test plan

- [x] TypeScript clean on apps/web.
- [ ] Playwright on https://larry-pm.com/workspace after deploy: QA Test projects should render \"No description\" (muted italic), not the old placeholder.

Fixes #48