### PR TITLE
fix(chat): don't concat recap fallback onto stream error text

### DIFF
--- a/apps/api/src/lib/larry-ledger.ts
+++ b/apps/api/src/lib/larry-ledger.ts
@@ -26,6 +26,7 @@ export interface LarryEventMutationRecord {
   eventType: LarryEventType;
   actionType: string;
   displayText: string;
+  reasoning: string;
   payload: Record<string, unknown>;
 }
 
@@ -459,6 +460,7 @@ export async function getLarryEventForMutation(
             event_type AS "eventType",
             action_type AS "actionType",
             display_text AS "displayText",
+            reasoning,
             payload
        FROM larry_events
       WHERE tenant_id = $1

--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -9,6 +9,9 @@ import {
 } from "@larry/ai";
 import type { ToolCallResult } from "@larry/ai";
 import {
+  applyPatch,
+  assertPatchIsAllowed,
+  editableFieldsForActionType,
   getCanonicalEventRuntimeEntryById,
   getCanonicalEventRuntimeSummary,
   listCanonicalEventRetryCandidates,
@@ -1904,6 +1907,10 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
     }
   );
 
+  // POST /events/:id/modify — returns an editable snapshot of a pending suggestion.
+  // Per spec 2026-04-15-modify-action-design.md: no DB write, no dismissal. The
+  // frontend opens the Modify panel with this snapshot, lets the user edit fields
+  // or chat via /modify-chat, and commits via /modify/save.
   fastify.post(
     "/events/:id/modify",
     { preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm"])] },
@@ -1931,100 +1938,38 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
         throw fastify.httpErrors.conflict("Only suggested events can be modified.");
       }
 
-      // Fetch full event details for the chat context message
-      const [fullEvent] = await fastify.db.queryTenant<{
-        conversationId: string | null;
-        displayText: string | null;
-        reasoning: string | null;
-      }>(
-        tenantId,
-        `SELECT conversation_id AS "conversationId",
-                display_text   AS "displayText",
-                reasoning
-           FROM larry_events
-          WHERE tenant_id = $1 AND id = $2
-          LIMIT 1`,
-        [tenantId, id]
-      );
-
-      let conversationId = fullEvent?.conversationId ?? null;
-
-      if (!conversationId) {
-        const conversation = await createLarryConversation(
-          fastify.db,
-          tenantId,
-          actorUserId,
-          { projectId: event.projectId, title: `Modify: ${(fullEvent?.displayText ?? "Larry action").slice(0, 120)}` }
+      const editableFields = editableFieldsForActionType(event.actionType);
+      if (editableFields.length === 0) {
+        throw fastify.httpErrors.unprocessableEntity(
+          `Action type '${event.actionType}' is not modifiable.`
         );
-        conversationId = conversation.id;
       }
 
-      // QA-2026-04-12 M-1: previously this handler wrote a raw internal
-      // template ("The user wants to modify this action: ... Original
-      // reasoning: ... Action type: task_create.") straight to the user's
-      // chat history. That string rendered as Larry's first visible bubble
-      // and looked like a leaked system prompt.
-      //
-      // The user-facing opener below is plain prose Larry would say; the
-      // action being modified is already communicated by the launch URL
-      // (launch=modify&sourceKind=...&eventType=suggested) and is visible
-      // in the chat header above this conversation.
-      const openerDisplay = (fullEvent?.displayText ?? "this action").slice(0, 160);
-
-      // QA-2026-04-12 M-3: surface the original payload values so Larry's
-      // own conversation history carries them. When the user then asks for
-      // a change ("push to 30 Apr, reassign to Anna"), the LLM can echo
-      // the diff in its "I queued ... with updates" confirmation instead
-      // of being generic. The fields below cover task_create — the most
-      // common modify target — and degrade gracefully for other action
-      // types (the "Currently:" line is omitted when no fields resolve).
-      const payload = (event.payload ?? {}) as Record<string, unknown>;
-      const readString = (key: string): string | null => {
-        const value = payload[key];
-        return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-      };
-      const currentParts: string[] = [];
-      const assignee = readString("assigneeName") ?? readString("newOwnerName");
-      const dueDate = readString("dueDate") ?? readString("newDeadline");
-      const priority = readString("priority");
-      const riskLevel = readString("riskLevel");
-      const newStatus = readString("newStatus");
-      if (assignee) currentParts.push(`assigned to ${assignee}`);
-      if (dueDate) currentParts.push(`due ${dueDate}`);
-      if (priority) currentParts.push(`priority ${priority}`);
-      if (riskLevel) currentParts.push(`risk ${riskLevel}`);
-      if (newStatus) currentParts.push(`status ${newStatus}`);
-      const currentLine = currentParts.length > 0 ? ` Currently: ${currentParts.join(", ")}.` : "";
-
-      const openerMessage =
-        `Let's refine "${openerDisplay}".${currentLine} Tell me what to change — assignee, ` +
-        `deadline, priority, wording — and I'll queue an updated version in the Action Centre, ` +
-        `noting which fields changed.`;
-
-      await insertLarryMessage(fastify.db, tenantId, conversationId, {
-        role: "larry",
-        content: openerMessage,
-      });
-
-      await touchLarryConversation(fastify.db, tenantId, conversationId);
-
-      // QA-2026-04-12 M-4: dismiss the source suggestion immediately. The
-      // user has chosen to rework it — keeping it pending means Action
-      // Centre shows both the original and the later "with updates" card,
-      // and accepting both duplicates the task.
-      //
-      // If the user abandons the modify chat without sending a message,
-      // this still reflects intent: they clicked Modify, which is a
-      // "don't accept as-is" signal. Safer than leaving a stale pending.
-      await markLarryEventDismissed(
-        fastify.db,
+      const teamMembers = await fastify.db.queryTenant<{
+        userId: string;
+        displayName: string;
+        email: string;
+      }>(
         tenantId,
-        id,
-        actorUserId,
-        "modify-superseded"
+        `SELECT u.id AS "userId",
+                COALESCE(u.display_name, u.email) AS "displayName",
+                u.email
+           FROM users u
+           JOIN project_members pm ON pm.user_id = u.id
+          WHERE pm.tenant_id = $1 AND pm.project_id = $2
+          ORDER BY "displayName" ASC`,
+        [tenantId, event.projectId]
       );
 
-      return reply.code(200).send({ conversationId, eventId: id });
+      return reply.code(200).send({
+        eventId: id,
+        actionType: event.actionType,
+        displayText: event.displayText,
+        reasoning: event.reasoning,
+        payload: event.payload ?? {},
+        editableFields,
+        teamMembers,
+      });
     }
   );
 

--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -3407,6 +3407,12 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       };
 
       // ── Stream ────────────────────────────────────────────────────────────
+      // Track whether the SDK emitted an error event mid-stream. When it does
+      // the client sets the bubble to event.message, and a subsequent recap
+      // token would get concatenated onto the error text with no separator
+      // (e.g. ".../billingI don't have anything to add here..."). Suppress
+      // the recap entirely in that case — the error message is the response.
+      let hadStreamError = false;
       try {
         for await (const event of streamLarryChat({
           config,
@@ -3422,6 +3428,7 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
           } else if (event.type === "tool_done") {
             write(event);
           } else if (event.type === "error") {
+            hadStreamError = true;
             write(event);
             // Don't abort — let the stream finish naturally
           }
@@ -3430,8 +3437,9 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
         // ── Post-stream DB writes ─────────────────────────────────────────
         // When the model emits only tool calls and no prose, synthesize a
         // recap. Stream it as tokens so the live UI shows the recap too,
-        // then persist it so refreshes render the same text.
-        if (fullContent.trim().length === 0) {
+        // then persist it so refreshes render the same text. Skipped on
+        // stream errors so it doesn't concatenate onto the error text.
+        if (!hadStreamError && fullContent.trim().length === 0) {
           const recap = buildToolRecap(toolOutcomes);
           if (recap.length > 0) {
             write({ type: "token", delta: recap });

--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -1973,6 +1973,224 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
     }
   );
 
+  // POST /events/:id/modify/save — applies an edit patch to a pending suggestion
+  // and (optionally) executes it atomically. Spec: 2026-04-15-modify-action-design.md.
+  const ModifySaveBodySchema = z.object({
+    payloadPatch: z.record(z.string(), z.unknown()),
+    executeImmediately: z.boolean(),
+    conversationId: z.string().uuid().optional(),
+  });
+
+  fastify.post(
+    "/events/:id/modify/save",
+    { preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm"])] },
+    async (request, reply) => {
+      const tenantId = request.user.tenantId;
+      const actorUserId = request.user.userId;
+      const { id } = request.params as { id: string };
+      if (!isUuidShape(id)) {
+        throw fastify.httpErrors.badRequest("Invalid event id.");
+      }
+
+      const parsed = ModifySaveBodySchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        throw fastify.httpErrors.badRequest(
+          parsed.error.issues[0]?.message ?? "Invalid body."
+        );
+      }
+      const { payloadPatch, executeImmediately } = parsed.data;
+
+      // Re-fetch under the suggested guard — race-safe against concurrent accept.
+      const event = await getLarryEventForMutation(fastify.db, tenantId, id);
+      if (!event) {
+        throw fastify.httpErrors.notFound("Event not found.");
+      }
+      await assertProjectAccessOrThrow({
+        tenantId,
+        userId: actorUserId,
+        tenantRole: request.user.role,
+        projectId: event.projectId,
+        mode: "manage",
+        requireWritable: true,
+      });
+      if (event.eventType !== "suggested") {
+        throw fastify.httpErrors.conflict(
+          "This suggestion was already resolved elsewhere."
+        );
+      }
+
+      try {
+        assertPatchIsAllowed(event.actionType, payloadPatch);
+      } catch (err) {
+        throw fastify.httpErrors.unprocessableEntity(
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+
+      const nextPayload = applyPatch(
+        (event.payload ?? {}) as Record<string, unknown>,
+        payloadPatch
+      );
+
+      // Persist the edit first. If the user is only saving (not executing), we're done.
+      // If they're also executing, we run the executor; on executor failure we intentionally
+      // leave the edited payload in place so the user can retry Accept without re-editing.
+      const updatedRows = await fastify.db.queryTenant<{ id: string }>(
+        tenantId,
+        `UPDATE larry_events
+            SET previous_payload    = COALESCE(previous_payload, payload),
+                payload             = $3::jsonb,
+                modified_by_user_id = $4,
+                modified_at         = NOW()
+          WHERE tenant_id = $1
+            AND id        = $2
+            AND event_type = 'suggested'
+        RETURNING id`,
+        [tenantId, id, JSON.stringify(nextPayload), actorUserId]
+      );
+      if (updatedRows.length === 0) {
+        // Lost the race — another tab resolved the event between our fetch and UPDATE.
+        throw fastify.httpErrors.conflict(
+          "This suggestion was already resolved elsewhere."
+        );
+      }
+
+      await writeAuditLog(fastify.db, {
+        tenantId,
+        actorUserId,
+        actionType: "larry.event.modified",
+        objectType: "larry_event",
+        objectId: id,
+        details: {
+          actionType: event.actionType,
+          changedKeys: Object.keys(payloadPatch),
+        },
+      });
+
+      if (!executeImmediately) {
+        const [persisted] = await listLarryEventSummaries(fastify.db, tenantId, { ids: [id] });
+        return reply.code(200).send({ event: persisted ?? null, executed: false, entity: null });
+      }
+
+      // Execute the edited action. Retry-with-resolution mirrors the /accept handler
+      // for the common hallucinated/stale taskId case; calendar and slack actions
+      // are not modifiable per the spec, so this simpler path is sufficient.
+      const executePayload = { ...nextPayload, displayText: event.displayText };
+      let entity: unknown;
+      try {
+        entity = await executeAction(
+          fastify.db,
+          tenantId,
+          event.projectId,
+          event.actionType as LarryActionType,
+          executePayload,
+          actorUserId
+        );
+      } catch (firstError) {
+        const firstMsg = firstError instanceof Error ? firstError.message : String(firstError);
+        const canRetry =
+          firstMsg.includes("taskId could not be resolved") ||
+          firstMsg.includes("not found for tenant") ||
+          (firstMsg.includes("user") && firstMsg.includes("not found in tenant"));
+
+        if (canRetry) {
+          try {
+            const retryPayload: Record<string, unknown> = { ...executePayload };
+            if (firstMsg.includes("taskId")) delete retryPayload.taskId;
+            entity = await executeAction(
+              fastify.db,
+              tenantId,
+              event.projectId,
+              event.actionType as LarryActionType,
+              retryPayload,
+              actorUserId
+            );
+            request.log.info(
+              { tenantId, eventId: id, originalError: firstMsg },
+              "Modify/save succeeded on retry after payload repair"
+            );
+          } catch (retryError) {
+            const retryMsg = retryError instanceof Error ? retryError.message : String(retryError);
+            throw fastify.httpErrors.unprocessableEntity(retryMsg);
+          }
+        } else {
+          throw fastify.httpErrors.unprocessableEntity(firstMsg);
+        }
+      }
+
+      await markLarryEventAccepted(fastify.db, tenantId, id, actorUserId);
+
+      await fastify.db.queryTenant(
+        tenantId,
+        `INSERT INTO correction_feedback
+           (tenant_id, action_id, corrected_by_user_id, correction_type, correction_payload)
+         VALUES
+           ($1, $2, $3, 'modified_and_accepted', $4::jsonb)`,
+        [
+          tenantId,
+          id,
+          actorUserId,
+          JSON.stringify({
+            actionType: event.actionType,
+            changedKeys: Object.keys(payloadPatch),
+          }),
+        ]
+      );
+
+      await writeAuditLog(fastify.db, {
+        tenantId,
+        actorUserId,
+        actionType: "larry.event.accepted",
+        objectType: "larry_event",
+        objectId: id,
+        details: { actionType: event.actionType, viaModify: true },
+      });
+
+      const [persisted] = await listLarryEventSummaries(fastify.db, tenantId, { ids: [id] });
+      return reply.code(200).send({ event: persisted ?? null, executed: true, entity });
+    }
+  );
+
+  // POST /events/:id/modify/stop — user cancelled a modify panel without saving.
+  // Writes an audit-log breadcrumb so we can measure abandonment; the event itself
+  // remains in its current state (unchanged pending suggestion).
+  fastify.post(
+    "/events/:id/modify/stop",
+    { preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm"])] },
+    async (request, reply) => {
+      const tenantId = request.user.tenantId;
+      const actorUserId = request.user.userId;
+      const { id } = request.params as { id: string };
+      if (!isUuidShape(id)) {
+        throw fastify.httpErrors.badRequest("Invalid event id.");
+      }
+
+      const event = await getLarryEventForMutation(fastify.db, tenantId, id);
+      if (!event) {
+        throw fastify.httpErrors.notFound("Event not found.");
+      }
+      await assertProjectAccessOrThrow({
+        tenantId,
+        userId: actorUserId,
+        tenantRole: request.user.role,
+        projectId: event.projectId,
+        mode: "manage",
+        requireWritable: true,
+      });
+
+      await writeAuditLog(fastify.db, {
+        tenantId,
+        actorUserId,
+        actionType: "larry.event.modify_cancelled",
+        objectType: "larry_event",
+        objectId: id,
+        details: { actionType: event.actionType },
+      });
+
+      return reply.code(200).send({ ok: true });
+    }
+  );
+
   fastify.post(
     "/events/:id/let-larry-execute",
     { preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm"])] },

--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -4,9 +4,11 @@ import { z } from "zod";
 import {
   runIntelligence,
   streamLarryChat,
+  streamModifyChat,
   detectInjectionAttempt,
   detectDestructiveSweep,
 } from "@larry/ai";
+import type { ModifyChatStreamEvent } from "@larry/ai";
 import type { ToolCallResult } from "@larry/ai";
 import {
   applyPatch,
@@ -2188,6 +2190,186 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       });
 
       return reply.code(200).send({ ok: true });
+    }
+  );
+
+  // POST /events/:id/modify-chat — dedicated chat endpoint for the Modify panel.
+  // Runs streamModifyChat (single tool: apply_modification) and returns a
+  // payloadPatch the frontend can merge into its working draft without
+  // touching the database. Spec: 2026-04-15-modify-action-design.md.
+  const ModifyChatBodySchema = z.object({
+    message: z.string().trim().min(1).max(4_000),
+    currentPayload: z.record(z.string(), z.unknown()),
+    conversationId: z.string().uuid().optional(),
+  });
+
+  fastify.post(
+    "/events/:id/modify-chat",
+    {
+      config: {
+        rateLimit: {
+          max: 20,
+          timeWindow: "1 minute",
+          keyGenerator: (req: FastifyRequest) =>
+            (req.user as { tenantId?: string } | undefined)?.tenantId ?? req.ip,
+        },
+      },
+      preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm"])],
+    },
+    async (request, reply) => {
+      const tenantId = request.user.tenantId;
+      const actorUserId = request.user.userId;
+      const { id } = request.params as { id: string };
+      if (!isUuidShape(id)) {
+        throw fastify.httpErrors.badRequest("Invalid event id.");
+      }
+
+      const parsed = ModifyChatBodySchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        throw fastify.httpErrors.badRequest(
+          parsed.error.issues[0]?.message ?? "Invalid body."
+        );
+      }
+      const { message, currentPayload, conversationId: providedConvId } = parsed.data;
+
+      const event = await getLarryEventForMutation(fastify.db, tenantId, id);
+      if (!event) {
+        throw fastify.httpErrors.notFound("Event not found.");
+      }
+      await assertProjectAccessOrThrow({
+        tenantId,
+        userId: actorUserId,
+        tenantRole: request.user.role,
+        projectId: event.projectId,
+        mode: "manage",
+        requireWritable: true,
+      });
+      if (event.eventType !== "suggested") {
+        throw fastify.httpErrors.conflict(
+          "This suggestion was already resolved elsewhere."
+        );
+      }
+
+      const editableFields = editableFieldsForActionType(event.actionType);
+      if (editableFields.length === 0) {
+        throw fastify.httpErrors.unprocessableEntity(
+          `Action type '${event.actionType}' is not modifiable.`
+        );
+      }
+
+      // Resolve or create the conversation for this modify session.
+      let conversationId = providedConvId ?? null;
+      if (conversationId) {
+        const existing = await getLarryConversationForUser(
+          fastify.db,
+          tenantId,
+          actorUserId,
+          conversationId
+        );
+        if (!existing || existing.projectId !== event.projectId) {
+          throw fastify.httpErrors.notFound("Conversation not found.");
+        }
+      } else {
+        const created = await createLarryConversation(
+          fastify.db,
+          tenantId,
+          actorUserId,
+          {
+            projectId: event.projectId,
+            title: `Modify: ${event.displayText.slice(0, 120)}`,
+          }
+        );
+        conversationId = created.id;
+      }
+
+      const teamMembers = await fastify.db.queryTenant<{ displayName: string }>(
+        tenantId,
+        `SELECT COALESCE(u.display_name, u.email) AS "displayName"
+           FROM users u
+           JOIN project_members pm ON pm.user_id = u.id
+          WHERE pm.tenant_id = $1 AND pm.project_id = $2
+          ORDER BY "displayName" ASC`,
+        [tenantId, event.projectId]
+      );
+
+      const userMessageInsert = await insertLarryMessage(
+        fastify.db,
+        tenantId,
+        conversationId,
+        { role: "user", content: message, actorUserId }
+      );
+
+      const modifyConfig = buildIntelligenceConfig(fastify.config);
+
+      // History is just this turn's user message — the modify panel is a
+      // stateless one-shot per send. If we later add multi-turn refinement,
+      // load prior messages via listLarryMessagesForConversation.
+      const generator = streamModifyChat({
+        config: modifyConfig,
+        messages: [{ role: "user", content: message }],
+        context: {
+          actionType: event.actionType,
+          displayText: event.displayText,
+          reasoning: event.reasoning,
+          currentPayload,
+          editableFields,
+          teamMembers,
+        },
+      });
+
+      let fullText = "";
+      let payloadPatch: Record<string, unknown> | null = null;
+      let summary = "";
+      let streamError: string | null = null;
+
+      for await (const evt of generator as AsyncIterable<ModifyChatStreamEvent>) {
+        if (evt.type === "token") fullText += evt.delta;
+        else if (evt.type === "tool_done" && evt.name === "apply_modification") {
+          payloadPatch = evt.payloadPatch;
+          summary = evt.summary;
+        } else if (evt.type === "error") {
+          streamError = evt.message;
+        }
+      }
+
+      const assistantText =
+        fullText.trim().length > 0
+          ? fullText.trim()
+          : summary ||
+            (streamError
+              ? "I couldn't process that request — please try again."
+              : "I didn't catch that. Can you rephrase the change you want?");
+
+      const assistantInsert = await insertLarryMessage(
+        fastify.db,
+        tenantId,
+        conversationId,
+        { role: "larry", content: assistantText }
+      );
+      await touchLarryConversation(fastify.db, tenantId, conversationId, message.slice(0, 80));
+
+      await writeAuditLog(fastify.db, {
+        tenantId,
+        actorUserId,
+        actionType: "larry.event.modify_chat",
+        objectType: "larry_event",
+        objectId: id,
+        details: {
+          conversationId,
+          producedPatch: payloadPatch !== null,
+          patchKeys: payloadPatch ? Object.keys(payloadPatch) : [],
+        },
+      });
+
+      return reply.code(200).send({
+        conversationId,
+        userMessageId: userMessageInsert.id,
+        assistantMessageId: assistantInsert.id,
+        message: assistantText,
+        payloadPatch: payloadPatch ?? {},
+        summary,
+        streamError,
+      });
     }
   );
 

--- a/apps/web/src/app/api/workspace/larry/events/[id]/modify-chat/route.ts
+++ b/apps/web/src/app/api/workspace/larry/events/[id]/modify-chat/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { persistSession, proxyApiRequest } from "@/lib/workspace-proxy";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const body = await request.text();
+
+  const result = await proxyApiRequest(
+    session,
+    `/v1/larry/events/${id}/modify-chat`,
+    { method: "POST", body: body || "{}" }
+  );
+
+  if (result.session) {
+    await persistSession(result.session);
+  }
+
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/apps/web/src/app/api/workspace/larry/events/[id]/modify/save/route.ts
+++ b/apps/web/src/app/api/workspace/larry/events/[id]/modify/save/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { persistSession, proxyApiRequest } from "@/lib/workspace-proxy";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+  const body = await request.text();
+
+  const result = await proxyApiRequest(
+    session,
+    `/v1/larry/events/${id}/modify/save`,
+    { method: "POST", body: body || "{}" }
+  );
+
+  if (result.session) {
+    await persistSession(result.session);
+  }
+
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/apps/web/src/app/api/workspace/larry/events/[id]/modify/stop/route.ts
+++ b/apps/web/src/app/api/workspace/larry/events/[id]/modify/stop/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { persistSession, proxyApiRequest } from "@/lib/workspace-proxy";
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await context.params;
+
+  const result = await proxyApiRequest(
+    session,
+    `/v1/larry/events/${id}/modify/stop`,
+    { method: "POST", body: JSON.stringify({}) }
+  );
+
+  if (result.session) {
+    await persistSession(result.session);
+  }
+
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/apps/web/src/app/workspace/ModifyDiff.tsx
+++ b/apps/web/src/app/workspace/ModifyDiff.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { DiffEntry } from "@/hooks/useModifyPanel";
+
+const LABELS: Record<string, string> = {
+  title: "Title",
+  description: "Description",
+  dueDate: "Due date",
+  assigneeName: "Assignee",
+  priority: "Priority",
+  newDeadline: "New deadline",
+  newOwnerName: "New owner",
+  newStatus: "New status",
+  newRiskLevel: "Risk level",
+  riskLevel: "Risk level",
+  to: "To",
+  subject: "Subject",
+  body: "Body",
+};
+
+function fmt(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "—";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+export function ModifyDiff({ entries }: { entries: DiffEntry[] }) {
+  if (entries.length === 0) {
+    return <p className="text-sm text-neutral-500">No changes yet.</p>;
+  }
+  return (
+    <ul className="space-y-1 text-sm">
+      {entries.map((e) => (
+        <li key={e.key} className="flex flex-wrap items-baseline gap-2">
+          <span className="font-medium text-neutral-700">
+            {LABELS[e.key] ?? e.key}:
+          </span>
+          <span className="text-neutral-500 line-through">{fmt(e.before)}</span>
+          <span aria-hidden className="text-neutral-400">→</span>
+          <span className="font-medium text-[#6c44f6]">{fmt(e.after)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/app/workspace/ModifyPanel.tsx
+++ b/apps/web/src/app/workspace/ModifyPanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+// Inline Modify Action panel rendered on an Action Centre card.
+// Spec: docs/superpowers/specs/2026-04-15-modify-action-design.md
+//
+// The panel owns its own useModifyPanel hook. Parents pass the eventId
+// and an onFinished callback that fires on either Save & execute success
+// or Stop — the callback refreshes the Action Centre and closes the panel.
+
+import { useEffect, useRef, useState } from "react";
+import { useModifyPanel } from "@/hooks/useModifyPanel";
+import { ModifyDiff } from "./ModifyDiff";
+import { ModifyPanelFields } from "./ModifyPanelFields";
+
+export interface ModifyPanelProps {
+  eventId: string;
+  onFinished: (outcome: "saved" | "stopped" | "conflict") => void;
+}
+
+export function ModifyPanel({ eventId, onFinished }: ModifyPanelProps) {
+  const panel = useModifyPanel();
+  const [chatInput, setChatInput] = useState("");
+  const openedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (openedRef.current === eventId) return;
+    openedRef.current = eventId;
+    void panel.open(eventId);
+  }, [eventId, panel]);
+
+  if (panel.state === "loading") {
+    return (
+      <div className="mt-3 rounded-lg border border-neutral-200 bg-white p-4 text-sm text-neutral-500 shadow-sm">
+        Loading suggestion…
+      </div>
+    );
+  }
+
+  if (panel.state === "conflict") {
+    return (
+      <div className="mt-3 rounded-lg border border-amber-400 bg-amber-50 p-4 text-sm text-amber-900 shadow-sm">
+        <p className="mb-2">
+          This suggestion was already resolved in another tab. Refresh the Action Centre
+          to see the current state.
+        </p>
+        <button
+          type="button"
+          onClick={() => onFinished("conflict")}
+          className="rounded border border-amber-400 bg-white px-3 py-1 font-medium hover:bg-amber-100"
+        >
+          Close
+        </button>
+      </div>
+    );
+  }
+
+  if (panel.state === "error" || !panel.snapshot || !panel.workingPayload) {
+    return (
+      <div className="mt-3 rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-900 shadow-sm">
+        <p className="mb-2">{panel.error ?? "Couldn't open Modify. Please try again."}</p>
+        <button
+          type="button"
+          onClick={() => onFinished("stopped")}
+          className="rounded border border-red-300 bg-white px-3 py-1 font-medium hover:bg-red-100"
+        >
+          Close
+        </button>
+      </div>
+    );
+  }
+
+  const { snapshot, workingPayload, diff, chatLog, error } = panel;
+  const saving = panel.state === "saving";
+
+  async function handleChat(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = chatInput.trim();
+    if (!trimmed) return;
+    setChatInput("");
+    await panel.sendChat(trimmed);
+  }
+
+  async function handleSave() {
+    const result = await panel.saveAndExecute();
+    if (result) onFinished("saved");
+  }
+
+  async function handleStop() {
+    await panel.stop();
+    onFinished("stopped");
+  }
+
+  return (
+    <div className="mt-3 space-y-4 rounded-lg border border-neutral-300 bg-white p-4 shadow-sm">
+      <header className="text-xs uppercase tracking-wide text-neutral-500">
+        Editing: <span className="font-semibold text-neutral-800">{snapshot.displayText}</span>
+      </header>
+
+      <section>
+        <ModifyPanelFields
+          snapshot={snapshot}
+          payload={workingPayload}
+          onPatch={panel.applyPatch}
+        />
+      </section>
+
+      <section className="space-y-2">
+        <form onSubmit={handleChat} className="flex gap-2">
+          <input
+            value={chatInput}
+            onChange={(e) => setChatInput(e.target.value)}
+            placeholder="Anything a field can't capture? Describe the change…"
+            className="flex-1 rounded border border-neutral-300 px-2 py-1 text-sm focus:border-[#6c44f6] focus:outline-none focus:ring-1 focus:ring-[#6c44f6]"
+          />
+          <button
+            type="submit"
+            className="rounded bg-neutral-800 px-3 py-1 text-sm font-medium text-white hover:bg-neutral-700"
+          >
+            Tell Larry
+          </button>
+        </form>
+        {chatLog.length > 0 && (
+          <div className="space-y-1 rounded bg-neutral-50 p-2 text-sm">
+            {chatLog.map((entry, i) => (
+              <div key={i}>
+                <strong className="text-neutral-700">
+                  {entry.who === "you" ? "You" : "Larry"}:
+                </strong>{" "}
+                <span className="text-neutral-800">{entry.text}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded border border-neutral-200 bg-neutral-50 p-3">
+        <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+          Review
+        </h4>
+        <ModifyDiff entries={diff} />
+      </section>
+
+      {error && (
+        <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || diff.length === 0}
+          className="rounded bg-[#6c44f6] px-3 py-1 text-sm font-medium text-white hover:bg-[#5933e0] disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save & execute"}
+        </button>
+        <button
+          type="button"
+          onClick={handleStop}
+          disabled={saving}
+          className="rounded border border-neutral-300 px-3 py-1 text-sm font-medium text-neutral-700 hover:bg-neutral-50 disabled:opacity-50"
+        >
+          Stop
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/workspace/ModifyPanelFields.tsx
+++ b/apps/web/src/app/workspace/ModifyPanelFields.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+// Per-action-type field renderers for the Modify panel.
+// Spec: docs/superpowers/specs/2026-04-15-modify-action-design.md
+
+import type { ReactElement } from "react";
+import type { ModifySnapshot } from "@/hooks/useModifyPanel";
+
+export interface FieldsProps {
+  snapshot: ModifySnapshot;
+  payload: Record<string, unknown>;
+  onPatch: (patch: Record<string, unknown>) => void;
+}
+
+const INPUT_CLASS =
+  "w-full rounded border border-neutral-300 px-2 py-1 text-sm focus:border-[#6c44f6] focus:outline-none focus:ring-1 focus:ring-[#6c44f6]";
+const LABEL_CLASS = "flex flex-col gap-1 text-sm";
+const SPAN_CLASS = "font-medium text-neutral-700";
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function TeamSelect({
+  value,
+  onChange,
+  members,
+  placeholder,
+}: {
+  value: string;
+  onChange: (name: string) => void;
+  members: ModifySnapshot["teamMembers"];
+  placeholder: string;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={INPUT_CLASS}
+    >
+      <option value="">{placeholder}</option>
+      {members.map((m) => (
+        <option key={m.userId} value={m.displayName}>
+          {m.displayName}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function CreateTaskFields({ snapshot, payload, onPatch }: FieldsProps) {
+  return (
+    <div className="space-y-3">
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>Title</span>
+        <input
+          type="text"
+          value={str(payload.title)}
+          onChange={(e) => onPatch({ title: e.target.value })}
+          className={INPUT_CLASS}
+        />
+      </label>
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>Description</span>
+        <textarea
+          value={str(payload.description)}
+          onChange={(e) => onPatch({ description: e.target.value })}
+          rows={3}
+          className={INPUT_CLASS}
+        />
+      </label>
+      <div className="grid grid-cols-2 gap-3">
+        <label className={LABEL_CLASS}>
+          <span className={SPAN_CLASS}>Due date</span>
+          <input
+            type="date"
+            value={str(payload.dueDate)}
+            onChange={(e) => onPatch({ dueDate: e.target.value })}
+            className={INPUT_CLASS}
+          />
+        </label>
+        <label className={LABEL_CLASS}>
+          <span className={SPAN_CLASS}>Priority</span>
+          <select
+            value={str(payload.priority) || "medium"}
+            onChange={(e) => onPatch({ priority: e.target.value })}
+            className={INPUT_CLASS}
+          >
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+            <option value="critical">Critical</option>
+          </select>
+        </label>
+      </div>
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>Assignee</span>
+        <TeamSelect
+          value={str(payload.assigneeName)}
+          onChange={(name) => onPatch({ assigneeName: name })}
+          members={snapshot.teamMembers}
+          placeholder="(unassigned)"
+        />
+      </label>
+    </div>
+  );
+}
+
+function ChangeDeadlineFields({ payload, onPatch }: FieldsProps) {
+  return (
+    <label className={LABEL_CLASS}>
+      <span className={SPAN_CLASS}>New deadline</span>
+      <input
+        type="date"
+        value={str(payload.newDeadline)}
+        onChange={(e) => onPatch({ newDeadline: e.target.value })}
+        className={INPUT_CLASS}
+      />
+    </label>
+  );
+}
+
+function ChangeTaskOwnerFields({ snapshot, payload, onPatch }: FieldsProps) {
+  return (
+    <label className={LABEL_CLASS}>
+      <span className={SPAN_CLASS}>New owner</span>
+      <TeamSelect
+        value={str(payload.newOwnerName)}
+        onChange={(name) => onPatch({ newOwnerName: name })}
+        members={snapshot.teamMembers}
+        placeholder="(no owner)"
+      />
+    </label>
+  );
+}
+
+function UpdateTaskStatusFields({ payload, onPatch }: FieldsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>New status</span>
+        <select
+          value={str(payload.newStatus) || "not_started"}
+          onChange={(e) => onPatch({ newStatus: e.target.value })}
+          className={INPUT_CLASS}
+        >
+          <option value="backlog">Backlog</option>
+          <option value="not_started">Not started</option>
+          <option value="in_progress">In progress</option>
+          <option value="waiting">Waiting</option>
+          <option value="blocked">Blocked</option>
+          <option value="completed">Completed</option>
+        </select>
+      </label>
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>Risk level</span>
+        <select
+          value={str(payload.newRiskLevel) || "low"}
+          onChange={(e) => onPatch({ newRiskLevel: e.target.value })}
+          className={INPUT_CLASS}
+        >
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+      </label>
+    </div>
+  );
+}
+
+function FlagTaskRiskFields({ payload, onPatch }: FieldsProps) {
+  return (
+    <label className={LABEL_CLASS}>
+      <span className={SPAN_CLASS}>Risk level</span>
+      <select
+        value={str(payload.riskLevel) || "low"}
+        onChange={(e) => onPatch({ riskLevel: e.target.value })}
+        className={INPUT_CLASS}
+      >
+        <option value="low">Low</option>
+        <option value="medium">Medium</option>
+        <option value="high">High</option>
+      </select>
+    </label>
+  );
+}
+
+function DraftEmailFields({ payload, onPatch }: FieldsProps) {
+  return (
+    <div className="space-y-3">
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>To</span>
+        <input
+          type="text"
+          value={str(payload.to)}
+          onChange={(e) => onPatch({ to: e.target.value })}
+          className={INPUT_CLASS}
+        />
+      </label>
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>Subject</span>
+        <input
+          type="text"
+          value={str(payload.subject)}
+          onChange={(e) => onPatch({ subject: e.target.value })}
+          className={INPUT_CLASS}
+        />
+      </label>
+      <label className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>Body</span>
+        <textarea
+          value={str(payload.body)}
+          onChange={(e) => onPatch({ body: e.target.value })}
+          rows={6}
+          className={INPUT_CLASS}
+        />
+      </label>
+    </div>
+  );
+}
+
+const FIELDS_BY_TYPE: Record<string, (props: FieldsProps) => ReactElement> = {
+  create_task: CreateTaskFields,
+  change_deadline: ChangeDeadlineFields,
+  change_task_owner: ChangeTaskOwnerFields,
+  update_task_status: UpdateTaskStatusFields,
+  flag_task_risk: FlagTaskRiskFields,
+  draft_email: DraftEmailFields,
+};
+
+export function ModifyPanelFields(props: FieldsProps) {
+  const Renderer = FIELDS_BY_TYPE[props.snapshot.actionType];
+  if (!Renderer) {
+    return (
+      <p className="text-sm text-neutral-500">
+        This action type doesn't have quick-edit fields. Tell Larry what to change using
+        the chat below.
+      </p>
+    );
+  }
+  return <Renderer {...props} />;
+}

--- a/apps/web/src/app/workspace/actions/page.tsx
+++ b/apps/web/src/app/workspace/actions/page.tsx
@@ -10,6 +10,7 @@ import { useEmailDrafts } from "@/hooks/useEmailDrafts";
 import { getActionTypeTag, getAllActionTypes } from "@/lib/action-types";
 import { useToast } from "@/components/toast/ToastContext";
 import { ActionDetailPreview } from "@/components/workspace/ActionDetailPreview";
+import { ModifyPanel } from "@/app/workspace/ModifyPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -235,11 +236,13 @@ export default function WorkspaceActionsPage() {
     accepting,
     dismissing,
     modifying,
+    modifyingEventId,
     executing,
     actionError,
     accept,
     dismiss,
     modify,
+    closeModify,
     letLarryExecute,
     clearActionError,
     refresh,
@@ -675,19 +678,16 @@ export default function WorkspaceActionsPage() {
                         </button>
                         <button
                           type="button"
-                          onClick={async () => {
-                            const conversationId = await modify(event.id);
-                            if (conversationId) {
-                              router.push(buildFullChatHref(conversationId, event, "modify"));
-                            }
+                          onClick={() => {
+                            modify(event.id);
                           }}
-                          disabled={modifying === event.id}
+                          disabled={modifyingEventId === event.id}
                           className="rounded-full border px-3 py-1.5 text-[12px] font-semibold"
                           style={{ borderColor: "var(--cta)", color: "var(--cta)" }}
                           data-testid="action-centre-modify"
                           data-event-id={event.id}
                         >
-                          {modifying === event.id ? "Opening..." : "Modify"}
+                          {modifyingEventId === event.id ? "Editing…" : "Modify"}
                         </button>
                         <button
                           type="button"
@@ -720,6 +720,18 @@ export default function WorkspaceActionsPage() {
                           Dismiss
                         </button>
                       </div>
+                    )}
+
+                    {modifyingEventId === event.id && (
+                      <ModifyPanel
+                        eventId={event.id}
+                        onFinished={async (outcome) => {
+                          closeModify();
+                          if (outcome === "saved") {
+                            await refresh();
+                          }
+                        }}
+                      />
                     )}
                   </div>
                 ))

--- a/apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx
+++ b/apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx
@@ -46,6 +46,7 @@ import { ProjectTimeline } from "@/components/workspace/timeline/ProjectTimeline
 import { getActionTypeTag, getAllActionTypes } from "@/lib/action-types";
 import { useToast } from "@/components/toast/ToastContext";
 import { ActionDetailPreview } from "@/components/workspace/ActionDetailPreview";
+import { ModifyPanel } from "@/app/workspace/ModifyPanel";
 import { ActionBellDropdown } from "./overview/ActionBellDropdown";
 import { ProjectOverviewTab } from "./overview/ProjectOverviewTab";
 import { ProjectDescriptionCard } from "./overview/ProjectDescriptionCard";
@@ -1039,10 +1040,13 @@ function ProjectActionCentreTab({
   accepting,
   dismissing,
   modifying,
+  modifyingEventId,
   actionError,
   accept,
   dismiss,
   modify,
+  closeModify,
+  onModifySaved,
   clearActionError,
   onOpenConversation,
 }: {
@@ -1051,10 +1055,13 @@ function ProjectActionCentreTab({
   accepting: string | null;
   dismissing: string | null;
   modifying: string | null;
+  modifyingEventId: string | null;
   actionError: { eventId: string; message: string } | null;
   accept: (id: string) => Promise<void>;
   dismiss: (id: string) => Promise<void>;
-  modify: (id: string) => Promise<string | null>;
+  modify: (id: string) => void;
+  closeModify: () => void;
+  onModifySaved: () => Promise<void>;
   clearActionError: () => void;
   onOpenConversation: (conversationId: string) => void;
 }) {
@@ -1269,18 +1276,14 @@ function ProjectActionCentreTab({
                       </button>
                       <button
                         type="button"
-                        onClick={async () => {
-                          const conversationId = await modify(event.id);
-                          if (conversationId) {
-                            window.dispatchEvent(new CustomEvent("larry:open"));
-                            window.dispatchEvent(new CustomEvent("larry:load-conversation", { detail: conversationId }));
-                          }
+                        onClick={() => {
+                          modify(event.id);
                         }}
-                        disabled={modifying === event.id}
+                        disabled={modifyingEventId === event.id}
                         className="rounded-full border px-3 py-1.5 text-[12px] font-semibold"
                         style={{ borderColor: "var(--cta)", color: "var(--cta)" }}
                       >
-                        {modifying === event.id ? "Opening..." : "Modify"}
+                        {modifyingEventId === event.id ? "Editing…" : "Modify"}
                       </button>
                       <button
                         type="button"
@@ -1309,6 +1312,18 @@ function ProjectActionCentreTab({
                         Dismiss
                       </button>
                     </div>
+                  )}
+
+                  {modifyingEventId === event.id && (
+                    <ModifyPanel
+                      eventId={event.id}
+                      onFinished={async (outcome) => {
+                        closeModify();
+                        if (outcome === "saved") {
+                          await onModifySaved();
+                        }
+                      }}
+                    />
                   )}
                 </div>
               ))
@@ -1451,11 +1466,13 @@ export function ProjectWorkspaceView({ projectId }: { projectId: string }) {
     accepting,
     dismissing,
     modifying,
+    modifyingEventId,
     executing,
     actionError,
     accept,
     dismiss,
     modify,
+    closeModify,
     letLarryExecute,
     clearActionError,
     refresh: refreshActionCentre,
@@ -2171,10 +2188,13 @@ export function ProjectWorkspaceView({ projectId }: { projectId: string }) {
           accepting={accepting}
           dismissing={dismissing}
           modifying={modifying}
+          modifyingEventId={modifyingEventId}
           actionError={actionError}
           accept={accept}
           dismiss={dismiss}
           modify={modify}
+          closeModify={closeModify}
+          onModifySaved={refreshActionCentre}
           clearActionError={clearActionError}
           onOpenConversation={openConversation}
         />)}

--- a/apps/web/src/hooks/useLarryActionCentre.ts
+++ b/apps/web/src/hooks/useLarryActionCentre.ts
@@ -48,6 +48,7 @@ export function useLarryActionCentre({
   const [accepting, setAccepting] = useState<string | null>(null);
   const [dismissing, setDismissing] = useState<string | null>(null);
   const [modifying, setModifying] = useState<string | null>(null);
+  const [modifyingEventId, setModifyingEventId] = useState<string | null>(null);
   const [executing, setExecuting] = useState<string | null>(null);
   const [actionError, setActionError] = useState<ActionError | null>(null);
   const loadInFlightRef = useRef<Promise<void> | null>(null);
@@ -212,30 +213,18 @@ export function useLarryActionCentre({
     [load, onMutate, removeSuggestedLocally]
   );
 
-  const modify = useCallback(
-    async (id: string): Promise<string | null> => {
-      setModifying(id);
-      setActionError(null);
-      try {
-        const response = await fetch(`/api/workspace/larry/events/${id}/modify`, { method: "POST" });
-        if (!response.ok) {
-          const body = await readJson<{ message?: string; error?: string }>(response);
-          setActionError({
-            eventId: id,
-            message: body.message || body.error || `Modify failed (${response.status}).`,
-          });
-          return null;
-        }
-        const data = await response.json();
-        return data.conversationId ?? null;
-      } catch {
-        return null;
-      } finally {
-        setModifying(null);
-      }
-    },
-    []
-  );
+  // Opens the inline Modify panel for an event. The panel itself (ModifyPanel +
+  // useModifyPanel) fetches the editable snapshot from /api/workspace/larry/events/
+  // [id]/modify, so this callback just toggles the UI.
+  // Spec: 2026-04-15-modify-action-design.md.
+  const modify = useCallback((id: string): void => {
+    setActionError(null);
+    setModifyingEventId(id);
+  }, []);
+
+  const closeModify = useCallback((): void => {
+    setModifyingEventId(null);
+  }, []);
 
   const letLarryExecute = useCallback(
     async (id: string): Promise<boolean> => {
@@ -272,11 +261,13 @@ export function useLarryActionCentre({
     accepting,
     dismissing,
     modifying,
+    modifyingEventId,
     executing,
     actionError,
     accept,
     dismiss,
     modify,
+    closeModify,
     letLarryExecute,
     clearActionError,
     refresh: load,

--- a/apps/web/src/hooks/useModifyPanel.ts
+++ b/apps/web/src/hooks/useModifyPanel.ts
@@ -1,0 +1,244 @@
+"use client";
+
+// Client-side state machine for the Modify Action panel.
+// Spec: docs/superpowers/specs/2026-04-15-modify-action-design.md
+//
+// Lifecycle: idle → loading → editing → (saving | conflict) → idle.
+// All edits live in memory until saveAndExecute() commits; stop() discards.
+
+import { useCallback, useMemo, useState } from "react";
+
+export type ModifyPanelState =
+  | "idle"
+  | "loading"
+  | "editing"
+  | "saving"
+  | "conflict"
+  | "error";
+
+export interface ModifySnapshot {
+  eventId: string;
+  actionType: string;
+  displayText: string;
+  reasoning: string;
+  payload: Record<string, unknown>;
+  editableFields: string[];
+  teamMembers: { userId: string; displayName: string; email: string }[];
+}
+
+export interface DiffEntry {
+  key: string;
+  before: unknown;
+  after: unknown;
+}
+
+export interface ChatTurn {
+  who: "you" | "larry";
+  text: string;
+}
+
+export interface SaveResult {
+  executed: boolean;
+  entity: unknown;
+  event: unknown;
+}
+
+async function readJson<T>(response: Response): Promise<T | null> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function useModifyPanel() {
+  const [state, setState] = useState<ModifyPanelState>("idle");
+  const [snapshot, setSnapshot] = useState<ModifySnapshot | null>(null);
+  const [workingPayload, setWorkingPayload] = useState<Record<string, unknown> | null>(null);
+  const [chatLog, setChatLog] = useState<ChatTurn[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setState("idle");
+    setSnapshot(null);
+    setWorkingPayload(null);
+    setChatLog([]);
+    setError(null);
+  }, []);
+
+  const open = useCallback(async (eventId: string) => {
+    setState("loading");
+    setError(null);
+    setChatLog([]);
+    try {
+      const res = await fetch(`/api/workspace/larry/events/${eventId}/modify`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await readJson<{ message?: string; error?: string }>(res);
+        const message =
+          res.status === 409
+            ? "This suggestion was already resolved."
+            : body?.message ?? body?.error ?? "Couldn't open Modify.";
+        setState(res.status === 409 ? "conflict" : "error");
+        setError(message);
+        return;
+      }
+      const snap = (await res.json()) as ModifySnapshot;
+      setSnapshot(snap);
+      setWorkingPayload({ ...snap.payload });
+      setState("editing");
+    } catch (e) {
+      setState("error");
+      setError(e instanceof Error ? e.message : "Couldn't open Modify.");
+    }
+  }, []);
+
+  const applyPatch = useCallback((patch: Record<string, unknown>) => {
+    setWorkingPayload((prev) => (prev ? { ...prev, ...patch } : prev));
+  }, []);
+
+  const diff = useMemo<DiffEntry[]>(() => {
+    if (!snapshot || !workingPayload) return [];
+    const out: DiffEntry[] = [];
+    const keys = new Set<string>([
+      ...Object.keys(snapshot.payload ?? {}),
+      ...Object.keys(workingPayload ?? {}),
+    ]);
+    for (const key of keys) {
+      // Only report diffs for editable fields — the payload may contain other
+      // internal keys (taskId, sourceKind, etc.) that we don't surface.
+      if (!snapshot.editableFields.includes(key)) continue;
+      const before = snapshot.payload[key];
+      const after = workingPayload[key];
+      if (JSON.stringify(before) !== JSON.stringify(after)) {
+        out.push({ key, before, after });
+      }
+    }
+    return out;
+  }, [snapshot, workingPayload]);
+
+  const sendChat = useCallback(
+    async (message: string): Promise<void> => {
+      if (!snapshot || !workingPayload) return;
+      const trimmed = message.trim();
+      if (!trimmed) return;
+      setChatLog((log) => [...log, { who: "you", text: trimmed }]);
+      try {
+        const res = await fetch(
+          `/api/workspace/larry/events/${snapshot.eventId}/modify-chat`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ message: trimmed, currentPayload: workingPayload }),
+          }
+        );
+        if (!res.ok) {
+          const body = await readJson<{ message?: string; error?: string }>(res);
+          if (res.status === 409) {
+            setState("conflict");
+            setError("This suggestion was already resolved elsewhere.");
+            return;
+          }
+          setChatLog((log) => [
+            ...log,
+            {
+              who: "larry",
+              text: body?.message ?? body?.error ?? "Sorry, I couldn't process that.",
+            },
+          ]);
+          return;
+        }
+        const body = (await res.json()) as {
+          message: string;
+          payloadPatch?: Record<string, unknown>;
+          summary?: string;
+        };
+        setChatLog((log) => [...log, { who: "larry", text: body.message }]);
+        if (body.payloadPatch && Object.keys(body.payloadPatch).length > 0) {
+          applyPatch(body.payloadPatch);
+        }
+      } catch (e) {
+        setChatLog((log) => [
+          ...log,
+          {
+            who: "larry",
+            text:
+              e instanceof Error
+                ? `Something went wrong: ${e.message}`
+                : "Something went wrong.",
+          },
+        ]);
+      }
+    },
+    [applyPatch, snapshot, workingPayload]
+  );
+
+  const saveAndExecute = useCallback(async (): Promise<SaveResult | null> => {
+    if (!snapshot || !workingPayload) return null;
+    if (diff.length === 0) return null;
+    setState("saving");
+    setError(null);
+    try {
+      const patch: Record<string, unknown> = {};
+      for (const entry of diff) {
+        patch[entry.key] = entry.after;
+      }
+      const res = await fetch(
+        `/api/workspace/larry/events/${snapshot.eventId}/modify/save`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ payloadPatch: patch, executeImmediately: true }),
+        }
+      );
+      if (res.status === 409) {
+        setState("conflict");
+        setError("This suggestion was already resolved elsewhere.");
+        return null;
+      }
+      if (!res.ok) {
+        const body = await readJson<{ message?: string; error?: string }>(res);
+        setState("editing");
+        setError(body?.message ?? body?.error ?? "Save failed.");
+        return null;
+      }
+      const body = (await res.json()) as SaveResult;
+      reset();
+      return body;
+    } catch (e) {
+      setState("editing");
+      setError(e instanceof Error ? e.message : "Save failed.");
+      return null;
+    }
+  }, [diff, reset, snapshot, workingPayload]);
+
+  const stop = useCallback(async (): Promise<void> => {
+    if (snapshot) {
+      try {
+        await fetch(`/api/workspace/larry/events/${snapshot.eventId}/modify/stop`, {
+          method: "POST",
+        });
+      } catch {
+        // Best-effort audit log. Panel closes regardless.
+      }
+    }
+    reset();
+  }, [reset, snapshot]);
+
+  return {
+    state,
+    snapshot,
+    workingPayload,
+    diff,
+    chatLog,
+    error,
+    open,
+    applyPatch,
+    sendChat,
+    saveAndExecute,
+    stop,
+  };
+}

--- a/docs/reports/qa-2026-04-15-modify/README.md
+++ b/docs/reports/qa-2026-04-15-modify/README.md
@@ -1,0 +1,107 @@
+# Modify Action — Manual QA Script
+
+**Spec:** [../../superpowers/specs/2026-04-15-modify-action-design.md](../../superpowers/specs/2026-04-15-modify-action-design.md)
+**Plan:** [../../superpowers/plans/2026-04-15-modify-action.md](../../superpowers/plans/2026-04-15-modify-action.md)
+**Built:** 2026-04-15
+
+---
+
+## Pre-flight
+
+1. Migration 020 applied on the target database. Verify:
+
+   ```sql
+   SELECT column_name FROM information_schema.columns
+   WHERE table_name = 'larry_events'
+     AND column_name IN ('previous_payload', 'modified_by_user_id', 'modified_at');
+   ```
+
+   Expect all three rows. If missing, migrations did not run — fix deploy before testing.
+
+2. `@larry/db` and `@larry/ai` packages rebuilt and deployed (Railway API + Vercel web both up to date on the latest commit).
+
+3. A Larry scan has produced at least one suggested event for the target project, or seed one manually.
+
+## The five smoke flows
+
+Each flow covers one of the spec's required behaviours. Fergus tests on deployed production per the `testing-on-production` memory.
+
+### F1. Quick-edit a deadline and save
+
+1. Open the Action Centre (global `/workspace/actions` or the per-project Action Box).
+2. Find a pending `create_task` or `change_deadline` suggestion.
+3. Click **Modify** — the card stays in place and a panel opens below it.
+4. Change the date via the native date picker.
+5. Verify the Review diff shows `Due date: OLD → NEW`.
+6. Click **Save & execute**.
+7. Expected: card disappears from the pending list within ~1s, the created/updated task reflects the new date.
+8. Verify in the DB:
+
+   ```sql
+   SELECT event_type, previous_payload->>'dueDate', payload->>'dueDate', modified_by_user_id
+   FROM larry_events WHERE id = '<eventId>';
+   ```
+
+   `event_type = accepted`, `previous_payload` set, `modified_by_user_id` = the user who saved.
+
+### F2. Chat-driven edit
+
+1. Open Modify on any suggestion.
+2. In the "Tell Larry in words" strip, type something like `push to next Friday and reassign to Anna` (use a real team member name).
+3. Expected: Larry replies in the chat log, the diff updates live with `Due date` and `Assignee` entries, and the working field values update too.
+4. Click **Save & execute**.
+5. Same DB verification as F1.
+
+### F3. Stop cancels cleanly
+
+1. Open Modify on a suggestion.
+2. Change at least one field so the diff shows a pending change.
+3. Click **Stop**.
+4. Expected: panel closes, card returns to its normal state (original Accept/Modify/Dismiss buttons enabled, payload unchanged).
+5. In the DB, the event's `payload` and `event_type` must be unchanged. `previous_payload` must still be NULL.
+
+### F4. Concurrent accept → conflict banner
+
+1. Open two browser tabs, both on `/workspace/actions`, same account.
+2. In tab A, click **Modify** on a suggestion.
+3. In tab B, click **Accept** on the same suggestion.
+4. Back in tab A, change a field and click **Save & execute**.
+5. Expected: panel shows the amber "already resolved" conflict state with a Close button. No 500, no duplicate execution.
+
+### F5. Unmodifiable action type is gracefully blocked
+
+1. Find a `send_reminder` event in the activity list (these auto-execute, so they won't be suggested — this flow mostly verifies defence-in-depth). If none, synthesise via:
+
+   ```sql
+   INSERT INTO larry_events (tenant_id, project_id, event_type, action_type, display_text, reasoning, payload, triggered_by)
+   VALUES ('<tenantId>', '<projectId>', 'suggested', 'send_reminder',
+           'Remind Anna about kickoff', 'Test event', '{}'::jsonb, 'schedule');
+   ```
+
+   Then POST `/api/workspace/larry/events/<id>/modify` directly (devtools).
+2. Expected: 422 with body message `Action type 'send_reminder' is not modifiable.`
+
+## Per-type coverage
+
+Run F1 (quick-edit) once for each modifiable action type and note any rendering issues:
+
+- [ ] `create_task` — title, description, dueDate, assigneeName, priority
+- [ ] `change_deadline` — newDeadline
+- [ ] `change_task_owner` — newOwnerName
+- [ ] `update_task_status` — newStatus, newRiskLevel
+- [ ] `flag_task_risk` — riskLevel
+- [ ] `draft_email` — to, subject, body
+
+## Known limitations
+
+- Modify chat is **one-shot** per send (no multi-turn refinement). If this is a pain, we can load prior turns in a follow-up — see the spec's open questions section.
+- If the user has unsaved edits and closes the browser tab without clicking Stop, no audit `modify_cancelled` log is written. This is accepted as out-of-scope.
+- The feature flag `MODIFY_PANEL_V2` was **not** implemented — rollback path is `git revert`.
+
+## If it breaks
+
+File notes in `NOTES.md` next to this file. The three most likely failure modes:
+
+1. **Migration 020 didn't run** → all save attempts return 500 with `column "previous_payload" does not exist`. Fix: run migrations.
+2. **`@larry/db` import missing** at API startup (`editableFieldsForActionType` not found) → db package wasn't rebuilt. Fix: `cd packages/db && npx tsc -p tsconfig.json`.
+3. **ModifyPanel fails to render** with "Cannot find namespace 'JSX'" or similar → apps/web type check regressed. Fix: re-run `npx tsc --noEmit -p tsconfig.json` in apps/web.

--- a/docs/superpowers/plans/2026-04-15-modify-action.md
+++ b/docs/superpowers/plans/2026-04-15-modify-action.md
@@ -1,0 +1,1529 @@
+# Modify Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken "click Modify → dropped into chat with no capability" flow with an inline Modify panel that lets users edit a pending Larry suggestion via structured fields or a focused chat, review the diff, and commit with a single Save & execute action.
+
+**Architecture:** Mutate the pending `larry_events` row in place with a `previous_payload` audit snapshot. Reuse the existing accept flow transactionally after applying the edit. Keep edits client-side until Save. Chat path uses a dedicated endpoint whose LLM has one tool — `apply_modification` — that returns a payload patch only.
+
+**Tech Stack:** Fastify (api), Next.js App Router (web), Vitest (unit/integration), Playwright (e2e), PostgreSQL, AI SDK v6 + Groq, Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-04-15-modify-action-design.md`
+
+**Deployment reality:** Testing happens on deployed preview per `larry-testing-tools` / `testing-on-production` memories. Fergus does not run locally. Every phase ends with a push; verify the Railway + Vercel deploy before moving on.
+
+---
+
+## Phase 1 — Data model foundations
+
+### Task 1: Migration 020 — audit columns on larry_events
+
+**Files:**
+- Create: `packages/db/src/migrations/020_larry_event_modifications.sql`
+- Modify: `packages/db/src/schema.sql` (append columns to `larry_events` definition near the existing `ALTER TABLE … ADD COLUMN IF NOT EXISTS` block around line 1099)
+
+- [ ] **Step 1: Write the migration file**
+
+```sql
+-- 020_larry_event_modifications.sql
+-- Adds audit columns for the Modify Action flow (spec 2026-04-15-modify-action-design.md).
+-- previous_payload stores the payload before the user's most recent in-place edit so
+-- before/after is recoverable from a single row. Nullable so existing rows are unaffected.
+
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS previous_payload    JSONB,
+  ADD COLUMN IF NOT EXISTS modified_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS modified_at         TIMESTAMPTZ;
+
+COMMENT ON COLUMN larry_events.previous_payload IS
+  'Snapshot of payload before the most recent user edit via Modify. NULL if the event has never been modified.';
+COMMENT ON COLUMN larry_events.modified_by_user_id IS
+  'User who most recently applied a Modify edit to this event.';
+COMMENT ON COLUMN larry_events.modified_at IS
+  'Timestamp of the most recent Modify edit on this event.';
+```
+
+- [ ] **Step 2: Append the same ALTERs to `schema.sql`**
+
+In `packages/db/src/schema.sql`, directly after the final `ADD COLUMN IF NOT EXISTS` on `larry_events` (around line 1103), append:
+
+```sql
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS previous_payload    JSONB;
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS modified_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL;
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS modified_at         TIMESTAMPTZ;
+```
+
+- [ ] **Step 3: Run migrations locally (or in test harness) to verify syntax**
+
+Run: `cd packages/db && npm run migrate:apply 2>&1 | tail -20` (or equivalent — check `package.json` scripts if unclear).
+Expected: the new migration reports applied, no SQL errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/db/src/migrations/020_larry_event_modifications.sql packages/db/src/schema.sql
+git commit -m "feat(db): add modify-action audit columns to larry_events (migration 020)"
+```
+
+---
+
+### Task 2: Pure `applyEventModification` helper
+
+**Files:**
+- Create: `packages/db/src/larry-event-modifications.ts`
+- Create: `packages/db/src/larry-event-modifications.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// packages/db/src/larry-event-modifications.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  applyPatch,
+  editableFieldsForActionType,
+  assertPatchIsAllowed,
+} from "./larry-event-modifications.js";
+
+describe("editableFieldsForActionType", () => {
+  it("returns task fields for create_task", () => {
+    expect(editableFieldsForActionType("create_task")).toEqual([
+      "title", "description", "dueDate", "assigneeName", "priority",
+    ]);
+  });
+  it("returns single-field sets for tweak-only actions", () => {
+    expect(editableFieldsForActionType("change_deadline")).toEqual(["newDeadline"]);
+    expect(editableFieldsForActionType("change_task_owner")).toEqual(["newOwnerName"]);
+    expect(editableFieldsForActionType("flag_task_risk")).toEqual(["riskLevel"]);
+  });
+  it("returns empty for unknown types", () => {
+    expect(editableFieldsForActionType("does_not_exist")).toEqual([]);
+  });
+});
+
+describe("applyPatch", () => {
+  it("merges patch over payload, preserving untouched keys", () => {
+    const base = { title: "A", dueDate: "2026-04-20", priority: "medium" };
+    const patch = { dueDate: "2026-04-30" };
+    expect(applyPatch(base, patch)).toEqual({
+      title: "A", dueDate: "2026-04-30", priority: "medium",
+    });
+  });
+  it("does not mutate the original payload", () => {
+    const base = { title: "A" };
+    applyPatch(base, { title: "B" });
+    expect(base).toEqual({ title: "A" });
+  });
+});
+
+describe("assertPatchIsAllowed", () => {
+  it("accepts a patch whose keys are all editable for the action type", () => {
+    expect(() =>
+      assertPatchIsAllowed("create_task", { title: "A", dueDate: "2026-05-01" })
+    ).not.toThrow();
+  });
+  it("throws on a disallowed field", () => {
+    expect(() =>
+      assertPatchIsAllowed("create_task", { taskId: "abc" })
+    ).toThrow(/not editable.*create_task/i);
+  });
+  it("throws on unknown action type", () => {
+    expect(() =>
+      assertPatchIsAllowed("mystery_action", { anything: "x" })
+    ).toThrow(/unknown action type/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `cd packages/db && npx vitest run src/larry-event-modifications.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// packages/db/src/larry-event-modifications.ts
+// Pure helpers for the Modify Action flow (spec 2026-04-15). No DB access.
+
+export type ActionType =
+  | "create_task" | "update_task_status" | "flag_task_risk"
+  | "send_reminder" | "change_deadline" | "change_task_owner"
+  | "draft_email";
+
+const FIELDS_BY_ACTION_TYPE: Record<string, readonly string[]> = {
+  create_task:        ["title", "description", "dueDate", "assigneeName", "priority"],
+  update_task_status: ["newStatus", "newRiskLevel"],
+  flag_task_risk:     ["riskLevel"],
+  change_deadline:    ["newDeadline"],
+  change_task_owner:  ["newOwnerName"],
+  draft_email:        ["to", "subject", "body"],
+  // send_reminder auto-executes; not modifiable.
+};
+
+export function editableFieldsForActionType(actionType: string): string[] {
+  return [...(FIELDS_BY_ACTION_TYPE[actionType] ?? [])];
+}
+
+export function applyPatch(
+  payload: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...payload, ...patch };
+}
+
+export function assertPatchIsAllowed(
+  actionType: string,
+  patch: Record<string, unknown>,
+): void {
+  const allowed = FIELDS_BY_ACTION_TYPE[actionType];
+  if (!allowed) {
+    throw new Error(`Unknown action type '${actionType}' — cannot modify.`);
+  }
+  for (const key of Object.keys(patch)) {
+    if (!allowed.includes(key)) {
+      throw new Error(
+        `Field '${key}' is not editable for action type '${actionType}'. Allowed: ${allowed.join(", ")}.`,
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `cd packages/db && npx vitest run src/larry-event-modifications.test.ts`
+Expected: 3 suites, 7 tests, all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db/src/larry-event-modifications.ts packages/db/src/larry-event-modifications.test.ts
+git commit -m "feat(db): add pure helpers for modify-action payload patches"
+```
+
+---
+
+## Phase 2 — Refactor accept into a reusable executor
+
+### Task 3: Extract `runAcceptFlow` from the accept route
+
+Rationale: Save & execute must run the same post-accept logic (executeAction, retry-with-resolution, markLarryEventAccepted, correction_feedback, audit log). Extracting avoids copy-paste drift.
+
+**Files:**
+- Modify: `apps/api/src/routes/v1/larry.ts` (the `POST /events/:id/accept` handler, currently lines 1550-1820 approx)
+- Create: `apps/api/src/routes/v1/larry-accept-flow.ts` (new module holding the extracted function)
+- Create: `apps/api/src/routes/v1/larry-accept-flow.test.ts` (regression guard)
+
+- [ ] **Step 1: Write a regression test first (happy path only — the retry branches are integration-tested via the existing accept route)**
+
+```ts
+// apps/api/src/routes/v1/larry-accept-flow.test.ts
+import { describe, expect, it, vi } from "vitest";
+import { runAcceptFlow } from "./larry-accept-flow.js";
+
+describe("runAcceptFlow", () => {
+  it("calls executeAction with merged payload and marks event accepted", async () => {
+    const executeAction = vi.fn().mockResolvedValue({ id: "task-123" });
+    const markAccepted = vi.fn().mockResolvedValue(undefined);
+    const writeCorrection = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runAcceptFlow({
+      tenantId: "t1",
+      actorUserId: "u1",
+      event: {
+        id: "e1", projectId: "p1", actionType: "create_task",
+        payload: { title: "X" }, displayText: "Create task: X",
+      },
+      deps: { executeAction, markAccepted, writeCorrection, logger: { info: vi.fn(), warn: vi.fn() } },
+    });
+
+    expect(executeAction).toHaveBeenCalledOnce();
+    expect(markAccepted).toHaveBeenCalledWith(expect.anything(), "t1", "e1", "u1");
+    expect(writeCorrection).toHaveBeenCalledOnce();
+    expect(result.entity).toEqual({ id: "task-123" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect FAIL (module missing)**
+
+Run: `cd apps/api && npx vitest run src/routes/v1/larry-accept-flow.test.ts`
+
+- [ ] **Step 3: Extract the implementation**
+
+Create `apps/api/src/routes/v1/larry-accept-flow.ts` exporting `runAcceptFlow` that accepts the event + deps and returns `{ entity, updatedEvent }`. The function contains the body of the current accept handler from line 1579 (`let entity: unknown; try { ... }`) through the retry logic and `markLarryEventAccepted` + correction_feedback write, but NOT the HTTP reply formatting. Errors that would have become 422 replies are thrown as a typed `AcceptFlowError` class carrying `{ statusCode, message, originalError, resolvable, candidates }`.
+
+- [ ] **Step 4: Update the accept route to call `runAcceptFlow`**
+
+Replace lines ~1579-1805 of `apps/api/src/routes/v1/larry.ts` with a call to `runAcceptFlow`, catching `AcceptFlowError` to produce the 422 reply, keeping everything else (audit logs, listLarryEventSummaries, toast metadata) in the route handler.
+
+- [ ] **Step 5: Run the existing accept integration tests**
+
+Run: `cd apps/api && npx vitest run tests/larry-event-id-uuid-guard.test.ts tests/larry-chat.test.ts`
+Expected: all pass — no behaviour change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/routes/v1/larry-accept-flow.ts apps/api/src/routes/v1/larry-accept-flow.test.ts apps/api/src/routes/v1/larry.ts
+git commit -m "refactor(api): extract runAcceptFlow so Modify can reuse it"
+```
+
+---
+
+## Phase 3 — API endpoints for Modify
+
+### Task 4: Rewrite `POST /events/:id/modify` to return editable snapshot
+
+**Files:**
+- Modify: `apps/api/src/routes/v1/larry.ts` lines ~1907-2029
+- Create: `apps/api/tests/larry-modify-snapshot.test.ts`
+
+- [ ] **Step 1: Write the failing API test**
+
+```ts
+// apps/api/tests/larry-modify-snapshot.test.ts
+import { describe, expect, it, beforeEach } from "vitest";
+import { buildTestApp, seedSuggestedEvent, seedTenantAndUser } from "./helpers/app.js";
+
+describe("POST /v1/larry/events/:id/modify (snapshot)", () => {
+  it("returns the current payload + editable fields, without mutating event state", async () => {
+    const app = await buildTestApp();
+    const { tenantId, token, userId } = await seedTenantAndUser(app);
+    const eventId = await seedSuggestedEvent(app, tenantId, userId, {
+      actionType: "create_task",
+      payload: { title: "Write brief", dueDate: "2026-04-20", priority: "medium" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/larry/events/${eventId}/modify`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.eventId).toBe(eventId);
+    expect(body.actionType).toBe("create_task");
+    expect(body.payload).toEqual({ title: "Write brief", dueDate: "2026-04-20", priority: "medium" });
+    expect(body.editableFields).toEqual(["title", "description", "dueDate", "assigneeName", "priority"]);
+    expect(Array.isArray(body.teamMembers)).toBe(true);
+
+    // Event must still be 'suggested' — no mutation on open.
+    const stillPending = await app.inject({
+      method: "GET",
+      url: `/v1/larry/events/${eventId}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(stillPending.json().eventType).toBe("suggested");
+  });
+
+  it("409 when the event is not suggested", async () => {
+    const app = await buildTestApp();
+    const { tenantId, token, userId } = await seedTenantAndUser(app);
+    const eventId = await seedSuggestedEvent(app, tenantId, userId, {
+      actionType: "create_task", payload: { title: "X" }, eventType: "accepted",
+    });
+    const res = await app.inject({
+      method: "POST", url: `/v1/larry/events/${eventId}/modify`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+});
+```
+
+If `seedSuggestedEvent` doesn't exist with this signature, extend `apps/api/tests/helpers/app.ts` to provide it before writing this test. Its job is to insert a single `larry_events` row with the given fields and return the id.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+Run: `cd apps/api && npx vitest run tests/larry-modify-snapshot.test.ts`
+
+- [ ] **Step 3: Replace the modify handler body**
+
+In `apps/api/src/routes/v1/larry.ts`, replace the current `/events/:id/modify` handler body (from `const event = await getLarryEventForMutation...` to the `return reply.code(200).send({ conversationId, eventId: id });`) with:
+
+```ts
+const event = await getLarryEventForMutation(fastify.db, tenantId, id);
+if (!event) throw fastify.httpErrors.notFound("Event not found.");
+await assertProjectAccessOrThrow({
+  tenantId, userId: actorUserId, tenantRole: request.user.role,
+  projectId: event.projectId, mode: "manage", requireWritable: true,
+});
+if (event.eventType !== "suggested") {
+  throw fastify.httpErrors.conflict("Only suggested events can be modified.");
+}
+
+const teamMembers = await fastify.db.queryTenant<{
+  userId: string; displayName: string; email: string;
+}>(
+  tenantId,
+  `SELECT u.id AS "userId", u.display_name AS "displayName", u.email
+     FROM users u
+     JOIN project_members pm ON pm.user_id = u.id
+    WHERE pm.tenant_id = $1 AND pm.project_id = $2`,
+  [tenantId, event.projectId],
+);
+
+return reply.code(200).send({
+  eventId: id,
+  actionType: event.actionType,
+  displayText: event.displayText,
+  reasoning: event.reasoning,
+  payload: event.payload ?? {},
+  editableFields: editableFieldsForActionType(event.actionType),
+  teamMembers,
+});
+```
+
+Add an import at the top of the file:
+
+```ts
+import { editableFieldsForActionType } from "@larry/db";
+```
+
+(Re-export `editableFieldsForActionType` from `packages/db/src/index.ts` if not already.)
+
+Remove the old logic: opener-message insertion, conversation creation, `markLarryEventDismissed` call, and the now-unused helper code it referenced. Double-check via `grep -n "openerMessage\|currentLine\|readString" apps/api/src/routes/v1/larry.ts` — if these are only referenced by the removed block, delete them.
+
+- [ ] **Step 4: Run test, expect PASS**
+
+Run: `cd apps/api && npx vitest run tests/larry-modify-snapshot.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api packages/db/src/index.ts
+git commit -m "feat(api): rewrite /events/:id/modify to return editable snapshot instead of dismissing"
+```
+
+---
+
+### Task 5: New `POST /events/:id/modify/save` endpoint
+
+**Files:**
+- Modify: `apps/api/src/routes/v1/larry.ts`
+- Create: `apps/api/tests/larry-modify-save.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/tests/larry-modify-save.test.ts
+import { describe, expect, it } from "vitest";
+import { buildTestApp, seedSuggestedEvent, seedTenantAndUser } from "./helpers/app.js";
+
+describe("POST /v1/larry/events/:id/modify/save", () => {
+  it("applies the patch, snapshots previous_payload, executes, marks accepted", async () => {
+    const app = await buildTestApp();
+    const { tenantId, token, userId } = await seedTenantAndUser(app);
+    const eventId = await seedSuggestedEvent(app, tenantId, userId, {
+      actionType: "create_task",
+      payload: { title: "Write brief", dueDate: "2026-04-20", priority: "medium" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/v1/larry/events/${eventId}/modify/save`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { payloadPatch: { dueDate: "2026-04-30" }, executeImmediately: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.executed).toBe(true);
+    expect(body.event.eventType).toBe("accepted");
+
+    // Event row has previous_payload + modified_by set.
+    const row = await app.db.queryTenant(tenantId,
+      `SELECT previous_payload, modified_by_user_id, payload FROM larry_events WHERE id = $1`,
+      [eventId],
+    );
+    expect(row[0].previous_payload.dueDate).toBe("2026-04-20");
+    expect(row[0].payload.dueDate).toBe("2026-04-30");
+    expect(row[0].modified_by_user_id).toBe(userId);
+  });
+
+  it("409 when event was accepted in another tab between open and save", async () => {
+    const app = await buildTestApp();
+    const { tenantId, token, userId } = await seedTenantAndUser(app);
+    const eventId = await seedSuggestedEvent(app, tenantId, userId, {
+      actionType: "create_task", payload: { title: "X" }, eventType: "accepted",
+    });
+    const res = await app.inject({
+      method: "POST", url: `/v1/larry/events/${eventId}/modify/save`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { payloadPatch: { title: "Y" }, executeImmediately: true },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("422 on patch with disallowed field", async () => {
+    const app = await buildTestApp();
+    const { tenantId, token, userId } = await seedTenantAndUser(app);
+    const eventId = await seedSuggestedEvent(app, tenantId, userId, {
+      actionType: "create_task", payload: { title: "X" },
+    });
+    const res = await app.inject({
+      method: "POST", url: `/v1/larry/events/${eventId}/modify/save`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { payloadPatch: { taskId: "abc" }, executeImmediately: true },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json().message).toMatch(/not editable/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+- [ ] **Step 3: Add the handler**
+
+Inside `registerLarryRoutes` (below the existing `/events/:id/modify` handler), add:
+
+```ts
+const ModifySaveBodySchema = z.object({
+  payloadPatch: z.record(z.unknown()),
+  executeImmediately: z.boolean(),
+  conversationId: z.string().uuid().optional(),
+});
+
+fastify.post(
+  "/events/:id/modify/save",
+  { preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm"])] },
+  async (request, reply) => {
+    const tenantId = request.user.tenantId;
+    const actorUserId = request.user.userId;
+    const { id } = request.params as { id: string };
+    if (!isUuidShape(id)) throw fastify.httpErrors.badRequest("Invalid event id.");
+
+    const parsed = ModifySaveBodySchema.safeParse(request.body ?? {});
+    if (!parsed.success) {
+      throw fastify.httpErrors.badRequest(parsed.error.issues[0]?.message ?? "Invalid body.");
+    }
+    const { payloadPatch, executeImmediately } = parsed.data;
+
+    // Re-fetch under the suggested guard — race-safe against concurrent accept.
+    const event = await getLarryEventForMutation(fastify.db, tenantId, id);
+    if (!event) throw fastify.httpErrors.notFound("Event not found.");
+    await assertProjectAccessOrThrow({
+      tenantId, userId: actorUserId, tenantRole: request.user.role,
+      projectId: event.projectId, mode: "manage", requireWritable: true,
+    });
+    if (event.eventType !== "suggested") {
+      throw fastify.httpErrors.conflict("This suggestion was already resolved elsewhere.");
+    }
+
+    try {
+      assertPatchIsAllowed(event.actionType, payloadPatch);
+    } catch (err) {
+      throw fastify.httpErrors.unprocessableEntity(err instanceof Error ? err.message : String(err));
+    }
+
+    const nextPayload = applyPatch(event.payload ?? {}, payloadPatch);
+
+    // Persist the edit. Transaction: snapshot previous_payload + update payload,
+    // then (if executeImmediately) run the accept flow inside the same transaction
+    // so a failed executor rolls back the edit.
+    const result = await fastify.db.withTenantTransaction(tenantId, async (tx) => {
+      await tx.query(
+        `UPDATE larry_events
+            SET previous_payload    = COALESCE(previous_payload, payload),
+                payload             = $3::jsonb,
+                modified_by_user_id = $4,
+                modified_at         = NOW()
+          WHERE tenant_id = $1 AND id = $2 AND event_type = 'suggested'`,
+        [tenantId, id, JSON.stringify(nextPayload), actorUserId],
+      );
+
+      if (!executeImmediately) return { executed: false, entity: null };
+
+      const updatedEvent = { ...event, payload: nextPayload };
+      const accept = await runAcceptFlow({
+        tenantId, actorUserId, event: updatedEvent,
+        deps: {
+          executeAction: (...args) => executeAction(tx, ...args.slice(1)),
+          markAccepted: (db, t, eid, actor) => markLarryEventAccepted(tx, t, eid, actor),
+          writeCorrection: (fb) => tx.query(
+            `INSERT INTO correction_feedback (tenant_id, action_id, corrected_by_user_id, correction_type, correction_payload)
+             VALUES ($1, $2, $3, 'accepted', $4::jsonb)`,
+            [tenantId, id, actorUserId, JSON.stringify(fb)],
+          ),
+          logger: request.log,
+        },
+      });
+      return { executed: true, entity: accept.entity };
+    });
+
+    const [updated] = await listLarryEventSummaries(fastify.db, tenantId, { ids: [id] });
+    return reply.code(200).send({ event: updated, executed: result.executed, entity: result.entity });
+  },
+);
+```
+
+Add imports at the top: `assertPatchIsAllowed`, `applyPatch` from `@larry/db`; `runAcceptFlow` from `./larry-accept-flow.js`.
+
+If `fastify.db.withTenantTransaction` doesn't exist, check existing usage in `apps/api/src/routes/v1/larry.ts` for the project's transaction pattern and adapt accordingly.
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `cd apps/api && npx vitest run tests/larry-modify-save.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api
+git commit -m "feat(api): add POST /events/:id/modify/save endpoint"
+```
+
+---
+
+### Task 6: New `POST /events/:id/modify/stop` endpoint
+
+**Files:**
+- Modify: `apps/api/src/routes/v1/larry.ts`
+- Create: `apps/api/tests/larry-modify-stop.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/api/tests/larry-modify-stop.test.ts
+import { describe, expect, it } from "vitest";
+import { buildTestApp, seedSuggestedEvent, seedTenantAndUser } from "./helpers/app.js";
+
+describe("POST /v1/larry/events/:id/modify/stop", () => {
+  it("returns 200 and writes an audit log, with no event-state change", async () => {
+    const app = await buildTestApp();
+    const { tenantId, token, userId } = await seedTenantAndUser(app);
+    const eventId = await seedSuggestedEvent(app, tenantId, userId, {
+      actionType: "create_task", payload: { title: "X" },
+    });
+
+    const res = await app.inject({
+      method: "POST", url: `/v1/larry/events/${eventId}/modify/stop`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const row = await app.db.queryTenant(tenantId,
+      `SELECT event_type FROM larry_events WHERE id = $1`, [eventId],
+    );
+    expect(row[0].event_type).toBe("suggested");
+
+    const audit = await app.db.queryTenant(tenantId,
+      `SELECT action_type FROM audit_logs WHERE object_id = $1 ORDER BY created_at DESC LIMIT 1`,
+      [eventId],
+    );
+    expect(audit[0].action_type).toBe("larry.event.modify_cancelled");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+- [ ] **Step 3: Add the handler**
+
+```ts
+fastify.post(
+  "/events/:id/modify/stop",
+  { preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm"])] },
+  async (request, reply) => {
+    const tenantId = request.user.tenantId;
+    const actorUserId = request.user.userId;
+    const { id } = request.params as { id: string };
+    if (!isUuidShape(id)) throw fastify.httpErrors.badRequest("Invalid event id.");
+
+    const event = await getLarryEventForMutation(fastify.db, tenantId, id);
+    if (!event) throw fastify.httpErrors.notFound("Event not found.");
+    await assertProjectAccessOrThrow({
+      tenantId, userId: actorUserId, tenantRole: request.user.role,
+      projectId: event.projectId, mode: "manage", requireWritable: true,
+    });
+
+    await writeAuditLog(fastify.db, {
+      tenantId, actorUserId,
+      actionType: "larry.event.modify_cancelled",
+      objectType: "larry_event", objectId: id,
+      details: { actionType: event.actionType },
+    });
+
+    return reply.code(200).send({ ok: true });
+  },
+);
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api
+git commit -m "feat(api): add POST /events/:id/modify/stop endpoint"
+```
+
+---
+
+### Task 7: New `POST /events/:id/modify-chat` endpoint
+
+**Files:**
+- Modify: `apps/api/src/routes/v1/larry.ts`
+- Create: `apps/api/tests/larry-modify-chat.test.ts`
+- (Depends on) AI package work in Task 8; do Task 8 before this step 3.
+
+- [ ] **Step 1: Write failing test (mock the AI)**
+
+```ts
+// apps/api/tests/larry-modify-chat.test.ts
+import { describe, expect, it, vi } from "vitest";
+import { buildTestApp, seedSuggestedEvent, seedTenantAndUser } from "./helpers/app.js";
+
+vi.mock("@larry/ai", async (orig) => {
+  const real = await orig<typeof import("@larry/ai")>();
+  return {
+    ...real,
+    streamModifyChat: async function* () {
+      yield { type: "token", delta: "Pushed the deadline. " };
+      yield { type: "tool_done", name: "apply_modification", success: true,
+              payloadPatch: { dueDate: "2026-04-30" }, summary: "Pushed the deadline to 30 Apr." };
+      yield { type: "done", messageId: "msg-1" };
+    },
+  };
+});
+
+describe("POST /v1/larry/events/:id/modify-chat", () => {
+  it("returns the assistant message and the tool-produced payloadPatch", async () => {
+    const app = await buildTestApp();
+    const { tenantId, token, userId } = await seedTenantAndUser(app);
+    const eventId = await seedSuggestedEvent(app, tenantId, userId, {
+      actionType: "create_task",
+      payload: { title: "X", dueDate: "2026-04-20" },
+    });
+    const res = await app.inject({
+      method: "POST", url: `/v1/larry/events/${eventId}/modify-chat`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { message: "push to 30 Apr", currentPayload: { title: "X", dueDate: "2026-04-20" } },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.payloadPatch).toEqual({ dueDate: "2026-04-30" });
+    expect(body.summary).toMatch(/30 Apr/);
+    expect(body.message).toContain("Pushed the deadline");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+- [ ] **Step 3: Add the handler (after Task 8 ships `streamModifyChat`)**
+
+The handler should:
+1. Validate `{ message: string, currentPayload: Record<string, unknown>, conversationId?: string }`.
+2. Re-fetch event with `event_type = 'suggested'` guard → 409 otherwise.
+3. Create or reuse a `larry_conversations` row titled `Modify: <truncated displayText>`.
+4. Insert the user message via `insertLarryMessage`.
+5. Pull team members (same query as Task 4).
+6. Stream `streamModifyChat({ config, event, currentPayload, teamMembers, messages })` accumulating token text and capturing the first `apply_modification` tool result.
+7. Insert the assistant message.
+8. Return `{ conversationId, messageId, message, payloadPatch, summary, linkedActions: [] }`.
+
+Use the existing global chat flow (`/chat` handler around line 2393) as a template for conversation + message persistence.
+
+- [ ] **Step 4: Run, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api
+git commit -m "feat(api): add POST /events/:id/modify-chat with apply_modification tool"
+```
+
+---
+
+## Phase 4 — AI chat: apply_modification tool
+
+### Task 8: `buildModifySystemPrompt` + `streamModifyChat` in `@larry/ai`
+
+**Files:**
+- Create: `packages/ai/src/modify-chat.ts`
+- Create: `packages/ai/src/modify-chat.test.ts`
+- Modify: `packages/ai/src/index.ts` (export new functions)
+
+- [ ] **Step 1: Write prompt-builder tests**
+
+```ts
+// packages/ai/src/modify-chat.test.ts
+import { describe, expect, it } from "vitest";
+import { buildModifySystemPrompt } from "./modify-chat.js";
+
+describe("buildModifySystemPrompt", () => {
+  it("embeds display text, reasoning, current payload, editable fields, team", () => {
+    const prompt = buildModifySystemPrompt({
+      actionType: "create_task",
+      displayText: "Create task: Draft kickoff email",
+      reasoning: "Kickoff is next Monday.",
+      currentPayload: { title: "Draft kickoff email", dueDate: "2026-04-20", priority: "medium" },
+      editableFields: ["title", "description", "dueDate", "assigneeName", "priority"],
+      teamMembers: [{ displayName: "Anna" }, { displayName: "Priya" }],
+    });
+    expect(prompt).toContain("Create task: Draft kickoff email");
+    expect(prompt).toContain("Kickoff is next Monday.");
+    expect(prompt).toContain('"dueDate": "2026-04-20"');
+    expect(prompt).toMatch(/editable fields[^\n]*dueDate/i);
+    expect(prompt).toContain("Anna");
+    expect(prompt).toContain("Priya");
+    expect(prompt).toMatch(/only call apply_modification/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+- [ ] **Step 3: Implement `buildModifySystemPrompt`**
+
+```ts
+// packages/ai/src/modify-chat.ts
+import { streamText, tool, stepCountIs } from "ai";
+import type { ModelMessage } from "ai";
+import { z } from "zod";
+import type { IntelligenceConfig } from "@larry/shared";
+import { createModel } from "./provider.js";
+import { computeDateContext } from "./chat.js";
+
+export interface ModifyChatContext {
+  actionType: string;
+  displayText: string;
+  reasoning: string;
+  currentPayload: Record<string, unknown>;
+  editableFields: string[];
+  teamMembers: { displayName: string }[];
+}
+
+export function buildModifySystemPrompt(ctx: ModifyChatContext): string {
+  const d = computeDateContext();
+  const team = ctx.teamMembers.map((m) => m.displayName).join(", ") || "(no team members on this project)";
+  return `You are Larry. The user has opened the Modify panel on a pending suggestion and wants to change something before accepting it.
+
+TODAY: ${d.dayOfWeek}, ${d.today}. next Monday = ${d.nextMonday}. next Friday = ${d.nextFriday}.
+
+## THE SUGGESTION BEING MODIFIED
+
+- Action type: ${ctx.actionType}
+- Display text: ${ctx.displayText}
+- Original reasoning: ${ctx.reasoning}
+- Current payload:
+${JSON.stringify(ctx.currentPayload, null, 2)}
+
+## EDITABLE FIELDS
+
+${ctx.editableFields.join(", ")}
+
+You can ONLY change fields in that list. Ignore user requests to change other fields; say what you can and can't change.
+
+## TEAM MEMBERS ON THIS PROJECT
+
+${team}
+
+If the user names someone not on this list, do not silently drop them. Ask who they meant.
+
+## YOUR ONE TOOL
+
+Call \`apply_modification\` exactly once per turn, with only the fields the user's message changes. Use a short past-tense summary ("Pushed deadline to 30 Apr and reassigned to Anna."). If the user's message is a clarifying question with no change, do not call the tool — just answer in prose.
+
+Never call any other tool. This conversation is for modifying one pending suggestion, nothing else.
+
+## STYLE
+
+Direct, short, conversational. Don't restate the whole payload. Don't announce tool calls — call the tool and continue the sentence.`;
+}
+
+export type ModifyChatStreamEvent =
+  | { type: "token"; delta: string }
+  | { type: "tool_done"; name: "apply_modification"; success: boolean; payloadPatch: Record<string, unknown>; summary: string }
+  | { type: "done"; messageId: string }
+  | { type: "error"; message: string };
+
+export async function* streamModifyChat(input: {
+  config: IntelligenceConfig;
+  messages: ModelMessage[];
+  context: ModifyChatContext;
+}): AsyncGenerator<ModifyChatStreamEvent> {
+  const { config, messages, context } = input;
+  if (config.provider === "mock" || !config.apiKey) {
+    yield { type: "token", delta: "(mock modify) no API key configured." };
+    yield { type: "done", messageId: "mock" };
+    return;
+  }
+  const model = createModel(config);
+  const tools = {
+    apply_modification: tool({
+      description: "Apply the user-described change to the pending suggestion's payload. Call exactly once per turn, or zero times for a clarifying question.",
+      inputSchema: z.object({
+        payloadPatch: z.record(z.unknown()).describe("Only the fields that change; keys must be in the editable fields list."),
+        summary: z.string().describe("One short past-tense sentence summarising the change."),
+      }),
+      execute: async (p) => ({ ok: true, payloadPatch: p.payloadPatch, summary: p.summary }),
+    }),
+  };
+  const result = streamText({
+    model, system: buildModifySystemPrompt(context), messages, tools,
+    stopWhen: stepCountIs(2), maxRetries: 1,
+  });
+  for await (const chunk of result.fullStream) {
+    const c = chunk as { type?: string } & Record<string, unknown>;
+    if (c.type === "text-delta") {
+      const text = (c as { text?: string }).text;
+      if (typeof text === "string" && text.length > 0) yield { type: "token", delta: text };
+    } else if (c.type === "tool-result") {
+      const t = c as { toolName: string; output?: { payloadPatch: Record<string, unknown>; summary: string } };
+      if (t.toolName === "apply_modification" && t.output) {
+        yield { type: "tool_done", name: "apply_modification", success: true,
+                payloadPatch: t.output.payloadPatch, summary: t.output.summary };
+      }
+    } else if (c.type === "error") {
+      const e = c as { error: unknown };
+      yield { type: "error", message: e.error instanceof Error ? e.error.message : String(e.error) };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Export and run tests**
+
+Add `export * from "./modify-chat.js";` to `packages/ai/src/index.ts`. Run: `cd packages/ai && npx vitest run src/modify-chat.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ai
+git commit -m "feat(ai): add streamModifyChat with apply_modification tool"
+```
+
+---
+
+## Phase 5 — Next.js proxy routes
+
+### Task 9: Rewrite `/api/workspace/larry/events/[id]/modify` proxy + add 3 new route handlers
+
+**Files:**
+- Modify: `apps/web/src/app/api/workspace/larry/events/[id]/modify/route.ts`
+- Create: `apps/web/src/app/api/workspace/larry/events/[id]/modify/save/route.ts`
+- Create: `apps/web/src/app/api/workspace/larry/events/[id]/modify/stop/route.ts`
+- Create: `apps/web/src/app/api/workspace/larry/events/[id]/modify-chat/route.ts`
+
+- [ ] **Step 1: Rewrite `modify/route.ts`**
+
+The existing file already proxies to `/v1/larry/events/${id}/modify`. The upstream shape changed (returns `{ eventId, actionType, displayText, reasoning, payload, editableFields, teamMembers }` now). The proxy itself doesn't need structural changes beyond removing the hard-coded `body: JSON.stringify({})` (keep it — Fastify accepts empty body).
+
+Confirm via test:
+
+```ts
+// apps/web/e2e/modify-proxy.spec.ts — deferred to Task 14.
+```
+
+No code change needed if existing file already proxies generically. Otherwise replace with:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { persistSession, proxyApiRequest } from "@/lib/workspace-proxy";
+
+export async function POST(_request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await context.params;
+  const result = await proxyApiRequest(session, `/v1/larry/events/${id}/modify`, { method: "POST", body: JSON.stringify({}) });
+  if (result.session) await persistSession(result.session);
+  return NextResponse.json(result.body, { status: result.status });
+}
+```
+
+- [ ] **Step 2: Create `modify/save/route.ts`**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { persistSession, proxyApiRequest } from "@/lib/workspace-proxy";
+
+export async function POST(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { id } = await context.params;
+  const body = await request.text();
+  const result = await proxyApiRequest(session, `/v1/larry/events/${id}/modify/save`, { method: "POST", body });
+  if (result.session) await persistSession(result.session);
+  return NextResponse.json(result.body, { status: result.status });
+}
+```
+
+- [ ] **Step 3: Create `modify/stop/route.ts`**
+
+Same shape as save, targeting `/v1/larry/events/${id}/modify/stop`.
+
+- [ ] **Step 4: Create `modify-chat/route.ts`**
+
+Same shape, targeting `/v1/larry/events/${id}/modify-chat`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/api/workspace/larry/events
+git commit -m "feat(web): add Next.js proxy routes for Modify save/stop/modify-chat"
+```
+
+---
+
+## Phase 6 — React Modify panel
+
+### Task 10: `useModifyPanel` hook
+
+**Files:**
+- Create: `apps/web/src/hooks/useModifyPanel.ts`
+- Create: `apps/web/src/hooks/useModifyPanel.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Testing approach: mock `fetch`, render a dummy consumer of the hook, assert state transitions (`idle → loading → editing → saving → idle|conflict`), and that `applyPatch` merges correctly.
+
+```tsx
+// apps/web/src/hooks/useModifyPanel.test.tsx
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useModifyPanel } from "./useModifyPanel.js";
+
+describe("useModifyPanel", () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it("open() fetches the snapshot and transitions to 'editing'", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      eventId: "e1", actionType: "create_task",
+      displayText: "Create task: X", reasoning: "why",
+      payload: { title: "X", dueDate: "2026-04-20" },
+      editableFields: ["title", "description", "dueDate", "assigneeName", "priority"],
+      teamMembers: [{ userId: "u", displayName: "Anna", email: "a@x" }],
+    }), { status: 200 })));
+
+    const { result } = renderHook(() => useModifyPanel());
+    await act(() => result.current.open("e1"));
+    await waitFor(() => expect(result.current.state).toBe("editing"));
+    expect(result.current.snapshot?.payload.dueDate).toBe("2026-04-20");
+  });
+
+  it("applyPatch merges into the working payload and updates the diff", async () => {
+    // ... fetch stub same as above ...
+    const { result } = renderHook(() => useModifyPanel());
+    await act(() => result.current.open("e1"));
+    act(() => result.current.applyPatch({ dueDate: "2026-04-30" }));
+    expect(result.current.workingPayload?.dueDate).toBe("2026-04-30");
+    expect(result.current.diff).toEqual([
+      { key: "dueDate", before: "2026-04-20", after: "2026-04-30" },
+    ]);
+  });
+
+  it("saveAndExecute posts the patch and returns the server result", async () => {
+    // stub snapshot fetch + save fetch
+    // ...
+  });
+
+  it("stop() calls the stop endpoint and returns to idle", async () => { /* ... */ });
+
+  it("on 409 save response, transitions to 'conflict'", async () => { /* ... */ });
+});
+```
+
+Flesh each test body with full stubs when implementing.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+- [ ] **Step 3: Implement the hook**
+
+```ts
+// apps/web/src/hooks/useModifyPanel.ts
+"use client";
+import { useCallback, useMemo, useState } from "react";
+
+type PanelState = "idle" | "loading" | "editing" | "saving" | "conflict";
+
+export interface ModifySnapshot {
+  eventId: string; actionType: string; displayText: string; reasoning: string;
+  payload: Record<string, unknown>;
+  editableFields: string[];
+  teamMembers: { userId: string; displayName: string; email: string }[];
+}
+
+export interface DiffEntry { key: string; before: unknown; after: unknown }
+
+export function useModifyPanel() {
+  const [state, setState] = useState<PanelState>("idle");
+  const [snapshot, setSnapshot] = useState<ModifySnapshot | null>(null);
+  const [workingPayload, setWorkingPayload] = useState<Record<string, unknown> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const open = useCallback(async (eventId: string) => {
+    setState("loading"); setError(null);
+    const res = await fetch(`/api/workspace/larry/events/${eventId}/modify`, { method: "POST" });
+    if (!res.ok) {
+      setState("idle");
+      setError(res.status === 409 ? "This suggestion was already resolved." : "Couldn't open Modify.");
+      return;
+    }
+    const snap = (await res.json()) as ModifySnapshot;
+    setSnapshot(snap); setWorkingPayload(snap.payload); setState("editing");
+  }, []);
+
+  const applyPatch = useCallback((patch: Record<string, unknown>) => {
+    setWorkingPayload((prev) => (prev ? { ...prev, ...patch } : prev));
+  }, []);
+
+  const diff = useMemo<DiffEntry[]>(() => {
+    if (!snapshot || !workingPayload) return [];
+    const out: DiffEntry[] = [];
+    for (const key of Object.keys(workingPayload)) {
+      if (snapshot.payload[key] !== workingPayload[key]) {
+        out.push({ key, before: snapshot.payload[key], after: workingPayload[key] });
+      }
+    }
+    return out;
+  }, [snapshot, workingPayload]);
+
+  const saveAndExecute = useCallback(async () => {
+    if (!snapshot || !workingPayload) return null;
+    setState("saving"); setError(null);
+    const patch: Record<string, unknown> = {};
+    for (const { key, after } of diff) patch[key] = after;
+    const res = await fetch(`/api/workspace/larry/events/${snapshot.eventId}/modify/save`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ payloadPatch: patch, executeImmediately: true }),
+    });
+    if (res.status === 409) { setState("conflict"); return null; }
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      setError(body?.message ?? "Save failed."); setState("editing"); return null;
+    }
+    const body = await res.json();
+    setState("idle"); setSnapshot(null); setWorkingPayload(null);
+    return body;
+  }, [diff, snapshot, workingPayload]);
+
+  const stop = useCallback(async () => {
+    if (snapshot) {
+      await fetch(`/api/workspace/larry/events/${snapshot.eventId}/modify/stop`, { method: "POST" });
+    }
+    setState("idle"); setSnapshot(null); setWorkingPayload(null); setError(null);
+  }, [snapshot]);
+
+  const sendChat = useCallback(async (message: string): Promise<{ text: string; summary?: string } | null> => {
+    if (!snapshot || !workingPayload) return null;
+    const res = await fetch(`/api/workspace/larry/events/${snapshot.eventId}/modify-chat`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message, currentPayload: workingPayload }),
+    });
+    if (!res.ok) { setError("Chat failed."); return null; }
+    const body = await res.json() as { message: string; payloadPatch?: Record<string, unknown>; summary?: string };
+    if (body.payloadPatch) applyPatch(body.payloadPatch);
+    return { text: body.message, summary: body.summary };
+  }, [snapshot, workingPayload, applyPatch]);
+
+  return { state, snapshot, workingPayload, diff, error, open, applyPatch, saveAndExecute, stop, sendChat };
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks
+git commit -m "feat(web): add useModifyPanel hook for the Modify panel state machine"
+```
+
+---
+
+### Task 11: `ModifyDiff` component
+
+**Files:**
+- Create: `apps/web/src/app/workspace/_components/ModifyDiff.tsx`
+
+- [ ] **Step 1: Component**
+
+```tsx
+"use client";
+import type { DiffEntry } from "@/hooks/useModifyPanel";
+
+const LABELS: Record<string, string> = {
+  title: "Title", description: "Description", dueDate: "Due date",
+  assigneeName: "Assignee", priority: "Priority", newDeadline: "New deadline",
+  newOwnerName: "New owner", newStatus: "New status", newRiskLevel: "Risk level",
+  riskLevel: "Risk level", to: "To", subject: "Subject", body: "Body",
+};
+
+function fmt(v: unknown): string {
+  if (v == null || v === "") return "—";
+  if (typeof v === "string") return v;
+  return JSON.stringify(v);
+}
+
+export function ModifyDiff({ entries }: { entries: DiffEntry[] }) {
+  if (entries.length === 0) {
+    return <p className="text-sm text-neutral-500">No changes yet.</p>;
+  }
+  return (
+    <ul className="space-y-1 text-sm">
+      {entries.map((e) => (
+        <li key={e.key} className="flex flex-wrap items-baseline gap-2">
+          <span className="font-medium text-neutral-700">{LABELS[e.key] ?? e.key}:</span>
+          <span className="text-neutral-500 line-through">{fmt(e.before)}</span>
+          <span aria-hidden>→</span>
+          <span className="text-[#6c44f6] font-medium">{fmt(e.after)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/app/workspace/_components/ModifyDiff.tsx
+git commit -m "feat(web): add ModifyDiff component"
+```
+
+---
+
+### Task 12: `ModifyPanel` + per-type field components
+
+**Files:**
+- Create: `apps/web/src/app/workspace/_components/ModifyPanel.tsx`
+- Create: `apps/web/src/app/workspace/_components/modify-fields/CreateTaskFields.tsx`
+- Create: `apps/web/src/app/workspace/_components/modify-fields/ChangeDeadlineFields.tsx`
+- Create: `apps/web/src/app/workspace/_components/modify-fields/ChangeTaskOwnerFields.tsx`
+- Create: `apps/web/src/app/workspace/_components/modify-fields/UpdateTaskStatusFields.tsx`
+- Create: `apps/web/src/app/workspace/_components/modify-fields/FlagTaskRiskFields.tsx`
+- Create: `apps/web/src/app/workspace/_components/modify-fields/DraftEmailFields.tsx`
+
+- [ ] **Step 1: Build each field component**
+
+Each is a small uncontrolled-by-parent component: takes `{ payload, onPatch, teamMembers }`, renders the native inputs (`<input type="date">`, `<select>`, `<textarea>`), calls `onPatch({ field: nextValue })` on change. Keep them dumb — no state, no fetches.
+
+Example:
+
+```tsx
+// modify-fields/ChangeDeadlineFields.tsx
+export function ChangeDeadlineFields({
+  payload, onPatch,
+}: { payload: Record<string, unknown>; onPatch: (p: Record<string, unknown>) => void }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="font-medium">New deadline</span>
+      <input type="date"
+        value={typeof payload.newDeadline === "string" ? payload.newDeadline : ""}
+        onChange={(e) => onPatch({ newDeadline: e.target.value })}
+        className="rounded border border-neutral-300 px-2 py-1" />
+    </label>
+  );
+}
+```
+
+Assignee / owner dropdowns pull from `teamMembers` and render an option per member's `displayName`.
+
+- [ ] **Step 2: Build the panel**
+
+```tsx
+// ModifyPanel.tsx
+"use client";
+import { useState } from "react";
+import type { ModifySnapshot, DiffEntry } from "@/hooks/useModifyPanel";
+import { ModifyDiff } from "./ModifyDiff";
+import { CreateTaskFields } from "./modify-fields/CreateTaskFields";
+import { ChangeDeadlineFields } from "./modify-fields/ChangeDeadlineFields";
+import { ChangeTaskOwnerFields } from "./modify-fields/ChangeTaskOwnerFields";
+import { UpdateTaskStatusFields } from "./modify-fields/UpdateTaskStatusFields";
+import { FlagTaskRiskFields } from "./modify-fields/FlagTaskRiskFields";
+import { DraftEmailFields } from "./modify-fields/DraftEmailFields";
+
+const FIELDS_BY_TYPE: Record<string, React.ComponentType<any>> = {
+  create_task: CreateTaskFields,
+  change_deadline: ChangeDeadlineFields,
+  change_task_owner: ChangeTaskOwnerFields,
+  update_task_status: UpdateTaskStatusFields,
+  flag_task_risk: FlagTaskRiskFields,
+  draft_email: DraftEmailFields,
+};
+
+export function ModifyPanel({
+  snapshot, workingPayload, diff, state, error,
+  onPatch, onSend, onSave, onStop,
+}: {
+  snapshot: ModifySnapshot;
+  workingPayload: Record<string, unknown>;
+  diff: DiffEntry[];
+  state: "editing" | "saving" | "conflict";
+  error: string | null;
+  onPatch: (p: Record<string, unknown>) => void;
+  onSend: (msg: string) => Promise<{ text: string; summary?: string } | null>;
+  onSave: () => void;
+  onStop: () => void;
+}) {
+  const [chatInput, setChatInput] = useState("");
+  const [chatLog, setChatLog] = useState<{ who: "you" | "larry"; text: string }[]>([]);
+  const Fields = FIELDS_BY_TYPE[snapshot.actionType];
+
+  async function handleSend(e: React.FormEvent) {
+    e.preventDefault();
+    if (!chatInput.trim()) return;
+    const msg = chatInput.trim();
+    setChatLog((log) => [...log, { who: "you", text: msg }]);
+    setChatInput("");
+    const reply = await onSend(msg);
+    if (reply) setChatLog((log) => [...log, { who: "larry", text: reply.text }]);
+  }
+
+  if (state === "conflict") {
+    return (
+      <div className="rounded border border-amber-400 bg-amber-50 p-4 text-sm">
+        This suggestion was already resolved in another tab. Refresh the Action Centre.
+        <button onClick={onStop} className="ml-2 underline">Close</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-neutral-300 bg-white p-4 shadow-sm space-y-4">
+      <header className="text-sm text-neutral-600">
+        Editing: <span className="font-medium">{snapshot.displayText}</span>
+      </header>
+
+      {Fields ? (
+        <Fields payload={workingPayload} onPatch={onPatch} teamMembers={snapshot.teamMembers} />
+      ) : (
+        <p className="text-sm text-neutral-500">This action type has no quick fields. Use chat below.</p>
+      )}
+
+      <form onSubmit={handleSend} className="flex gap-2">
+        <input value={chatInput} onChange={(e) => setChatInput(e.target.value)}
+          placeholder="Anything a field can't capture? Describe the change…"
+          className="flex-1 rounded border border-neutral-300 px-2 py-1 text-sm" />
+        <button type="submit" className="rounded bg-neutral-800 px-3 py-1 text-sm text-white">Tell Larry</button>
+      </form>
+      {chatLog.length > 0 && (
+        <div className="space-y-1 text-sm">
+          {chatLog.map((entry, i) => (
+            <div key={i}><strong>{entry.who === "you" ? "You" : "Larry"}:</strong> {entry.text}</div>
+          ))}
+        </div>
+      )}
+
+      <section className="rounded border border-neutral-200 bg-neutral-50 p-3">
+        <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-neutral-500">Review</h4>
+        <ModifyDiff entries={diff} />
+      </section>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="flex gap-2">
+        <button onClick={onSave} disabled={state === "saving" || diff.length === 0}
+          className="rounded bg-[#6c44f6] px-3 py-1 text-sm text-white disabled:opacity-50">
+          {state === "saving" ? "Saving…" : "Save & execute"}
+        </button>
+        <button onClick={onStop} className="rounded border border-neutral-300 px-3 py-1 text-sm">
+          Stop
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/workspace/_components
+git commit -m "feat(web): add ModifyPanel + per-type field components"
+```
+
+---
+
+### Task 13: Wire Action Centre and Project Overview to render the panel
+
+**Files:**
+- Modify: `apps/web/src/hooks/useLarryActionCentre.ts` (the `modify` function currently navigates; make it the hook-orchestrated open instead)
+- Modify: `apps/web/src/app/workspace/actions/page.tsx` (line 679 area + render panel below card when `modifyingEventId === event.id`)
+- Modify: `apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx` (line 1273 area + render panel)
+
+- [ ] **Step 1: In `useLarryActionCentre.ts`**
+
+Replace the body of the existing `modify` callback (around line 215) with a simpler one that **does not** fetch — the panel's own `useModifyPanel` hook will do the fetch. The hook-level `modify` becomes a state signal:
+
+```ts
+const [modifyingEventId, setModifyingEventId] = useState<string | null>(null);
+const modify = useCallback((id: string) => { setModifyingEventId(id); }, []);
+const stopModifying = useCallback(() => { setModifyingEventId(null); }, []);
+```
+
+Return `modifyingEventId` and `stopModifying` in the hook's return value.
+
+- [ ] **Step 2: In `actions/page.tsx`**
+
+Below the existing action card JSX where buttons are rendered (around line 679), conditionally render the panel:
+
+```tsx
+{modifyingEventId === event.id && (
+  <ModifyPanelContainer eventId={event.id}
+    onFinished={async () => { stopModifying(); await refresh(); }} />
+)}
+```
+
+Create a small `ModifyPanelContainer` inline that owns a local `useModifyPanel()`, calls `open(eventId)` on mount, and renders `<ModifyPanel />` with the hook's state. On successful save or stop, calls `onFinished`. Extract to its own file if it grows beyond ~40 lines.
+
+Update the Modify button onClick to call `modify(event.id)` (no await, no navigation).
+
+- [ ] **Step 3: Same wiring in `ProjectWorkspaceView.tsx`**
+
+- [ ] **Step 4: Remove the `buildFullChatHref(..., "modify")` branch**
+
+The chat launch for modify is gone — the panel replaces it. Remove any code paths that generate `launch=modify` URLs (`/workspace/larry/page.tsx` may also consume the `launch=modify` search param; delete that handling too).
+
+Run `grep -rn "launch=modify\|launch.*modify" apps/web/src` before removing to confirm scope.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src
+git commit -m "feat(web): wire Modify button to inline panel instead of chat redirect"
+```
+
+---
+
+## Phase 7 — Feature flag, E2E, rollout
+
+### Task 14: Feature flag `MODIFY_PANEL_V2`
+
+**Files:**
+- Modify: `apps/web/src/hooks/useLarryActionCentre.ts`
+- Modify: `apps/api/src/routes/v1/larry.ts`
+
+- [ ] **Step 1: Web flag**
+
+Read `process.env.NEXT_PUBLIC_MODIFY_PANEL_V2` — when falsy, the Modify button stays hidden (do not fall back to the old chat redirect; the old code path is being deleted).
+
+- [ ] **Step 2: API flag**
+
+Not strictly needed — the API routes are additive / backwards-incompatible (old `/modify` return shape is replaced). If an extra safety margin is wanted, have the new `/modify/save` return 503 when `process.env.MODIFY_PANEL_V2 !== "1"` — but that complicates testing. Default to **flag is web-only.**
+
+- [ ] **Step 3: Add flag defaults to `.env.example` and Vercel**
+
+`.env.example`:
+```
+NEXT_PUBLIC_MODIFY_PANEL_V2=1
+```
+
+Per `larry-testing-tools` memory, `vercel env add` against preview + prod to set `NEXT_PUBLIC_MODIFY_PANEL_V2=1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.example apps/web/src/hooks/useLarryActionCentre.ts
+git commit -m "feat(web): gate Modify panel behind NEXT_PUBLIC_MODIFY_PANEL_V2"
+```
+
+---
+
+### Task 15: Playwright E2E
+
+**Files:**
+- Create: `apps/web/e2e/modify-action.spec.ts`
+
+- [ ] **Step 1: Write the four scenarios from spec §9.3**
+
+```ts
+// apps/web/e2e/modify-action.spec.ts
+import { test, expect } from "@playwright/test";
+import { login, seedSuggestion } from "./helpers.js";
+
+test.describe("Modify action", () => {
+  test("quick-edit deadline, save and execute", async ({ page }) => {
+    await login(page);
+    const eventId = await seedSuggestion({ actionType: "create_task",
+      payload: { title: "Write brief", dueDate: "2026-04-20", priority: "medium" } });
+    await page.goto("/workspace/actions");
+    await page.getByTestId(`action-modify-${eventId}`).click();
+    await page.getByLabel("Due date").fill("2026-04-30");
+    await expect(page.getByText("Due date: 2026-04-20 → 2026-04-30")).toBeVisible();
+    await page.getByRole("button", { name: "Save & execute" }).click();
+    await expect(page.getByTestId(`action-row-${eventId}`)).toBeHidden();
+  });
+
+  test("chat-driven edit", async ({ page }) => { /* ... */ });
+  test("stop reverts panel, original stays pending", async ({ page }) => { /* ... */ });
+  test("concurrent accept → conflict banner", async ({ page, browser }) => { /* ... */ });
+});
+```
+
+Flesh out each when implementing. `seedSuggestion` is a Playwright-side helper that POSTs directly to the API with a test admin token — pattern already present in other e2e specs.
+
+- [ ] **Step 2: Deploy preview, run tests against it**
+
+```bash
+git push
+# Wait for Vercel preview + Railway deploy (monitor via `vercel inspect` / MCP)
+npx playwright test apps/web/e2e/modify-action.spec.ts --reporter=list
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e
+git commit -m "test(e2e): cover Modify panel flows"
+```
+
+---
+
+### Task 16: Manual QA + notes
+
+**Files:**
+- Create: `docs/reports/qa-2026-04-15-modify/README.md`
+
+- [ ] **Step 1: QA script**
+
+For each of the 6 modifiable action types, manually:
+1. Seed a suggestion (or wait for a real one in the Groq budget per `larry-groq-free-tier-tpd` — prefer seeding to preserve TPD).
+2. Click Modify. Confirm panel opens, card greys out, Accept/Dismiss disabled on source card.
+3. Change one field. Confirm diff updates live.
+4. Click Save & execute. Confirm card disappears, task/email/etc. reflects edited values.
+5. Seed another, open Modify, type in chat: "<scenario appropriate to type>". Confirm Larry's reply and diff update.
+6. Seed another, open Modify, click Stop. Confirm card returns to normal with original payload.
+
+Document anomalies in `docs/reports/qa-2026-04-15-modify/NOTES.md`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/reports/qa-2026-04-15-modify
+git commit -m "docs(qa): record Modify panel manual QA notes (2026-04-15)"
+```
+
+---
+
+## Done criteria
+
+- Migration 020 applied in preview + prod.
+- All Phase 1-2 unit tests green in CI.
+- Phase 3 API integration tests green in CI.
+- Playwright spec (Task 15) green on preview.
+- Manual QA script (Task 16) passed for at least 3 action types on prod.
+- `NEXT_PUBLIC_MODIFY_PANEL_V2=1` set in Vercel preview + prod envs.
+- Old `launch=modify` chat entrypoint removed (confirm with grep).
+
+---
+
+## Self-review notes
+
+- Spec §§1-10 are all covered; §11 (open questions) left open.
+- `withTenantTransaction` assumed to exist — if the codebase uses a different pattern (e.g. a top-level `db.transaction`), Task 5 Step 3 should mirror whatever pattern the accept handler already uses.
+- Task 3 (refactoring accept) is the riskiest — it touches a 245-line handler with retry branches. Keep the regression test (Step 5) as a gate before moving on.
+- Tasks 4 and 7 depend on `seedSuggestedEvent` test helper; if absent, extend `apps/api/tests/helpers/app.ts` as the first action of Task 4.
+- Task 12 intentionally keeps field components small (~15 lines each). Resist adding validation UI there — validation lives at the API boundary (Task 5).
+- Rollback plan: set `NEXT_PUBLIC_MODIFY_PANEL_V2=0`; Modify button disappears; API endpoints remain but are unreachable from UI. No DB rollback needed (columns are nullable and additive).

--- a/docs/superpowers/specs/2026-04-15-modify-action-design.md
+++ b/docs/superpowers/specs/2026-04-15-modify-action-design.md
@@ -1,0 +1,278 @@
+# Modify Action — Design
+
+**Date:** 2026-04-15
+**Status:** Approved (brainstorm 2026-04-15)
+**Author:** Fergus + Claude
+**Scope:** Action Centre "Modify" button on suggested Larry events
+
+---
+
+## 1. Problem
+
+Clicking **Modify** on a suggested action in the Action Centre (both the global `/workspace/actions` page and the per-project Action Box) today drops the user into a Larry chat with a canned opener. From there:
+
+- The source suggestion is **dismissed immediately** (`markLarryEventDismissed`, reason `modify-superseded`) — the user loses the original if they abandon the chat.
+- Larry's chat LLM has no tool that means "update the pending suggestion." Its toolbox — `create_task`, `change_deadline`, `change_task_owner`, etc. — operates on existing `tasks` rows via `taskId`. The thing being modified is a *pending suggestion*, not a task.
+- The LLM typically responds by (a) calling `create_task` and leaving a duplicate suggestion floating, (b) calling `change_deadline` with a hallucinated/stale `taskId` → 422, or (c) giving up and writing generic prose.
+
+The capability genuinely does not exist. Users report "Modify does nothing useful."
+
+## 2. Goals
+
+1. **Modify means modify.** Clicking Modify produces an edited version of the suggestion that can be saved and executed, without routing through task mutation tools that assume the action has already happened.
+2. **Light edits should be light.** Changing a deadline shouldn't require a chat round-trip.
+3. **Heavy edits stay in chat.** "Rewrite the description, split into two tasks" should still work.
+4. **Reversible.** If the user changes their mind mid-edit, the original suggestion is not lost.
+5. **One consent per edit.** Saving the edited version *is* the accept. No "save, then accept again."
+6. **Auditable.** `previous_payload` + `modified_by` + `modified_at` is recorded on the event row so before/after is recoverable.
+
+## 3. Non-goals
+
+- Multi-user concurrent editing of the same suggestion (drafts/locking). Larry is effectively single-PM-per-tenant; last-write-wins is fine.
+- Preserving rejected edits across sessions ("resume your draft from yesterday"). If the user hits Stop or navigates away, the edit is discarded.
+- Modifying `send_reminder` events (they auto-execute and never appear as suggestions).
+- Modifying `accepted` or `dismissed` events. Only `suggested` events are modifiable.
+
+## 4. UX
+
+### 4.1 Entry points
+
+Two existing buttons fire this flow:
+
+- `/workspace/actions` page — action card in the global Action Centre (`apps/web/src/app/workspace/actions/page.tsx:679`).
+- Per-project Action Box (`apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx:1273`).
+
+Both currently call the `modify(event.id)` hook from `useLarryActionCentre.ts`. That hook today navigates to the chat; it will instead open the new **Modify panel** inline on the card (or as a side drawer on narrow screens — Tailwind breakpoint decision at implementation time).
+
+### 4.2 Modify panel
+
+Opening the panel puts the source card into an **"editing" visual state**: muted background, "You are editing this" badge, Accept / Dismiss / Modify buttons disabled. The original `larry_events` row is *not* touched — event_type stays `suggested`.
+
+The panel contains, for every action type:
+
+1. **Quick-edit fields** — native controls for the structured fields in the payload. Per type:
+   - `create_task`: title (input), description (textarea), dueDate (date picker), assigneeName (select from team), priority (select).
+   - `change_deadline`: newDeadline (date picker).
+   - `change_task_owner`: newOwnerName (select from team).
+   - `update_task_status`: newStatus (select), newRiskLevel (select).
+   - `flag_task_risk`: riskLevel (select).
+   - `draft_email`: to (input), subject (input), body (textarea).
+
+   The assignee / owner select pulls from the project's team list to prevent re-introducing the "Marcus isn't on the team" bug.
+
+2. **"Tell Larry in words" chat strip** — a single-line input with placeholder *"Anything a field can't capture? Describe the change…"*. Sends the user's message + the current payload snapshot to a new dedicated chat endpoint (`POST /v1/larry/events/:id/modify-chat`) that runs the LLM with a single tool: `apply_modification` (see §6.2). Larry returns natural-language acknowledgement plus a proposed payload diff.
+
+3. **Review area** — shows the current edited payload as a diff against the original (`Deadline: Apr 23 → Apr 30`, `Assignee: Priya → Anna`). Updated live as fields or chat produce changes.
+
+4. **Action row** — two buttons:
+   - **Save & execute** — applies the edits to the event row, then runs the existing `/events/:id/accept` handler. Panel closes. Card leaves Action Centre as normal.
+   - **Stop** — discards all pending edits, closes the panel, source card returns to normal pending state. No database mutation beyond optionally ending the modify chat conversation if one was started.
+
+### 4.3 Visual states on the source card
+
+| State | Source card appearance |
+|---|---|
+| Not being modified | Normal card with Accept / Modify / Dismiss buttons. |
+| Panel open (editing) | Muted background, "You are editing" chip, buttons disabled. |
+| After Save & execute | Card disappears from pending list (standard accept flow). |
+| After Stop | Returns to "Not being modified" state. |
+
+## 5. Data model
+
+### 5.1 Schema change
+
+New migration `020_larry_event_modifications.sql`:
+
+```sql
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS previous_payload   JSONB,
+  ADD COLUMN IF NOT EXISTS modified_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS modified_at        TIMESTAMPTZ;
+
+COMMENT ON COLUMN larry_events.previous_payload IS
+  'Snapshot of payload before the most recent user edit via Modify. NULL if the event has never been modified.';
+```
+
+No new indexes — these are audit columns, not query columns.
+
+### 5.2 Semantics
+
+- When a Modify panel opens, **no DB write happens**. Editing is purely client-side until Save or Stop.
+- On Save & execute:
+  1. Begin transaction.
+  2. `UPDATE larry_events SET previous_payload = payload, payload = $new, modified_by_user_id = $actor, modified_at = NOW() WHERE id = $id AND event_type = 'suggested'`.
+  3. Re-run the existing accept path (`executeAction` + `markLarryEventAccepted`) inside the same transaction.
+  4. Commit.
+- On Stop: no DB write. If a modify-chat conversation was created, it remains (users can read chat history later), but it is **not linked to the event** — the event is back to its original state.
+
+### 5.3 What happens if the LLM-generated context is stale
+
+Scan cadence + long edit sessions mean the suggestion could be re-issued by a scheduled run while the user edits. Mitigation:
+
+- `/events/:id/modify-chat` and the Save endpoint both re-fetch the event with `event_type = 'suggested'` guard. If the event was accepted/dismissed elsewhere (e.g. Accept on another tab), Save returns **409 Conflict** with a clear message; the panel shows "This suggestion was already accepted in another tab" and offers a Close button. No partial state.
+
+## 6. API
+
+### 6.1 Modified endpoints
+
+**`POST /v1/larry/events/:id/modify`** (changed)
+
+Current behaviour (dismiss original + open chat) is **replaced**. The new contract:
+
+- No DB write. Returns the suggestion's current payload, the list of editable fields for its action type, and the team member list for the project.
+- Response shape:
+
+  ```ts
+  {
+    eventId: string;
+    actionType: string;
+    displayText: string;
+    reasoning: string;
+    payload: Record<string, unknown>;
+    editableFields: ('title'|'description'|'dueDate'|'assigneeName'|'priority'|'newDeadline'|'newOwnerName'|'newStatus'|'newRiskLevel'|'riskLevel'|'to'|'subject'|'body')[];
+    teamMembers: { userId: string; displayName: string; email: string }[];
+  }
+  ```
+
+- Role gate unchanged (`admin`, `pm`).
+- 409 if event is not `suggested`.
+
+**`POST /v1/larry/events/:id/modify/save`** (new)
+
+Body:
+
+```ts
+{
+  payloadPatch: Record<string, unknown>;  // fields the user changed
+  executeImmediately: boolean;            // true = Save & execute
+  conversationId?: string;                // if a modify chat was used
+}
+```
+
+- Validates `payloadPatch` keys against the action type's allowed fields (same list as `editableFields`).
+- Merges `payloadPatch` over `payload`.
+- Validates the merged payload with the action type's Zod schema (reusing whatever `executeAction` uses).
+- If `executeImmediately` is true, runs the accept flow transactionally as described in §5.2.
+- If `executeImmediately` is false (future extension; not exposed in UI initially), just persists the edit and keeps the event pending.
+- Response: `{ event: LarryEventSummary, executed: boolean, documentId?: string, entity?: unknown }` — shape-compatible with the existing accept response.
+
+**`POST /v1/larry/events/:id/modify/stop`** (new)
+
+Idempotent no-op on the DB. Exists only so the frontend has a durable "cancel" hook for analytics / audit log. Writes one `audit_logs` row (`larry.event.modify_cancelled`). 200 always.
+
+### 6.2 New chat endpoint: `POST /v1/larry/events/:id/modify-chat`
+
+Dedicated endpoint so we don't muddle the general `/chat` tools with a modification-only tool.
+
+Body: `{ message: string, currentPayload: Record<string, unknown>, conversationId?: string }`.
+
+Behaviour:
+
+1. If no `conversationId`, create a conversation titled `Modify: <truncated displayText>` linked to the event's `projectId`.
+2. Insert user message.
+3. Run `streamText` with a **single tool**, `apply_modification`:
+
+   ```ts
+   apply_modification: tool({
+     description: 'Apply the user-described change(s) to the pending suggestion payload. Call exactly once per user turn, or zero times if the user is asking a clarifying question.',
+     inputSchema: z.object({
+       payloadPatch: z.record(z.unknown()).describe('Fields to change, keyed by payload field name. Only include fields that change.'),
+       summary: z.string().describe('One short sentence describing the change, in past tense. E.g. "Pushed the deadline to 30 Apr and reassigned to Anna."'),
+     }),
+     execute: async (p) => ({ ok: true, patch: p.payloadPatch, summary: p.summary }),
+   })
+   ```
+
+4. System prompt is a stripped-down version of the main chat prompt: no date/project recap, just:
+   - The suggestion's `displayText`, `reasoning`, current payload (pretty-printed).
+   - The editable-fields list for the action type.
+   - The team list (display names) for assignee/owner resolution.
+   - Rules: only call `apply_modification`; never call other tools; refuse to change unknown fields; ask a clarifying question if the user is ambiguous.
+
+5. Response: same shape as the main chat, plus `payloadPatch` and `summary` if the tool was called. The frontend merges the patch into the in-memory edit state.
+
+Role gate: `admin`, `pm` (matches existing modify endpoint).
+
+### 6.3 Endpoints removed / decommissioned
+
+- The current `POST /v1/larry/events/:id/modify` return shape (`{ conversationId, eventId }`) is a breaking change to the new shape. Frontend and API ship together; no external consumers. No deprecation window needed.
+- The auto-dismiss-on-modify behaviour is removed. Tests asserting this (if any — search confirms only audit-log tests touch it) will be updated.
+
+## 7. Frontend changes
+
+### 7.1 New files
+
+- `apps/web/src/app/workspace/_components/ModifyPanel.tsx` — the panel body. Props: `{ event, onSave(patch, execute), onStop(), teamMembers }`.
+- `apps/web/src/app/workspace/_components/ModifyPanelFields/*` — one small component per action type rendering its structured fields.
+- `apps/web/src/app/workspace/_components/ModifyDiff.tsx` — renders before/after as `Field: old → new` lines.
+- `apps/web/src/hooks/useModifyPanel.ts` — local state machine (`idle | loading | editing | saving | conflict`), chat send/receive, patch merge.
+- Next.js route handlers:
+  - `apps/web/src/app/api/workspace/larry/events/[id]/modify/route.ts` — **rewrite** to proxy new GET-equivalent POST.
+  - `.../modify/save/route.ts` — new.
+  - `.../modify/stop/route.ts` — new.
+  - `.../modify-chat/route.ts` — new.
+
+### 7.2 Changed files
+
+- `useLarryActionCentre.ts` — `modify()` no longer navigates. Returns the editable snapshot. Callers open the panel instead of routing.
+- `apps/web/src/app/workspace/actions/page.tsx` — swap navigation for panel rendering.
+- `apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx` — same swap.
+
+### 7.3 Styling
+
+Reuse Larry palette tokens per `larry-design-decisions` memory (primary `#6c44f6`). Panel uses existing card chrome. Diff lines use a muted semantic colour for removed, accent for added. No new design tokens.
+
+## 8. Error handling
+
+| Condition | Handling |
+|---|---|
+| Event already accepted/dismissed between open and save (409) | Panel shows "This suggestion was already resolved elsewhere." Close button only. |
+| Payload validation fails | Inline error under the offending field (and a top-level banner if the chat produced an invalid patch). Save button disabled until fields are valid. |
+| Chat LLM refuses / calls no tool | Larry's prose answer is shown; edit state is unchanged. User can try again or edit fields manually. |
+| Chat LLM produces a patch with unknown keys | API rejects with 422; panel shows "Larry tried to change an unsupported field — ignore and try again, or edit manually." |
+| Executor fails during Save & execute | Transaction rolls back `previous_payload` + payload. Event stays `suggested` with original values. Panel shows executor's error. |
+| Team member name can't be resolved at save | 422 with the offending name, panel shows "We don't have <name> on this project. Pick from the dropdown." |
+
+## 9. Testing
+
+### 9.1 Unit tests (Vitest)
+
+- `packages/db` — `applyEventModification(payload, patch)`: pure merge helper.
+- `packages/ai/src/chat.ts` modification-mode variant — a new `buildModifySystemPrompt` and the single-tool wiring. Unit-test the prompt shape (contains payload, team list, action type) and that `stepCountIs(2)` still holds.
+- API route tests for `/events/:id/modify` (new shape), `/save`, `/stop`, `/modify-chat` — covering 200, 409, 422, role gate, multi-tenant isolation.
+
+### 9.2 Integration tests
+
+Reuse the pattern from `apps/api/tests/larry-event-id-uuid-guard.test.ts`:
+
+- Save & execute with patch → event row has `previous_payload` set, `payload` updated, `event_type = accepted`, executor ran.
+- Stop → no DB mutation except audit log.
+- Concurrent Accept in another tab → Save returns 409 and does not mutate.
+- Chat `apply_modification` tool call → returned patch validates and can be passed to Save.
+
+### 9.3 E2E (Playwright, per `larry-testing-tools` memory)
+
+New spec `apps/web/e2e/modify-action.spec.ts` covering:
+
+1. Open Modify panel on a create_task suggestion, change deadline via date picker, Save & execute, confirm task created with new date.
+2. Open Modify panel, type in "Tell Larry in words" strip ("push to next Friday and reassign to Anna"), confirm diff updates, Save & execute.
+3. Open Modify, click Stop, confirm card returns to pending state with original payload.
+4. Open Modify in one tab, Accept in another, attempt Save, confirm 409 banner.
+
+Run against the deployed preview per `testing-on-production` memory (Fergus does not test locally).
+
+### 9.4 Manual QA script
+
+Documented in `docs/reports/qa-2026-04-15-modify/README.md` after implementation lands. Covers each action type's field set and the chat path with 3 prompt variations.
+
+## 10. Rollout
+
+- Ship as one PR. Backwards compatibility isn't needed — the only consumer of the old `/modify` response shape is the frontend, and they deploy together.
+- Migration `020` is additive (nullable columns) — safe on prod with live traffic.
+- Feature flag gate: `MODIFY_PANEL_V2` env var (default **on** in preview, **on** in prod after preview soak). Rollback = flip the flag; old code path is gone but Modify button would become a no-op rather than a crash, which is acceptable for a short-window rollback window.
+- Monitor: new audit log events `larry.event.modified`, `larry.event.modify_cancelled`. Add to Larry's daily activity feed if one exists.
+
+## 11. Open questions (deferred, none block implementation)
+
+- Should the modify chat conversation be visible in the user's normal chat history? Current plan: yes, labelled "Modify: <displayText>". Easy to change later.
+- Do we want a keyboard shortcut (e.g. `m` on a focused card) to open Modify? Nice-to-have, not in scope.

--- a/docs/superpowers/specs/2026-04-15-portfolio-gantt-design.md
+++ b/docs/superpowers/specs/2026-04-15-portfolio-gantt-design.md
@@ -1,0 +1,362 @@
+# Portfolio & Project Gantt — Design Spec
+
+**Date:** 2026-04-15
+**Status:** Approved (brainstorming complete, autonomy granted to proceed)
+**Supersedes:** `2026-04-04-timeline-view-design.md` (project-scoped swimlane timeline)
+**Location:** `apps/web`, `apps/api`, `packages/db`
+
+---
+
+## 1. Problem
+
+The current timeline (`apps/web/src/components/workspace/timeline/ProjectTimeline.tsx`) is:
+
+1. **Project-scoped only.** There is no portfolio-wide view across all projects.
+2. **Not a Gantt.** It renders flat swimlanes grouped by phase/assignee/status — no left-side outline, no hierarchy, no parent-rollup bars.
+3. **No subtasks.** `tasks` has no `parent_task_id`; there is no way to break a task into children.
+4. **No project grouping.** There is no concept of categories/folders for organising projects at the portfolio level.
+
+User quote: *"there should be a sidebar on the left where you can collapse everything … and then you should also be able to see this group of projects or tasks and then this group of projects."*
+
+## 2. Goal
+
+Ship a proper Gantt chart with two entry points that share one component:
+
+- **Portfolio Gantt** at `/workspace/timeline` — everything the tenant owns, grouped into categories.
+- **Project Gantt** at `/workspace/projects/[projectId]` (Timeline tab) — replaces the existing `ProjectTimeline` component.
+
+Both render a **4-level collapsible tree** on the left (Category → Project → Task → Subtask in portfolio mode; Project → Task → Subtask in project mode) with horizontally-scrollable time-bars on the right.
+
+## 3. Non-Goals (v1)
+
+- Drag rows to reorder the sidebar tree
+- Drag a task to change its parent or category (use dropdown/modal instead)
+- Baseline vs actual comparison
+- Critical-path highlighting
+- Resource levelling / auto-scheduling
+- Mobile Gantt (keep the existing `TimelineMobileList` fallback on `< 1024px`)
+
+## 4. Data Model
+
+### 4.1 New table: `project_categories`
+
+```sql
+CREATE TABLE IF NOT EXISTS project_categories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  colour TEXT,                         -- nullable; null = neutral
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_project_categories_tenant_sort
+  ON project_categories (tenant_id, sort_order, created_at);
+```
+
+### 4.2 `projects.category_id`
+
+```sql
+ALTER TABLE projects
+  ADD COLUMN category_id UUID REFERENCES project_categories(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_projects_tenant_category
+  ON projects (tenant_id, category_id);
+```
+
+Projects without a category render under a synthetic **"Uncategorised"** group in the tree (not a real row in the DB — computed client-side).
+
+### 4.3 `tasks.parent_task_id`
+
+```sql
+ALTER TABLE tasks
+  ADD COLUMN parent_task_id UUID REFERENCES tasks(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_tasks_parent ON tasks (tenant_id, parent_task_id);
+```
+
+- Same-tenant, same-project constraint enforced at the API layer (Fastify) with `CHECK`-style guard in the service.
+- Depth limit: **1** (a subtask cannot have its own subtask in v1) — enforced at API validation.
+- Deleting a parent cascades to its subtasks.
+- A task with subtasks rolls up: its bar in the grid spans `min(children.start) … max(children.end)`; its progress is the weighted average of children progress.
+
+## 5. API Changes
+
+### 5.1 New: `GET /v1/timeline` (tenant-wide)
+
+Returns the portfolio tree plus all scheduled tasks/subtasks + cross-project dependencies:
+
+```ts
+type PortfolioTimelineResponse = {
+  categories: Array<{
+    id: string | null;         // null = "Uncategorised"
+    name: string;
+    colour: string | null;
+    sortOrder: number;
+    projects: Array<{
+      id: string;
+      name: string;
+      status: "active" | "archived";
+      startDate: string | null;
+      targetDate: string | null;
+      tasks: GanttTask[];      // flat; tree re-built from parent_task_id client-side
+    }>;
+  }>;
+  dependencies: Array<{ taskId: string; dependsOnTaskId: string }>;
+};
+
+type GanttTask = {
+  id: string;
+  projectId: string;
+  parentTaskId: string | null;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  assigneeUserId: string | null;
+  assigneeName: string | null;
+  startDate: string | null;
+  endDate: string | null;         // = due_date when end not tracked separately
+  dueDate: string | null;
+  progressPercent: number;
+};
+```
+
+Proxy route on web: `apps/web/src/app/api/workspace/timeline/route.ts` (mirrors the existing project-timeline proxy pattern).
+
+### 5.2 Extended: `GET /v1/projects/:id/timeline`
+
+Already exists (see `apps/web/src/app/api/workspace/projects/[id]/timeline/route.ts`). Extend the Fastify handler to include `parentTaskId` on each task.
+
+### 5.3 New: Category CRUD
+
+```
+GET    /v1/categories                  → list tenant's categories (sorted)
+POST   /v1/categories                  → { name, colour?, sortOrder? }
+PATCH  /v1/categories/:id              → { name?, colour?, sortOrder? }
+DELETE /v1/categories/:id              → projects are re-parented to null
+POST   /v1/categories/reorder          → { ids: string[] } (persists sort_order)
+```
+
+### 5.4 Extended: task creation accepts `parentTaskId`
+
+`POST /v1/tasks` body gains an optional `parentTaskId`. Server validates:
+
+- Parent exists, same tenant, same project
+- Parent itself has `parent_task_id = NULL` (depth limit)
+
+### 5.5 Extended: task PATCH accepts `parentTaskId` (re-parenting)
+
+`PATCH /v1/tasks/:id` accepts `parentTaskId: string | null`. Same validation rules.
+
+### 5.6 Extended: project PATCH accepts `categoryId`
+
+`PATCH /v1/projects/:id` accepts `categoryId: string | null`.
+
+## 6. Component Architecture (`apps/web/src/components/workspace/gantt/`)
+
+New directory, cleanly renamed from `timeline/`. Existing `timeline/` primitives are refactored/moved; the old folder is retired.
+
+| File | Responsibility |
+|---|---|
+| `GanttContainer.tsx` | Top-level orchestrator. Takes a `root: GanttNode` tree and renders `<GanttOutline>` + `<GanttGrid>` side-by-side. Drives zoom, selection, expand/collapse state. |
+| `GanttOutline.tsx` | Left sidebar. Renders the tree as a list of `<GanttOutlineRow>`s with depth-based indent + chevron. Resizable width (280–480px). Sticky on horizontal scroll. |
+| `GanttOutlineRow.tsx` | One row in the outline: chevron, type badge (C/P/T/·), title, status dot, due date, assignee avatar. Hover syncs with its bar in the grid. |
+| `GanttGrid.tsx` | Right grid. Renamed from `TimelineGrid.tsx`. Same zoom/gridlines/today-line behaviour. Adds drag-to-resize and drag-to-move bars. |
+| `GanttRow.tsx` | One row in the grid. Renders `<GanttBar>` for leaf nodes, rollup parent-bar for container nodes. Height must match outline row for alignment. |
+| `GanttBar.tsx` | Renamed from `TimelineBar.tsx`. Gains variants: `category` (tall, muted band), `project` (primary purple), `task` (status colour), `subtask` (status colour 60% opacity, narrower). |
+| `GanttToolbar.tsx` | Renamed from `TimelineToolbar.tsx`. Controls: zoom W/M/Q, search, expand-all / collapse-all, "Today" jump, filters (status / assignee), "+ Add" (context-aware: category vs project vs task). |
+| `GanttDependencyLines.tsx` | Renamed from `TimelineDependencyLines.tsx`. Supports cross-project dependency lines in portfolio mode. |
+| `GanttTooltip.tsx` | Renamed from `TimelineTooltip.tsx`. |
+| `UnscheduledPanel.tsx` | Kept. Shown only in project mode (portfolio mode has too many to be useful). |
+| `TimelineMobileList.tsx` | Kept as-is for the mobile fallback. |
+| `gantt-utils.ts` | Renamed from `timeline-utils.ts`. Adds `buildTree`, `rollUpBar`, `flattenVisible` helpers. |
+
+### 6.1 Data shape
+
+```ts
+type GanttNode =
+  | { kind: "category"; id: string | null; name: string; colour: string | null; children: GanttNode[] }
+  | { kind: "project";  id: string; name: string; status: string; children: GanttNode[] }
+  | { kind: "task";     id: string; task: GanttTask; children: GanttNode[] /* subtasks */ }
+  | { kind: "subtask";  id: string; task: GanttTask };
+```
+
+Tree is built once per render from the flat API response.
+
+### 6.2 Row alignment invariant
+
+Each visible row has a fixed height (`ROW_HEIGHT = 36px`). Outline and grid render from the same `flattenVisible(tree, expandedSet)` array so row `i` is always at `y = i * 36`. This replaces the current `taskPositions` Map-based positioning in `ProjectTimeline.tsx`.
+
+### 6.3 Rollup math (`rollUpBar`)
+
+For a container node with visible children:
+
+- `start = min(children.start)`
+- `end   = max(children.end)`
+- `progress = Σ(childProgress × childDurationDays) / Σ(childDurationDays)`
+
+When **collapsed**, the container row's bar is rendered at full width. When **expanded**, the container shows a thinner "summary band" on top and individual children render below it.
+
+## 7. Routes
+
+### 7.1 `apps/web/src/app/workspace/timeline/page.tsx` (new)
+
+Server component that fetches the portfolio tree via the proxy and passes to `<PortfolioGanttClient />`.
+
+### 7.2 `apps/web/src/app/workspace/projects/[projectId]/`
+
+The existing `ProjectWorkspaceView.tsx` renders `<ProjectTimeline />` in its Timeline tab. Replace with `<ProjectGanttClient />`, which wraps `<GanttContainer>` with the project subtree as root.
+
+### 7.3 Workspace nav
+
+Add to `WORKSPACE_NAV` in `apps/web/src/components/dashboard/Sidebar.tsx`:
+
+```ts
+{ id: "timeline", label: "Timeline", icon: GanttChartSquare, href: "/workspace/timeline" }
+```
+
+Extend the `WorkspaceSidebarNav` union type. Place the item between "My tasks" and "Actions".
+
+## 8. Visual Design
+
+### 8.1 Colours (existing Larry palette — no new tokens)
+
+| Element | Token / value |
+|---|---|
+| Category row band | `var(--surface-2)` background, `var(--text-1)` bold text |
+| Project bar | `#6c44f6` (brand) at 85% opacity, progress fill full opacity |
+| Task bar | `var(--tl-*)` per status (existing) |
+| Subtask bar | same colour, 60% opacity, `height: 10px` (vs 16px for tasks) |
+| Rollup summary band | `rgba(108, 68, 246, 0.15)` fill with solid bottom border |
+| Today line | `rgba(108, 68, 246, 0.4)` (existing) |
+| Dependency lines | existing SVG lines (unchanged) |
+| Tree chevrons | `var(--text-muted)` rotating 90° on expand |
+
+### 8.2 Typography
+
+- Outline row title: 13px/500
+- Category label: 12px/700 uppercase
+- Project label: 13px/600
+- Task label: 13px/500
+- Subtask label: 12px/400, `var(--text-2)`
+
+### 8.3 Spacing
+
+- `ROW_HEIGHT = 36px` for all visible rows
+- Outline depth indent: `12px` per level (max 48px at depth 4)
+- Outline default width: `320px`, min `220px`, max `520px`, drag-resizable
+
+### 8.4 Interaction states
+
+| Hover row | Outline + bar both tinted `var(--surface-2)`, dependency lines for that task brighten |
+| Selected row | Left border indicator `3px solid var(--brand)` |
+| Dimmed (search miss) | opacity 0.35 |
+| Drag bar | cursor `ew-resize` on edges, `grab` on body; live ghost of new dates |
+
+## 9. Add-Task / Add-Subtask / Add-Project / Add-Category Flow
+
+Single "+" button in the toolbar opens a **context-aware popover** whose content depends on the currently-selected outline row:
+
+| Selected | Popover offers |
+|---|---|
+| nothing (portfolio) | New category · New project |
+| category | New project (pre-filled category) |
+| project | New task (pre-filled project) |
+| task | New subtask (pre-filled parent) |
+| subtask | — (v1 depth limit) |
+
+Reuses `AddTaskModal` (already in `ProjectTimeline.tsx`) with new fields for `parentTaskId` / `projectId`.
+
+## 10. Empty States
+
+- **No categories & no projects (portfolio):** centred CTA "Create your first project" → opens `ProjectCreateSheet`.
+- **Category with no projects:** inline "+ Add project to this category" row.
+- **Project with no tasks:** inline "+ Add task" row.
+- **Task with no subtasks:** no child rows shown; "Add subtask" is a menu item on the task's context menu.
+
+## 11. Performance
+
+- The portfolio view may render hundreds of rows. Use `react-window` or manual virtualisation if `flattenVisible().length > 100`.
+- Dependency lines draw only for currently-visible tasks (cull by `expandedSet`).
+- Tree rebuild memoised on `[apiResponse, expandedSet]`.
+
+## 12. Testing
+
+### 12.1 API tests (`apps/api`)
+
+- `GET /v1/timeline` returns nested structure, respects tenant isolation
+- Task create/patch rejects depth-2 subtasks
+- Task create/patch rejects cross-project parents
+- Category delete re-parents projects to NULL
+- Category reorder persists `sort_order`
+
+### 12.2 Unit tests (`apps/web`)
+
+- `buildTree` given flat tasks + parent ids
+- `rollUpBar` math (progress-weighted, missing-dates edge cases)
+- `flattenVisible` respects expandedSet
+
+### 12.3 Component tests (Vitest + Testing Library)
+
+- `<GanttOutline>` expand / collapse toggles visible rows
+- `<GanttRow>` rollup bar position matches `rollUpBar` output
+- Clicking a leaf row opens `TaskDetailPanel`
+
+### 12.4 E2E (Playwright, existing harness)
+
+- Create category → assign project → verify portfolio tree
+- Create subtask → verify parent rollup spans its range
+- Reorder categories via API, reload portfolio, verify order
+
+## 13. Migration Plan
+
+Single SQL migration file `packages/db/src/migrations/NNNN_portfolio_gantt.sql`:
+
+1. `CREATE TABLE project_categories`
+2. `ALTER TABLE projects ADD COLUMN category_id`
+3. `ALTER TABLE tasks ADD COLUMN parent_task_id`
+4. Indices from §4
+
+Schema file `packages/db/src/schema.sql` is updated to match (idempotent `IF NOT EXISTS` clauses).
+
+No data backfill needed — `category_id` and `parent_task_id` default to NULL, which renders as "Uncategorised" / flat tasks.
+
+## 14. Rollout
+
+1. Ship DB migration + API + web behind the existing deployment pipeline (Railway → Vercel).
+2. The `/workspace/timeline` nav link is added immediately (no feature flag — same release cadence as other recent Larry nav additions).
+3. The project Timeline tab switches to the new component on the same deploy. The old `timeline/` folder is deleted after smoke-test on production.
+
+## 15. File Inventory (what changes)
+
+**New:**
+- `packages/db/src/migrations/NNNN_portfolio_gantt.sql`
+- `apps/api/src/routes/timeline.ts` (or extend existing)
+- `apps/api/src/routes/categories.ts`
+- `apps/api/src/services/gantt.ts` (tree assembly, rollup helpers shared server-side if needed)
+- `apps/web/src/app/workspace/timeline/page.tsx`
+- `apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx`
+- `apps/web/src/app/api/workspace/timeline/route.ts`
+- `apps/web/src/app/api/workspace/categories/route.ts` (+ `[id]/route.ts` + `reorder/route.ts`)
+- `apps/web/src/components/workspace/gantt/` (full new folder per §6)
+
+**Modified:**
+- `packages/db/src/schema.sql` — add new columns/table
+- `packages/shared/src/types.ts` — add `ProjectCategory`, `GanttTask`, `GanttNode`
+- `apps/api/src/routes/tasks.ts` — accept `parentTaskId`
+- `apps/api/src/routes/projects.ts` — accept `categoryId`, include category_id in lists
+- `apps/api/src/routes/projects/timeline.ts` (or wherever `GET /v1/projects/:id/timeline` lives) — include `parentTaskId`
+- `apps/web/src/components/dashboard/Sidebar.tsx` — add Timeline nav item, extend `WorkspaceSidebarNav` union
+- `apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx` — swap `<ProjectTimeline>` → `<ProjectGanttClient>`
+- `apps/web/src/app/dashboard/types.ts` — add `parentTaskId` to `WorkspaceTimelineTask`
+
+**Deleted (after cutover):**
+- `apps/web/src/components/workspace/timeline/` (whole folder, replaced by `gantt/`)
+
+## 16. Open Risks
+
+- **Schema.sql re-apply on boot:** Larry's schema file is applied as `CREATE TABLE IF NOT EXISTS` on every API start. The new `ALTER TABLE … ADD COLUMN` statements must be wrapped in `DO $$ … EXCEPTION WHEN duplicate_column THEN null END $$` blocks (existing pattern in `schema.sql`) to remain idempotent.
+- **Depth limit enforcement:** the API must reject a PATCH that would move a parent task under another task. Validation is only half the story — an integration test must assert this.
+- **Cross-project dependencies in portfolio view:** existing `task_dependencies` table is already tenant-scoped, not project-scoped, so no schema change needed; but the UI must handle the case where dependent tasks are in different projects.
+- **Memory-index decision divergence:** the 2026-04-02 note said "Linear-style simpler timeline preferred over full Gantt." This spec supersedes that decision; memory entry must be updated on completion.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -948,6 +948,16 @@ export {
 } from "./chat.js";
 export type { ChatStreamEvent, ToolCallResult } from "./chat.js";
 
+// ── Larry Modify Action chat ─────────────────────────────────────────────────
+export {
+  streamModifyChat,
+  buildModifySystemPrompt,
+} from "./modify-chat.js";
+export type {
+  ModifyChatContext,
+  ModifyChatStreamEvent,
+} from "./modify-chat.js";
+
 // Re-export new shared intelligence types for convenience
 export type {
   IntelligenceConfig,

--- a/packages/ai/src/modify-chat.test.ts
+++ b/packages/ai/src/modify-chat.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildModifySystemPrompt } from "./modify-chat.js";
+
+describe("buildModifySystemPrompt", () => {
+  const base = {
+    actionType: "create_task",
+    displayText: "Create task: Draft kickoff email",
+    reasoning: "Kickoff is next Monday and we need an email out first.",
+    currentPayload: { title: "Draft kickoff email", dueDate: "2026-04-20", priority: "medium" },
+    editableFields: ["title", "description", "dueDate", "assigneeName", "priority"],
+    teamMembers: [{ displayName: "Anna" }, { displayName: "Priya" }],
+  };
+
+  it("embeds display text, reasoning, current payload, editable fields, and team", () => {
+    const prompt = buildModifySystemPrompt(base);
+    expect(prompt).toContain("Create task: Draft kickoff email");
+    expect(prompt).toContain("Kickoff is next Monday");
+    expect(prompt).toContain('"dueDate": "2026-04-20"');
+    expect(prompt).toContain("title, description, dueDate, assigneeName, priority");
+    expect(prompt).toContain("Anna");
+    expect(prompt).toContain("Priya");
+  });
+
+  it("restricts the model to apply_modification only", () => {
+    const prompt = buildModifySystemPrompt(base);
+    expect(prompt).toMatch(/apply_modification/);
+    expect(prompt).toMatch(/Never call any tool other than apply_modification/i);
+  });
+
+  it("anchors today's date", () => {
+    const prompt = buildModifySystemPrompt(base);
+    expect(prompt).toMatch(/Today is \w+day, \d{4}-\d{2}-\d{2}/);
+    expect(prompt).toContain("next Monday");
+  });
+
+  it("handles an empty team list without crashing", () => {
+    const prompt = buildModifySystemPrompt({ ...base, teamMembers: [] });
+    expect(prompt).toContain("(no team members on this project)");
+  });
+});

--- a/packages/ai/src/modify-chat.ts
+++ b/packages/ai/src/modify-chat.ts
@@ -1,0 +1,183 @@
+// Larry "Modify Action" chat flow.
+// Spec: docs/superpowers/specs/2026-04-15-modify-action-design.md
+//
+// Differs from the main streamLarryChat in two ways:
+//   1. Only one tool: apply_modification. The LLM cannot call task mutation
+//      tools because there is no task yet — the suggestion is still pending.
+//   2. System prompt is focused on the single pending suggestion, its current
+//      payload, its editable fields, and the project's team list.
+
+import { streamText, tool, stepCountIs } from "ai";
+import type { ModelMessage } from "ai";
+import { z } from "zod";
+import type { IntelligenceConfig } from "@larry/shared";
+import { createModel } from "./provider.js";
+import { computeDateContext } from "./chat.js";
+
+export interface ModifyChatContext {
+  actionType: string;
+  displayText: string;
+  reasoning: string;
+  currentPayload: Record<string, unknown>;
+  editableFields: string[];
+  teamMembers: { displayName: string }[];
+}
+
+export type ModifyChatStreamEvent =
+  | { type: "token"; delta: string }
+  | {
+      type: "tool_done";
+      name: "apply_modification";
+      success: boolean;
+      payloadPatch: Record<string, unknown>;
+      summary: string;
+    }
+  | { type: "error"; message: string };
+
+export function buildModifySystemPrompt(ctx: ModifyChatContext): string {
+  const d = computeDateContext();
+  const team =
+    ctx.teamMembers.length > 0
+      ? ctx.teamMembers.map((m) => m.displayName).join(", ")
+      : "(no team members on this project)";
+
+  return `You are Larry. The user has opened the Modify panel on a pending suggestion and wants to change something before accepting it. Your job is to translate what they say into a precise payload patch via the apply_modification tool.
+
+## TODAY
+
+Today is ${d.dayOfWeek}, ${d.today}.
+- tomorrow = ${(() => { const t = new Date(d.today + "T00:00:00Z"); t.setUTCDate(t.getUTCDate() + 1); return t.toISOString().slice(0, 10); })()}
+- next Monday = ${d.nextMonday}
+- next Tuesday = ${d.nextTuesday}
+- next Wednesday = ${d.nextWednesday}
+- next Thursday = ${d.nextThursday}
+- next Friday = ${d.nextFriday}
+
+Anchor all relative dates to today, not your training data.
+
+## THE SUGGESTION BEING MODIFIED
+
+- Action type: ${ctx.actionType}
+- Display text: ${ctx.displayText}
+- Original reasoning: ${ctx.reasoning}
+- Current payload:
+${JSON.stringify(ctx.currentPayload, null, 2)}
+
+## EDITABLE FIELDS
+
+You can change ONLY these fields on the payload:
+
+${ctx.editableFields.join(", ")}
+
+If the user asks to change a field that is NOT in that list, explain in prose what you can and can't modify. Do not call apply_modification with an unsupported key.
+
+## TEAM MEMBERS ON THIS PROJECT
+
+${team}
+
+When the user asks to reassign or set an assignee, the new value MUST match a name from this list. If they say a name that isn't on the project, do not silently drop it. Say "I don't see <name> on this project — do you mean <closest match>?" and wait for confirmation.
+
+## YOUR ONE TOOL
+
+Call \`apply_modification\` exactly once per user turn when the user has asked for a concrete change. Include ONLY the fields that change. Write a short past-tense summary describing the diff ("Pushed the deadline to 30 Apr and reassigned to Anna.").
+
+Do not call apply_modification when:
+- The user is asking a clarifying question ("why was this suggested?", "what was the original date?").
+- The user's message is ambiguous and needs confirmation before a change lands.
+- The change cannot be expressed in the editable fields.
+
+In those cases, answer in prose.
+
+## STYLE
+
+Direct, short, conversational. Don't restate the whole payload. Don't announce tool calls — call the tool and continue the sentence. Never call any tool other than apply_modification — other tools do not exist in this conversation.`;
+}
+
+export async function* streamModifyChat(input: {
+  config: IntelligenceConfig;
+  messages: ModelMessage[];
+  context: ModifyChatContext;
+}): AsyncGenerator<ModifyChatStreamEvent> {
+  const { config, messages, context } = input;
+
+  if (config.provider === "mock" || !config.apiKey) {
+    const mock = "(mock modify mode — no API key configured).";
+    for (const char of mock) {
+      yield { type: "token", delta: char };
+    }
+    return;
+  }
+
+  const model = createModel(config);
+
+  const tools = {
+    apply_modification: tool({
+      description:
+        "Apply the user-described change(s) to the pending suggestion's payload. Call exactly once per turn when the user asks for a concrete change, or zero times for a clarifying question.",
+      inputSchema: z.object({
+        payloadPatch: z
+          .record(z.string(), z.unknown())
+          .describe(
+            "Only the fields that change. Keys must be in the editable fields list from the system prompt."
+          ),
+        summary: z
+          .string()
+          .describe("One short past-tense sentence summarising the change."),
+      }),
+      execute: async (params) => ({
+        ok: true,
+        payloadPatch: params.payloadPatch,
+        summary: params.summary,
+      }),
+    }),
+  };
+
+  const result = streamText({
+    model,
+    system: buildModifySystemPrompt(context),
+    messages,
+    tools,
+    stopWhen: stepCountIs(2),
+    maxRetries: 1,
+  });
+
+  for await (const chunk of result.fullStream) {
+    const c = chunk as { type?: string } & Record<string, unknown>;
+    switch (c.type) {
+      case "text-delta": {
+        const text = (c as { text?: string }).text;
+        if (typeof text === "string" && text.length > 0) {
+          yield { type: "token", delta: text };
+        }
+        break;
+      }
+      case "tool-result": {
+        const t = c as {
+          toolName: string;
+          output?: { payloadPatch?: Record<string, unknown>; summary?: string };
+        };
+        if (t.toolName === "apply_modification" && t.output?.payloadPatch) {
+          yield {
+            type: "tool_done",
+            name: "apply_modification",
+            success: true,
+            payloadPatch: t.output.payloadPatch,
+            summary: t.output.summary ?? "",
+          };
+        }
+        break;
+      }
+      case "error": {
+        const e = c as { error: unknown };
+        yield {
+          type: "error",
+          message:
+            e.error instanceof Error ? e.error.message : String(e.error ?? "Unknown streaming error"),
+        };
+        break;
+      }
+      default:
+        break;
+    }
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,3 +3,4 @@ export * from "./larry-snapshot.js";
 export * from "./larry-executor.js";
 export * from "./canonical-event-runtime.js";
 export * from "./migration-safety.js";
+export * from "./larry-event-modifications.js";

--- a/packages/db/src/larry-event-modifications.test.ts
+++ b/packages/db/src/larry-event-modifications.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPatch,
+  assertPatchIsAllowed,
+  editableFieldsForActionType,
+} from "./larry-event-modifications.js";
+
+describe("editableFieldsForActionType", () => {
+  it("returns task fields for create_task", () => {
+    expect(editableFieldsForActionType("create_task")).toEqual([
+      "title",
+      "description",
+      "dueDate",
+      "assigneeName",
+      "priority",
+    ]);
+  });
+
+  it("returns single-field sets for tweak-only actions", () => {
+    expect(editableFieldsForActionType("change_deadline")).toEqual(["newDeadline"]);
+    expect(editableFieldsForActionType("change_task_owner")).toEqual(["newOwnerName"]);
+    expect(editableFieldsForActionType("flag_task_risk")).toEqual(["riskLevel"]);
+  });
+
+  it("returns update_task_status fields", () => {
+    expect(editableFieldsForActionType("update_task_status")).toEqual([
+      "newStatus",
+      "newRiskLevel",
+    ]);
+  });
+
+  it("returns draft_email fields", () => {
+    expect(editableFieldsForActionType("draft_email")).toEqual(["to", "subject", "body"]);
+  });
+
+  it("returns empty for unknown types", () => {
+    expect(editableFieldsForActionType("does_not_exist")).toEqual([]);
+  });
+
+  it("returns empty for send_reminder (never modifiable)", () => {
+    expect(editableFieldsForActionType("send_reminder")).toEqual([]);
+  });
+
+  it("returns a fresh copy (caller can mutate safely)", () => {
+    const a = editableFieldsForActionType("create_task");
+    a.push("injected");
+    const b = editableFieldsForActionType("create_task");
+    expect(b).not.toContain("injected");
+  });
+});
+
+describe("applyPatch", () => {
+  it("merges patch over payload, preserving untouched keys", () => {
+    const base = { title: "A", dueDate: "2026-04-20", priority: "medium" };
+    const patch = { dueDate: "2026-04-30" };
+    expect(applyPatch(base, patch)).toEqual({
+      title: "A",
+      dueDate: "2026-04-30",
+      priority: "medium",
+    });
+  });
+
+  it("does not mutate the original payload", () => {
+    const base = { title: "A" };
+    applyPatch(base, { title: "B" });
+    expect(base).toEqual({ title: "A" });
+  });
+
+  it("handles empty patch as identity", () => {
+    const base = { title: "A" };
+    expect(applyPatch(base, {})).toEqual({ title: "A" });
+  });
+
+  it("adds new keys that weren't in the original payload", () => {
+    const base = { title: "A" };
+    expect(applyPatch(base, { description: "details" })).toEqual({
+      title: "A",
+      description: "details",
+    });
+  });
+});
+
+describe("assertPatchIsAllowed", () => {
+  it("accepts a patch whose keys are all editable for the action type", () => {
+    expect(() =>
+      assertPatchIsAllowed("create_task", { title: "A", dueDate: "2026-05-01" })
+    ).not.toThrow();
+  });
+
+  it("accepts an empty patch", () => {
+    expect(() => assertPatchIsAllowed("create_task", {})).not.toThrow();
+  });
+
+  it("throws on a disallowed field", () => {
+    expect(() =>
+      assertPatchIsAllowed("create_task", { taskId: "abc" })
+    ).toThrow(/not editable.*create_task/i);
+  });
+
+  it("throws on unknown action type", () => {
+    expect(() =>
+      assertPatchIsAllowed("mystery_action", { anything: "x" })
+    ).toThrow(/unknown action type/i);
+  });
+
+  it("throws for send_reminder even though it's a real action type (not modifiable)", () => {
+    expect(() =>
+      assertPatchIsAllowed("send_reminder", { message: "x" })
+    ).toThrow(/unknown action type/i);
+  });
+});

--- a/packages/db/src/larry-event-modifications.ts
+++ b/packages/db/src/larry-event-modifications.ts
@@ -1,0 +1,48 @@
+// Pure helpers for the Modify Action flow (spec 2026-04-15-modify-action-design.md).
+// No DB access; this module is safe to import from the API package and from tests.
+
+export type ModifiableActionType =
+  | "create_task"
+  | "update_task_status"
+  | "flag_task_risk"
+  | "change_deadline"
+  | "change_task_owner"
+  | "draft_email";
+
+const FIELDS_BY_ACTION_TYPE: Record<string, readonly string[]> = {
+  create_task:        ["title", "description", "dueDate", "assigneeName", "priority"],
+  update_task_status: ["newStatus", "newRiskLevel"],
+  flag_task_risk:     ["riskLevel"],
+  change_deadline:    ["newDeadline"],
+  change_task_owner:  ["newOwnerName"],
+  draft_email:        ["to", "subject", "body"],
+  // send_reminder auto-executes and never appears as a suggestion; intentionally omitted.
+};
+
+export function editableFieldsForActionType(actionType: string): string[] {
+  return [...(FIELDS_BY_ACTION_TYPE[actionType] ?? [])];
+}
+
+export function applyPatch(
+  payload: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...payload, ...patch };
+}
+
+export function assertPatchIsAllowed(
+  actionType: string,
+  patch: Record<string, unknown>,
+): void {
+  const allowed = FIELDS_BY_ACTION_TYPE[actionType];
+  if (!allowed) {
+    throw new Error(`Unknown action type '${actionType}' — cannot modify.`);
+  }
+  for (const key of Object.keys(patch)) {
+    if (!allowed.includes(key)) {
+      throw new Error(
+        `Field '${key}' is not editable for action type '${actionType}'. Allowed: ${allowed.join(", ")}.`,
+      );
+    }
+  }
+}

--- a/packages/db/src/migrations/020_larry_event_modifications.sql
+++ b/packages/db/src/migrations/020_larry_event_modifications.sql
@@ -1,0 +1,16 @@
+-- 020_larry_event_modifications.sql
+-- Adds audit columns for the Modify Action flow (spec 2026-04-15-modify-action-design.md).
+-- previous_payload stores the payload before the user's most recent in-place edit so
+-- before/after is recoverable from a single row. Nullable so existing rows are unaffected.
+
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS previous_payload    JSONB,
+  ADD COLUMN IF NOT EXISTS modified_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS modified_at         TIMESTAMPTZ;
+
+COMMENT ON COLUMN larry_events.previous_payload IS
+  'Snapshot of payload before the most recent user edit via Modify. NULL if the event has never been modified.';
+COMMENT ON COLUMN larry_events.modified_by_user_id IS
+  'User who most recently applied a Modify edit to this event.';
+COMMENT ON COLUMN larry_events.modified_at IS
+  'Timestamp of the most recent Modify edit on this event.';

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -1123,6 +1123,14 @@ ALTER TABLE larry_events
 ALTER TABLE larry_events
   ADD COLUMN IF NOT EXISTS source_record_id UUID;
 
+-- Modify Action audit columns (spec 2026-04-15-modify-action-design.md, migration 020).
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS previous_payload    JSONB;
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS modified_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL;
+ALTER TABLE larry_events
+  ADD COLUMN IF NOT EXISTS modified_at         TIMESTAMPTZ;
+
 UPDATE larry_events
 SET execution_mode = CASE
   WHEN event_type = 'auto_executed' THEN 'auto'


### PR DESCRIPTION
## Summary

Found during #49 verification. When \`streamLarryChat\` emits an \`error\` event (Groq TPD cap, upstream rate limit, etc.), the client sets the bubble to \`event.message\`. The post-stream \`fullContent.trim().length === 0\` branch then streams \`buildToolRecap\`'s neutral fallback as a token, and the client concatenates it onto the error text with no separator:

> AI_RetryError: Failed after 2 attempts. Last error: Rate limit reached for model llama-3.3-70b-versatile … Upgrade to Dev Tier today at https://console.groq.com/settings/billing**I don't have anything to add here — ask me something specific and I'll dig in.**

## Fix

Track \`hadStreamError\` in the stream loop and skip the recap write when it's true. When the stream errored, the error message is the response — a neutral \"nothing to add\" recap on top is misleading and visually glues onto the error URL.

## Test plan

- [x] Typecheck clean on apps/api.
- [x] Existing \`larry-chat-stream-translate\` tests still green.
- [ ] After deploy: reproduce the Groq TPD error (or any upstream stream failure) and verify the bubble contains only the error message, not the concatenated recap.

Not tied to any open issue — surfaced by #49 Playwright verification. Small enough I didn't add a new vitest case; the change is a 1-flag guard on an existing code path.