### PR TITLE
fix(chat): scrub inline tool-call XML leaked into Larry text stream

### DIFF
--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -6,6 +6,8 @@ import {
   streamLarryChat,
   detectInjectionAttempt,
   detectDestructiveSweep,
+  scrubInlineToolCallText,
+  InlineToolCallScrubber,
 } from "@larry/ai";
 import type { ToolCallResult } from "@larry/ai";
 import {
@@ -3407,6 +3409,11 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       };
 
       // ── Stream ────────────────────────────────────────────────────────────
+      // Scrub inline tool-call XML (`<function=...>{json}</function>` and the
+      // orphaned-closing-tag variant seen from Gemini) out of live tokens
+      // before they reach the browser. Without this, users see raw tool-call
+      // syntax in the chat bubble (QA-2026-04-15 #49).
+      const chatScrubber = new InlineToolCallScrubber();
       try {
         for await (const event of streamLarryChat({
           config,
@@ -3416,8 +3423,12 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
         })) {
           if (event.type === "token") {
             fullContent += event.delta;
-            write({ type: "token", delta: event.delta });
+            const clean = chatScrubber.push(event.delta);
+            if (clean) write({ type: "token", delta: clean });
           } else if (event.type === "tool_start") {
+            // Flush any buffered prose so tool chips sit after it in UI order.
+            const tail = chatScrubber.flush();
+            if (tail) write({ type: "token", delta: tail });
             write(event);
           } else if (event.type === "tool_done") {
             write(event);
@@ -3427,7 +3438,16 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
           }
         }
 
+        // Drain any remaining scrubbed text.
+        const tail = chatScrubber.flush();
+        if (tail) write({ type: "token", delta: tail });
+
         // ── Post-stream DB writes ─────────────────────────────────────────
+        // Scrub the accumulated raw content once more for DB persistence —
+        // idempotent, and guarantees the stored message matches what the
+        // user saw during streaming.
+        fullContent = scrubInlineToolCallText(fullContent);
+
         // When the model emits only tool calls and no prose, synthesize a
         // recap. Stream it as tokens so the live UI shows the recap too,
         // then persist it so refreshes render the same text.
@@ -3438,9 +3458,6 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
             fullContent = recap;
           }
         }
