### PR TITLE
fix(web): proxy /api/auth/me to forward avatarUrl + verification fields

### DIFF
--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -1,5 +1,21 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
+import { proxyApiRequest, persistSession } from "@/lib/workspace-proxy";
+
+interface UpstreamUser {
+  id?: string;
+  email?: string | null;
+  tenantId?: string | null;
+  role?: string | null;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  emailVerifiedAt?: string | null;
+  verificationGraceDeadline?: string | null;
+}
+
+interface UpstreamMeResponse {
+  user?: UpstreamUser | null;
+}
 
 export async function GET() {
   const session = await getSession();
@@ -7,12 +23,60 @@ export async function GET() {
     return NextResponse.json({ user: null }, { status: 401 });
   }
 
+  const sessionOnlyUser = {
+    id: session.userId,
+    email: session.email ?? null,
+    tenantId: session.tenantId ?? null,
+    role: session.role ?? null,
+    displayName: session.displayName ?? null,
+    authMode: session.authMode ?? "unknown",
+    avatarUrl: null,
+    emailVerifiedAt: null,
+    verificationGraceDeadline: null,
+  };
+
+  // Dev / legacy sessions never have an upstream access token — skip the proxy
+  // and serve the session-only shape so dev logins still render user identity.
+  if (!session.apiAccessToken || !session.tenantId) {
+    return NextResponse.json({ user: sessionOnlyUser });
+  }
+
+  // Proxy through to upstream /v1/auth/me so the caller receives the full user
+  // shape (avatarUrl, emailVerifiedAt, verificationGraceDeadline, …) that the
+  // JWT-backed session cookie doesn't carry.
+  const { status, body, session: refreshed } = await proxyApiRequest(session, "/v1/auth/me");
+
+  if (refreshed && refreshed.apiAccessToken !== session.apiAccessToken) {
+    await persistSession(refreshed);
+  }
+
+  if (status === 401) {
+    return NextResponse.json({ user: null }, { status: 401 });
+  }
+
+  if (status < 200 || status >= 300) {
+    // Upstream unreachable or returned an error — fall back to session-only so
+    // the UI still renders initials and basic identity.
+    return NextResponse.json({ user: sessionOnlyUser });
+  }
+
+  const payload = (body ?? {}) as UpstreamMeResponse;
+  const upstreamUser = payload.user ?? null;
+
+  if (!upstreamUser) {
+    return NextResponse.json({ user: sessionOnlyUser });
+  }
+
   return NextResponse.json({
     user: {
-      id: session.userId,
-      email: session.email ?? null,
-      tenantId: session.tenantId ?? null,
-      role: session.role ?? null,
+      id: upstreamUser.id ?? session.userId,
+      email: upstreamUser.email ?? session.email ?? null,
+      tenantId: upstreamUser.tenantId ?? session.tenantId ?? null,
+      role: upstreamUser.role ?? session.role ?? null,
+      displayName: upstreamUser.displayName ?? session.displayName ?? null,
+      avatarUrl: upstreamUser.avatarUrl ?? null,
+      emailVerifiedAt: upstreamUser.emailVerifiedAt ?? null,
+      verificationGraceDeadline: upstreamUser.verificationGraceDeadline ?? null,
       authMode: session.authMode ?? "unknown",
     },
   });


### PR DESCRIPTION
## Summary

`/api/auth/me` was returning a session-only shape (`{id, email, tenantId, role, authMode}`) and dropping avatarUrl, emailVerifiedAt, displayName, and verificationGraceDeadline — even though Railway /v1/auth/me already returns them.

This PR proxies the call through to upstream using \`proxyApiRequest\` (which handles token refresh + 401 retry). When the session has no upstream access token (dev / legacy auth modes) or upstream is unreachable, we fall back to the session-only shape so the UI still renders basic identity.

## Test plan

- [x] TypeScript clean on apps/web.
- [ ] After deploy: \`curl https://larry-pm.com/api/auth/me\` with a valid session cookie returns \`avatarUrl\` in the user payload.
- [ ] Playwright MCP: log in → verify avatar / verification fields render where expected.

Fixes #47