### PR TITLE
fix: Gantt bar rendering + category/subtask creation UI

### DIFF
--- a/apps/web/src/app/api/workspace/projects/route.ts
+++ b/apps/web/src/app/api/workspace/projects/route.ts
@@ -33,6 +33,7 @@ const CreateProjectSchema = z.object({
   description: z.string().max(4000).optional(),
   startDate: z.string().date().optional(),
   targetDate: z.string().date().optional(),
+  categoryId: z.string().uuid().nullable().optional(),
 });
 
 export async function POST(request: NextRequest) {

--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -3,10 +3,12 @@ import { useCallback, useEffect, useState } from "react";
 import type { PortfolioTimelineResponse } from "@/components/workspace/gantt/gantt-types";
 import { buildPortfolioTree, normalizePortfolioStatuses } from "@/components/workspace/gantt/gantt-utils";
 import { GanttContainer } from "@/components/workspace/gantt/GanttContainer";
+import { AddNodeModal } from "@/components/workspace/gantt/AddNodeModal";
 
 export function PortfolioGanttClient() {
   const [data, setData] = useState<PortfolioTimelineResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [addCtx, setAddCtx] = useState<{ mode: "category" | "project"; parentCategoryId?: string } | null>(null);
 
   const fetchTimeline = useCallback(async () => {
     try {
@@ -24,13 +26,31 @@ export function PortfolioGanttClient() {
   if (!data) return <div style={{ padding: 24 }}>Loading…</div>;
 
   const root = buildPortfolioTree(normalizePortfolioStatuses(data));
+
+  function handleAdd(context: { selectedKey: string | null }) {
+    if (context.selectedKey?.startsWith("cat:")) {
+      const id = context.selectedKey.slice("cat:".length);
+      setAddCtx({ mode: "project", parentCategoryId: id === "uncat" ? undefined : id });
+    } else {
+      setAddCtx({ mode: "category" });
+    }
+  }
+
   return (
     <div style={{ display: "flex", flexDirection: "column", flex: 1, padding: 24, minHeight: 0 }}>
       <h1 style={{ fontSize: 20, fontWeight: 700, margin: 0, marginBottom: 4 }}>Timeline</h1>
       <p style={{ fontSize: 13, color: "var(--text-muted)", margin: 0, marginBottom: 12 }}>
         Everything across your workspace. Click a row to open details.
       </p>
-      <GanttContainer root={root} defaultZoom="month" addLabel="+ Add" />
+      <GanttContainer root={root} defaultZoom="month" addLabel={addCtx?.mode === "project" ? "+ Project" : "+ Category"} onAdd={handleAdd} />
+      {addCtx && (
+        <AddNodeModal
+          mode={addCtx.mode}
+          parentCategoryId={addCtx.parentCategoryId}
+          onClose={() => setAddCtx(null)}
+          onCreated={async () => { await fetchTimeline(); }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/workspace/gantt/AddNodeModal.tsx
+++ b/apps/web/src/components/workspace/gantt/AddNodeModal.tsx
@@ -1,0 +1,112 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+
+type Mode = "category" | "project" | "task" | "subtask";
+
+interface Props {
+  mode: Mode;
+  parentProjectId?: string;   // for task
+  parentTaskId?: string;      // for subtask
+  parentCategoryId?: string;  // for project
+  onClose: () => void;
+  onCreated: () => Promise<void> | void;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%", padding: "8px 10px", borderRadius: 6, border: "1px solid var(--border)",
+  background: "var(--surface-2)", color: "var(--text-1)", fontSize: 13, outline: "none", boxSizing: "border-box",
+};
+
+export function AddNodeModal({ mode, parentProjectId, parentTaskId, parentCategoryId, onClose, onCreated }: Props) {
+  const [title, setTitle] = useState("");
+  const [colour, setColour] = useState<string>("#6c44f6");
+  const [dueDate, setDueDate] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { titleRef.current?.focus(); }, []);
+
+  async function handleSave() {
+    if (!title.trim() || saving) return;
+    setSaving(true); setErr(null);
+    try {
+      if (mode === "category") {
+        const res = await fetch("/api/workspace/categories", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: title.trim(), colour }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      } else if (mode === "project") {
+        const res = await fetch("/api/workspace/projects", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: title.trim(), categoryId: parentCategoryId ?? null }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      } else if (mode === "task" || mode === "subtask") {
+        const body: Record<string, unknown> = {
+          projectId: parentProjectId, title: title.trim(),
+        };
+        if (dueDate) body.dueDate = dueDate;
+        if (mode === "subtask") body.parentTaskId = parentTaskId;
+        const res = await fetch("/api/workspace/tasks", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      }
+      await onCreated();
+      onClose();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const label = mode === "category" ? "New category" : mode === "project" ? "New project" : mode === "task" ? "New task" : "New subtask";
+
+  return (
+    <div style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div onClick={onClose} style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.35)", backdropFilter: "blur(2px)" }} />
+      <div style={{ position: "relative", background: "var(--surface, #fff)", border: "1px solid var(--border, #eaeaea)", borderRadius: 12, padding: 24, width: 380, boxShadow: "0 8px 32px rgba(0,0,0,0.16)" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
+          <h3 style={{ fontSize: 15, fontWeight: 700, margin: 0, color: "var(--text-1)" }}>{label}</h3>
+          <button onClick={onClose} style={{ background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: 6, padding: 4, cursor: "pointer", color: "var(--text-muted)" }}><X size={14} /></button>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div>
+            <p style={{ fontSize: 11, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, color: "var(--text-muted)", margin: 0, marginBottom: 6 }}>Name *</p>
+            <input
+              ref={titleRef} type="text" value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") void handleSave(); if (e.key === "Escape") onClose(); }}
+              placeholder={mode === "category" ? "Category name..." : mode === "project" ? "Project name..." : "Task title..."}
+              style={inputStyle}
+            />
+          </div>
+          {mode === "category" && (
+            <div>
+              <p style={{ fontSize: 11, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, color: "var(--text-muted)", margin: 0, marginBottom: 6 }}>Colour</p>
+              <input type="color" value={colour} onChange={(e) => setColour(e.target.value)} style={{ ...inputStyle, padding: 2, height: 36 }} />
+            </div>
+          )}
+          {(mode === "task" || mode === "subtask") && (
+            <div>
+              <p style={{ fontSize: 11, fontWeight: 600, textTransform: "uppercase", letterSpacing: 1, color: "var(--text-muted)", margin: 0, marginBottom: 6 }}>Due date</p>
+              <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} style={inputStyle} />
+            </div>
+          )}
+          {err && <p style={{ color: "#e84c6f", fontSize: 12, margin: 0 }}>{err}</p>}
+        </div>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 20, paddingTop: 14, borderTop: "1px solid var(--border)" }}>
+          <button onClick={onClose} style={{ padding: "8px 14px", fontSize: 13, fontWeight: 500, background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: 8, color: "var(--text-2)", cursor: "pointer" }}>Cancel</button>
+          <button onClick={() => void handleSave()} disabled={!title.trim() || saving} style={{ padding: "8px 14px", fontSize: 13, fontWeight: 500, background: "#6c44f6", border: 0, borderRadius: 8, color: "#fff", cursor: "pointer", opacity: (!title.trim() || saving) ? 0.5 : 1 }}>
+            {saving ? "Saving..." : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/gantt/GanttRow.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttRow.tsx
@@ -32,14 +32,19 @@ export function GanttRow({ row, range, hoveredKey, selectedKey, onHoverKey, onSe
   let content: React.ReactNode = null;
   if (n.kind === "task" || n.kind === "subtask") {
     const t = n.task;
-    const start = t.startDate;
+    const todayIso = new Date().toISOString().slice(0, 10);
     const end = t.endDate ?? t.dueDate;
-    if (start && end) {
+    // Normalize end to yyyy-mm-dd (API can return full ISO timestamps like 2026-04-16T00:00:00.000Z)
+    const endNorm = end ? String(end).slice(0, 10) : null;
+    const startNorm = t.startDate
+      ? String(t.startDate).slice(0, 10)
+      : (endNorm && endNorm > todayIso ? todayIso : endNorm);
+    if (startNorm && endNorm) {
       content = (
         <GanttBar
           variant={n.kind}
-          start={start}
-          end={end}
+          start={startNorm}
+          end={endNorm}
           progressPercent={t.progressPercent}
           range={range}
           label={t.title}

--- a/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+++ b/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { WorkspaceTimelineTask, WorkspaceTimeline } from "@/app/dashboard/types";
 import type { GanttTask } from "./gantt-types";
 import { buildProjectTree, normalizeGanttStatus } from "./gantt-utils";
 import { GanttContainer } from "./GanttContainer";
+import { AddNodeModal } from "./AddNodeModal";
 
 interface Props {
   projectId: string;
@@ -30,8 +31,7 @@ function toGanttTask(t: WorkspaceTimelineTask): GanttTask {
   };
 }
 
-export function ProjectGanttClient({ projectId, projectName, tasks, timeline, refresh: _refresh }: Props) {
-  // _refresh: Wired via onAdd in a follow-up
+export function ProjectGanttClient({ projectId, projectName, tasks, timeline, refresh }: Props) {
   const source = (timeline?.gantt && timeline.gantt.length > 0) ? timeline.gantt : tasks;
   const ganttTasks = useMemo(() => (source as WorkspaceTimelineTask[]).map(toGanttTask), [source]);
   const root = useMemo(
@@ -39,5 +39,28 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
     [projectId, projectName, ganttTasks],
   );
 
-  return <GanttContainer root={root} defaultZoom="month" addLabel="+ Task" />;
+  const [addCtx, setAddCtx] = useState<{ mode: "task" | "subtask"; parentTaskId?: string } | null>(null);
+
+  function handleAdd(context: { selectedKey: string | null }) {
+    if (context.selectedKey?.startsWith("task:")) {
+      setAddCtx({ mode: "subtask", parentTaskId: context.selectedKey.slice("task:".length) });
+    } else {
+      setAddCtx({ mode: "task" });
+    }
+  }
+
+  return (
+    <>
+      <GanttContainer root={root} defaultZoom="month" addLabel={addCtx?.mode === "subtask" ? "+ Subtask" : "+ Task"} onAdd={handleAdd} />
+      {addCtx && (
+        <AddNodeModal
+          mode={addCtx.mode}
+          parentProjectId={projectId}
+          parentTaskId={addCtx.parentTaskId}
+          onClose={() => setAddCtx(null)}
+          onCreated={async () => { await refresh(); }}
+        />
+      )}
+    </>
+  );
 }

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -102,4 +102,15 @@ describe("rollUpBar", () => {
   it("returns null when no tasks have dates", () => {
     expect(rollUpBar([baseTask()])).toBeNull();
   });
+
+  it("rollUpBar synthesizes start = today when only dueDate present and date is in future", () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 30);
+    const futureIso = future.toISOString().slice(0, 10);
+    const t = baseTask({ id: "a", startDate: null, endDate: null, dueDate: futureIso });
+    const r = rollUpBar([t]);
+    expect(r).not.toBeNull();
+    expect(r!.start).toBeTruthy();
+    expect(r!.end).toBe(futureIso);
+  });
 });

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -128,15 +128,18 @@ export interface RolledBar {
 }
 
 export function rollUpBar(tasks: GanttTask[]): RolledBar | null {
+  const todayIso = new Date().toISOString().slice(0, 10);
   const ranges = tasks
     .map((t) => {
-      const s = t.startDate;
+      const s = t.startDate ? String(t.startDate).slice(0, 10) : null;
       const e = t.endDate ?? t.dueDate;
-      if (!s || !e) return null;
+      const eNorm = e ? String(e).slice(0, 10) : null;
+      const sNorm = s ?? (eNorm && eNorm > todayIso ? todayIso : eNorm);
+      if (!sNorm || !eNorm) return null;
       const days = Math.max(1, Math.round(
-        (new Date(e).getTime() - new Date(s).getTime()) / 86_400_000,
+        (new Date(eNorm).getTime() - new Date(sNorm).getTime()) / 86_400_000,
       ));
-      return { start: s, end: e, progress: t.progressPercent, days };
+      return { start: sNorm, end: eNorm, progress: t.progressPercent, days };
     })
     .filter((x): x is NonNullable<typeof x> => x !== null);
 


### PR DESCRIPTION
## Summary

- **Fix A (Critical):** Tasks with `dueDate` but no `startDate` now render a bar. `GanttRow` synthesizes `startDate = today` when only a due date is present, and normalizes full ISO timestamps (e.g. `2026-04-16T00:00:00.000Z`) to `yyyy-mm-dd`. The same fix is applied to `rollUpBar` in `gantt-utils.ts` so parent/category rollup bars also work when children only have a due date.
- **Fix B (Critical UX):** New `AddNodeModal` component wired into both `PortfolioGanttClient` (category + project creation) and `ProjectGanttClient` (task + subtask creation). The `+ Add` button is now functional.
- **Proxy fix:** `CreateProjectSchema` in `apps/web/src/app/api/workspace/projects/route.ts` now accepts `categoryId` so new projects can be assigned to a category via the modal.

## Test plan

- [ ] All 8 existing `gantt-utils` tests pass (`vitest run`)
- [ ] New test: `rollUpBar synthesizes start = today when only dueDate present and date is in future` passes
- [ ] `next build` compiles with no TypeScript errors (74 pages generated)
- [ ] In the Portfolio Gantt: click `+ Category` → modal appears → enter name + colour → Create → row appears in timeline
- [ ] In the Portfolio Gantt: select a category row → click `+ Project` → modal appears → enter name → Create → project appears under category
- [ ] In the Project Gantt: click `+ Task` → modal with optional due date → Create → task appears; bar renders if due date set
- [ ] In the Project Gantt: select a task row → click `+ Subtask` → subtask modal → Create
- [ ] A task with only `dueDate` (no `startDate`) now shows a bar anchored from today to the due date

🤖 Generated with [Claude Code](https://claude.com/claude-code)