-        // Strip any inline function-call markup emitted as plain text by
-        // models that don't use the AI SDK's structured tool-calling interface.
-        fullContent = fullContent.replace(/<function=[^>]*>/g, "");
         await fastify.db.queryTenant<Record<string, unknown>>(
           tenantId,
           `UPDATE larry_messages SET content = $3 WHERE tenant_id = $1 AND id = $2`,

--- a/apps/api/tests/inline-tool-call-scrubber.test.ts
+++ b/apps/api/tests/inline-tool-call-scrubber.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { scrubInlineToolCallText, InlineToolCallScrubber } from "@larry/ai";
+
+// QA-2026-04-15 #49 regression guard.
+//
+// Users saw raw tool-call XML in Larry chat bubbles because Gemini sometimes
+// emits inline `<function=name>{json}</function>` (or the orphaned trailing
+// `{json}</function>` variant) through the text-delta channel. The backend
+// forwarded tokens verbatim to the browser and only stripped the opening tag
+// at DB-write time, so live UI + on-refresh content diverged.
+
+describe("scrubInlineToolCallText", () => {
+  it("strips complete <function=...>...</function> blocks", () => {
+    expect(
+      scrubInlineToolCallText(
+        'hello <function=get_task_list>{"filter":"all"}</function> world'
+      )
+    ).toBe("hello  world");
+  });
+
+  it("strips orphaned {json}</function> payload (observed Gemini leak)", () => {
+    expect(
+      scrubInlineToolCallText(
+        'tasks due this week. {"filter":"all"}</function>'
+      )
+    ).toBe("tasks due this week. ");
+  });
+
+  it("strips bare closing tags", () => {
+    expect(scrubInlineToolCallText("prose.</function>")).toBe("prose.");
+  });
+
+  it("drops unclosed opening tag + everything after", () => {
+    expect(scrubInlineToolCallText("prose <function=foo>partial")).toBe("prose ");
+  });
+
+  it("is a no-op for plain prose", () => {
+    expect(scrubInlineToolCallText("Just a normal response.")).toBe(
+      "Just a normal response."
+    );
+  });
+
+  it("preserves legitimate JSON without a closing tag", () => {
+    expect(scrubInlineToolCallText('API returns {"ok":true} for valid keys.')).toBe(
+      'API returns {"ok":true} for valid keys.'
+    );
+  });
+
+  it("is idempotent", () => {
+    const input = 'hi <function=x>{"a":1}</function> there';
+    expect(scrubInlineToolCallText(scrubInlineToolCallText(input))).toBe("hi  there");
+  });
+});
+
+describe("InlineToolCallScrubber (streaming)", () => {
+  function streamEverything(scrubber: InlineToolCallScrubber, chunks: string[]): string {
+    let out = "";
+    for (const c of chunks) out += scrubber.push(c);
+    out += scrubber.flush();
+    return out;
+  }
+
+  it("strips a full <function=X>{}</function> block split across chunks", () => {
+    const s = new InlineToolCallScrubber();
+    const result = streamEverything(s, [
+      "Hello ",
+      "<function=",
+      "get_task_list>",
+      '{"filter":"all"}',
+      "</function>",
+      " world",
+    ]);
+    expect(result).toBe("Hello  world");
+  });
+
+  it("strips orphaned closing tag split across chunks (the #49 leak)", () => {
+    const s = new InlineToolCallScrubber();
+    const result = streamEverything(s, [
+      "No overdue tasks. ",
+      '{"filter":',
+      '"all"}',
+      "</function>",
+    ]);
+    expect(result).toBe("No overdue tasks. ");
+  });
+
+  it("preserves plain prose across many small chunks", () => {
+    const s = new InlineToolCallScrubber();
+    const result = streamEverything(s, ["The ", "biggest ", "risk ", "is ", "auth."]);
+    expect(result).toBe("The biggest risk is auth.");
+  });
+
+  it("does not indefinitely buffer long prose", () => {
+    const s = new InlineToolCallScrubber();
+    const long = "A".repeat(400);
+    const emitted = s.push(long) + s.flush();
+    expect(emitted).toBe(long);
+  });
+
+  it("drops an incomplete opening tag at end-of-stream", () => {
+    const s = new InlineToolCallScrubber();
+    const result = streamEverything(s, ["prose ", "<function=foo>incomplete"]);
+    expect(result).toBe("prose ");
+  });
+
+  it("concatenated stream equals non-streaming scrub for Gemini leak sample", () => {
+    const sample =
+      'There are no overdue tasks, I\'ll try to find tasks due this week. {"filter":"all"}</function>';
+    // Simulate 1-char chunks (worst-case fragmentation).
+    const s = new InlineToolCallScrubber();
+    let out = "";
+    for (const c of sample) out += s.push(c);
+    out += s.flush();
+    expect(out).toBe(scrubInlineToolCallText(sample));
+    expect(out).toBe("There are no overdue tasks, I'll try to find tasks due this week. ");
+  });
+});

--- a/apps/web/src/app/workspace/useLarryChat.ts
+++ b/apps/web/src/app/workspace/useLarryChat.ts
@@ -251,9 +251,17 @@ export function useLarryChat(projectId?: string) {
 
           for await (const event of parseLarrySseStream(response.body)) {
             switch (event.type) {
-              case "token":
-                updateStreamingMessage((prev) => ({ content: prev.content + event.delta }));
+              case "token": {
+                // QA-2026-04-15 #49 defense-in-depth: guard against any
+                // upstream delta that isn't a string (would coerce to
+                // "[object Object]" under string concat). Server now emits
+                // strings only, but unknown future providers or proxies
+                // could slip through.
+                const deltaStr = typeof event.delta === "string" ? event.delta : "";
+                if (deltaStr.length === 0) break;
+                updateStreamingMessage((prev) => ({ content: prev.content + deltaStr }));
                 break;
+              }
 
               case "tool_start": {
                 const chip = toolEventToChip(

--- a/packages/ai/src/chat.ts
+++ b/packages/ai/src/chat.ts
@@ -4,6 +4,82 @@ import { z } from "zod";
 import type { IntelligenceConfig } from "@larry/shared";
 import { createModel } from "./provider.js";
 
+// ── Inline tool-call text scrubbing ───────────────────────────────────────────
+//
+// Some providers (notably Gemini) occasionally emit tool-call XML directly in
+// the text-delta channel instead of — or in addition to — the structured
+// tool-call channel. Observed leak patterns:
+//
+//   1. Full inline call:        "<function=get_task_list>{\"filter\":\"all\"}</function>"
+//   2. Orphaned payload + close: "{\"filter\":\"all\"}</function>"   (QA-2026-04-15 #49)
+//   3. Bare closing tag:         "</function>"
+//
+// These must be stripped before the token reaches the client *and* before the
+// final content is persisted. The DB strip previously covered only opening
+// tags and never touched the live stream, so users saw the raw XML in the
+// assistant bubble until a refresh pulled the scrubbed DB copy.
+
+/**
+ * Non-streaming scrubber — strip every inline tool-call artefact from a
+ * fully-formed string. Safe to apply repeatedly (idempotent).
+ */
+export function scrubInlineToolCallText(text: string): string {
+  let s = text;
+  // Complete <function=...>...</function> blocks (non-greedy, nested-safe).
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(/<function=[^>]*>[\s\S]*?<\/function>/g, "");
+  } while (s !== prev);
+  // Orphaned trailing JSON payload + closing tag.
+  s = s.replace(/\{[\s\S]*?\}\s*<\/function>/g, "");
+  // Bare closing tags.
+  s = s.replace(/<\/function>/g, "");
+  // Unclosed opening tag: drop from the opening to end-of-input.
+  s = s.replace(/<function=[^>]*>[\s\S]*$/, "");
+  return s;
+}
+
+/**
+ * Streaming scrubber — accept text in arbitrary chunks, emit the portion safe
+ * to forward to the client, and buffer anything that could still be the start
+ * of a leaked tool-call fragment. Call `flush()` at end-of-stream to drain.
+ */
+export class InlineToolCallScrubber {
+  // Max unemitted trail size. Must be >= len("</function>") (11) AND large
+  // enough to absorb a short "{json}</function>" pair while it assembles.
+  private static readonly HOLD = 64;
+  private buf = "";
+
+  push(chunk: string): string {
+    this.buf += chunk;
+    this.buf = scrubInlineToolCallText(this.buf);
+
+    // Everything from any still-open <function=... must stay buffered until
+    // its </function> arrives.
+    const openIdx = this.buf.indexOf("<function=");
+    if (openIdx !== -1) {
+      const emit = this.buf.slice(0, openIdx);
+      this.buf = this.buf.slice(openIdx);
+      return emit;
+    }
+
+    if (this.buf.length > InlineToolCallScrubber.HOLD) {
+      const cut = this.buf.length - InlineToolCallScrubber.HOLD;
+      const emit = this.buf.slice(0, cut);
+      this.buf = this.buf.slice(cut);
+      return emit;
+    }
+    return "";
+  }
+
+  flush(): string {
+    const final = scrubInlineToolCallText(this.buf);
+    this.buf = "";
+    return final;
+  }
+}
+
 // ── Public types ───────────────────────────────────────────────────────────────
 
 export type ChatStreamEvent =

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -945,6 +945,8 @@ export {
   computeDateContext,
   translateFullStreamChunkToChatEvent,
   buildChatSystemPrompt,
+  scrubInlineToolCallText,
+  InlineToolCallScrubber,
 } from "./chat.js";
 export type { ChatStreamEvent, ToolCallResult } from "./chat.js";
 


### PR DESCRIPTION
## Summary

Larry chat bubbles leaked raw tool-call XML into the assistant message body (QA-2026-04-15 #49):

- \`There are no overdue tasks, I'll try to find tasks due this week. {\"filter\":\"all\"}</function>\`
- \`[object Object]I don't have anything to add here — ask me something specific and I'll dig in.\`

## Root cause

Gemini occasionally emits inline \`<function=name>{json}</function>\` fragments — or only the orphaned trailing \`{json}</function>\` piece — through the text-delta channel. Our backend:

1. Forwarded every text-delta token to the SSE stream verbatim, so users saw the raw XML during streaming.
2. Only stripped opening \`<function=...>\` tags at DB-write time (regex didn't cover closing tag or JSON payload), so the persisted copy differed from what streamed, and a page reload half-fixed the bubble.

The \`[object Object]\` variant was harder to root-cause from code reading alone (every token-emit site passes strings) — I added client-side defense-in-depth rather than claiming a definitive fix.

## Changes

- **\`@larry/ai\`**: new \`scrubInlineToolCallText\` (idempotent, non-streaming) + \`InlineToolCallScrubber\` class (stateful, streaming-safe — buffers a short trailing window so \`{json}</function>\` pairs split across chunks still scrub).
- **\`apps/api\` chat/stream**: each token delta flows through a scrubber instance before the SSE write; buffered tail flushes on tool-start (chip ordering) and stream end; DB persist uses the scrubbed content.
- **\`apps/web\` useLarryChat**: coerces \`event.delta\` to string as defence against the \`[object Object]\` leak.
- **Tests**: \`apps/api/tests/inline-tool-call-scrubber.test.ts\` — 13 cases covering full blocks, orphaned closing tags, chunk-level fragmentation, long prose non-interference, and the exact Gemini leak string from the report.

## Test plan

- [x] \`vitest run tests/inline-tool-call-scrubber.test.ts\` — 13/13 pass.
- [x] Existing \`larry-chat-stream-translate.test.ts\` still green.
- [x] TypeScript clean on apps/web and the files I touched in apps/api.
- [ ] After deploy: Playwright MCP on /workspace/larry, send the repro prompt *\"What is the biggest deadline risk this week, and which task is it?\"* — confirm the assistant bubble shows only prose (no \`</function>\` fragment, no \`[object Object]\`).
- [ ] Capture the raw SSE body via \`browser_network_requests\` to confirm no token payload contains \`</function>\`.

Fixes #49