### PR TITLE
feat(gantt): v2 category-colour inheritance, hierarchy & category management (#67)

### DIFF
--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -1,14 +1,24 @@
 "use client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Settings } from "lucide-react";
 import type { PortfolioTimelineResponse } from "@/components/workspace/gantt/gantt-types";
-import { buildPortfolioTree, normalizePortfolioStatuses } from "@/components/workspace/gantt/gantt-utils";
+import { buildPortfolioTree, buildCategoryColorMap, normalizePortfolioStatuses } from "@/components/workspace/gantt/gantt-utils";
 import { GanttContainer } from "@/components/workspace/gantt/GanttContainer";
 import { AddNodeModal } from "@/components/workspace/gantt/AddNodeModal";
+import { CategoryManagerPanel } from "@/components/workspace/gantt/CategoryManagerPanel";
+import type { InlineAddMode } from "@/components/workspace/gantt/gantt-utils";
+
+type AddCtx =
+  | { mode: "category" }
+  | { mode: "project"; parentCategoryId?: string }
+  | { mode: "task"; parentProjectId: string }
+  | { mode: "subtask"; parentProjectId: string; parentTaskId: string };
 
 export function PortfolioGanttClient() {
   const [data, setData] = useState<PortfolioTimelineResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [addCtx, setAddCtx] = useState<{ mode: "category" | "project"; parentCategoryId?: string } | null>(null);
+  const [addCtx, setAddCtx] = useState<AddCtx | null>(null);
+  const [managerOpen, setManagerOpen] = useState(false);
 
   const fetchTimeline = useCallback(async () => {
     try {
@@ -22,10 +32,16 @@ export function PortfolioGanttClient() {
 
   useEffect(() => { void fetchTimeline(); }, [fetchTimeline]);
 
+  const categoryColorMap = useMemo(
+    () => data ? buildCategoryColorMap(data.categories.map((c) => ({ id: c.id, colour: c.colour }))) : undefined,
+    [data],
+  );
+
   if (error) return <div style={{ padding: 24 }}>Couldn't load timeline: {error}</div>;
   if (!data) return <div style={{ padding: 24 }}>Loading…</div>;
 
-  const root = buildPortfolioTree(normalizePortfolioStatuses(data));
+  const normalized = normalizePortfolioStatuses(data);
+  const root = buildPortfolioTree(normalized);
 
   function handleAdd(context: { selectedKey: string | null }) {
     if (context.selectedKey?.startsWith("cat:")) {
@@ -36,17 +52,113 @@ export function PortfolioGanttClient() {
     }
   }
 
+  function findProjectIdForTaskKey(taskKey: string): string | null {
+    const taskId = taskKey.slice("task:".length);
+    for (const cat of normalized.categories) {
+      for (const proj of cat.projects) {
+        if (proj.tasks.some((t) => t.id === taskId)) return proj.id;
+      }
+    }
+    return null;
+  }
+
+  function handleInlineAdd(ctx: { mode: InlineAddMode; parentKey: string | null }) {
+    if (ctx.mode === "category") {
+      setAddCtx({ mode: "category" });
+      return;
+    }
+    if (ctx.mode === "project" && ctx.parentKey?.startsWith("cat:")) {
+      const id = ctx.parentKey.slice("cat:".length);
+      setAddCtx({ mode: "project", parentCategoryId: id === "uncat" ? undefined : id });
+      return;
+    }
+    if (ctx.mode === "task" && ctx.parentKey?.startsWith("proj:")) {
+      const id = ctx.parentKey.slice("proj:".length);
+      setAddCtx({ mode: "task", parentProjectId: id });
+      return;
+    }
+    if (ctx.mode === "subtask" && ctx.parentKey?.startsWith("task:")) {
+      const taskId = ctx.parentKey.slice("task:".length);
+      const projectId = findProjectIdForTaskKey(ctx.parentKey);
+      if (projectId) setAddCtx({ mode: "subtask", parentProjectId: projectId, parentTaskId: taskId });
+    }
+  }
+
+  const addLabel =
+    addCtx?.mode === "project" ? "+ Project"
+      : addCtx?.mode === "task" ? "+ Task"
+      : addCtx?.mode === "subtask" ? "+ Subtask"
+      : "+ Category";
+
   return (
-    <div style={{ display: "flex", flexDirection: "column", flex: 1, padding: 24, minHeight: 0 }}>
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, padding: 24, minHeight: 0, position: "relative" }}>
       <h1 style={{ fontSize: 20, fontWeight: 700, margin: 0, marginBottom: 4 }}>Timeline</h1>
       <p style={{ fontSize: 13, color: "var(--text-muted)", margin: 0, marginBottom: 12 }}>
         Everything across your workspace. Click a row to open details.
       </p>
-      <GanttContainer root={root} defaultZoom="month" addLabel={addCtx?.mode === "project" ? "+ Project" : "+ Category"} onAdd={handleAdd} />
+
+      <GanttContainer
+        root={root}
+        defaultZoom="month"
+        addLabel={addLabel}
+        onAdd={handleAdd}
+        categoryColorMap={categoryColorMap}
+        onInlineAdd={handleInlineAdd}
+        outlineHeaderActions={
+          <button
+            aria-label="Manage categories"
+            onClick={() => setManagerOpen(true)}
+            style={{
+              background: "transparent",
+              border: 0,
+              padding: 4,
+              borderRadius: 4,
+              color: "var(--text-muted, #bdb7d0)",
+              cursor: "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Settings size={14} />
+          </button>
+        }
+        outlineFooter={
+          <button
+            onClick={() => setAddCtx({ mode: "category" })}
+            style={{
+              textAlign: "left",
+              height: 36,
+              padding: "0 14px 0 34px",
+              background: "transparent",
+              border: 0,
+              borderTop: "1px solid var(--border, #f0edfa)",
+              fontSize: 11,
+              fontStyle: "italic",
+              color: "var(--text-muted, #bdb7d0)",
+              cursor: "pointer",
+              width: "100%",
+            }}
+          >
+            + Add category
+          </button>
+        }
+        outlineOverlay={
+          managerOpen ? (
+            <CategoryManagerPanel
+              onClose={() => setManagerOpen(false)}
+              onChanged={async () => { await fetchTimeline(); }}
+            />
+          ) : null
+        }
+      />
+
       {addCtx && (
         <AddNodeModal
           mode={addCtx.mode}
-          parentCategoryId={addCtx.parentCategoryId}
+          parentCategoryId={addCtx.mode === "project" ? addCtx.parentCategoryId : undefined}
+          parentProjectId={addCtx.mode === "task" || addCtx.mode === "subtask" ? addCtx.parentProjectId : undefined}
+          parentTaskId={addCtx.mode === "subtask" ? addCtx.parentTaskId : undefined}
           onClose={() => setAddCtx(null)}
           onCreated={async () => { await fetchTimeline(); }}
         />

--- a/apps/web/src/components/workspace/gantt/CategoryDot.tsx
+++ b/apps/web/src/components/workspace/gantt/CategoryDot.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { tinyTint } from "./gantt-utils";
+
+export type CategoryDotTier = "category" | "project" | "task" | "subtask";
+
+const SIZE_BY_TIER: Record<CategoryDotTier, number> = {
+  category: 8,
+  project: 7,
+  task: 5,
+  subtask: 4,
+};
+
+const OPACITY_BY_TIER: Record<CategoryDotTier, number> = {
+  category: 1,
+  project: 0.8,
+  task: 0.6,
+  subtask: 0.5,
+};
+
+interface Props {
+  color: string;
+  tier: CategoryDotTier;
+}
+
+export function CategoryDot({ color, tier }: Props) {
+  const size = SIZE_BY_TIER[tier];
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: color,
+        opacity: OPACITY_BY_TIER[tier],
+        boxShadow: tier === "category" ? `0 0 0 2px ${tinyTint(color, 0.18)}` : "none",
+        flexShrink: 0,
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/workspace/gantt/CategoryManagerPanel.tsx
+++ b/apps/web/src/components/workspace/gantt/CategoryManagerPanel.tsx
@@ -1,0 +1,287 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { X, Pencil, Trash2 } from "lucide-react";
+import type { ProjectCategory } from "./gantt-types";
+import { DEFAULT_CATEGORY_COLOUR } from "./gantt-types";
+
+interface Props {
+  onClose: () => void;
+  onChanged: () => Promise<void> | void; // refetch timeline after any mutation
+  topOffset?: number;                     // sits below the outline header
+}
+
+const iconBtnStyle: React.CSSProperties = {
+  background: "transparent",
+  border: 0,
+  padding: 4,
+  borderRadius: 4,
+  color: "var(--text-muted, #bdb7d0)",
+  cursor: "pointer",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+export function CategoryManagerPanel({ onClose, onChanged, topOffset = 48 }: Props) {
+  const [categories, setCategories] = useState<ProjectCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const creatingRef = useRef<HTMLInputElement>(null);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newColour, setNewColour] = useState(DEFAULT_CATEGORY_COLOUR);
+
+  const load = useCallback(async () => {
+    setLoading(true); setErr(null);
+    try {
+      const res = await fetch("/api/workspace/categories", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as { categories: ProjectCategory[] };
+      setCategories(body.categories ?? []);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Load failed");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function handleRecolour(id: string, colour: string) {
+    setCategories((prev) => prev.map((c) => c.id === id ? { ...c, colour } : c));
+    try {
+      const res = await fetch(`/api/workspace/categories/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ colour }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Update failed");
+      await load();
+    }
+  }
+
+  function startRename(c: ProjectCategory) {
+    setEditingId(c.id); setEditingName(c.name);
+    requestAnimationFrame(() => editInputRef.current?.focus());
+  }
+
+  async function saveRename(id: string) {
+    const name = editingName.trim();
+    setEditingId(null);
+    if (!name) return;
+    try {
+      const res = await fetch(`/api/workspace/categories/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await load();
+      await onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Update failed");
+    }
+  }
+
+  async function handleDelete(c: ProjectCategory) {
+    const ok = typeof window !== "undefined" &&
+      window.confirm(`Delete category "${c.name}"? Projects will move to Uncategorised.`);
+    if (!ok) return;
+    try {
+      const res = await fetch(`/api/workspace/categories/${c.id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await load();
+      await onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Delete failed");
+    }
+  }
+
+  async function handleCreate() {
+    const name = newName.trim();
+    if (!name) { setCreating(false); return; }
+    try {
+      const res = await fetch("/api/workspace/categories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, colour: newColour }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setNewName(""); setNewColour(DEFAULT_CATEGORY_COLOUR); setCreating(false);
+      await load();
+      await onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Create failed");
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Category manager"
+      style={{
+        position: "absolute",
+        top: topOffset,
+        left: 0,
+        width: 280,
+        bottom: 0,
+        background: "var(--surface, #fff)",
+        borderRight: "1px solid var(--border, #f0edfa)",
+        zIndex: 10,
+        padding: "14px",
+        boxShadow: "4px 0 12px rgba(0, 0, 0, 0.04)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        overflowY: "auto",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{
+          fontSize: 11, fontWeight: 500, letterSpacing: "0.08em", textTransform: "uppercase",
+          color: "var(--text-2, #4b556b)",
+        }}>
+          Categories
+        </span>
+        <button
+          onClick={onClose}
+          aria-label="Close category manager"
+          style={{ ...iconBtnStyle, padding: 6 }}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {err && <div style={{ fontSize: 12, color: "#e84c6f" }}>{err}</div>}
+      {loading && <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Loading…</div>}
+
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {categories.map((c) => (
+          <div
+            key={c.id}
+            style={{
+              display: "flex", alignItems: "center", gap: 8,
+              padding: "8px 0",
+              borderBottom: "1px solid var(--border, #f0edfa)",
+            }}
+          >
+            <input
+              aria-label={`Colour for ${c.name}`}
+              type="color"
+              value={c.colour ?? DEFAULT_CATEGORY_COLOUR}
+              onChange={(e) => void handleRecolour(c.id, e.target.value)}
+              style={{
+                width: 22, height: 22, border: "none", borderRadius: 4,
+                cursor: "pointer", padding: 0, background: "transparent",
+                flexShrink: 0,
+              }}
+            />
+            {editingId === c.id ? (
+              <input
+                ref={editInputRef}
+                value={editingName}
+                onChange={(e) => setEditingName(e.target.value)}
+                onBlur={() => void saveRename(c.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void saveRename(c.id);
+                  if (e.key === "Escape") setEditingId(null);
+                }}
+                style={{
+                  flex: 1, fontSize: 13, color: "var(--text-1)",
+                  border: "1px solid var(--border)",
+                  background: "var(--surface-2, #f6f2fc)",
+                  borderRadius: 4, padding: "2px 6px", outline: "none", minWidth: 0,
+                }}
+              />
+            ) : (
+              <span style={{
+                flex: 1, fontSize: 13, color: "var(--text-1)",
+                whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+              }}>
+                {c.name}
+              </span>
+            )}
+            <button
+              onClick={() => startRename(c)}
+              aria-label={`Rename ${c.name}`}
+              style={iconBtnStyle}
+            >
+              <Pencil size={12} />
+            </button>
+            <button
+              onClick={() => void handleDelete(c)}
+              aria-label={`Delete ${c.name}`}
+              style={iconBtnStyle}
+            >
+              <Trash2 size={12} />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {creating ? (
+        <div style={{
+          display: "flex", alignItems: "center", gap: 8,
+          padding: "8px", border: "1px solid var(--border)",
+          borderRadius: 8, background: "var(--surface-2, #f6f2fc)",
+        }}>
+          <input
+            aria-label="New category colour"
+            type="color"
+            value={newColour}
+            onChange={(e) => setNewColour(e.target.value)}
+            style={{ width: 22, height: 22, border: "none", padding: 0, cursor: "pointer", background: "transparent", flexShrink: 0 }}
+          />
+          <input
+            ref={creatingRef}
+            autoFocus
+            placeholder="Category name…"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleCreate();
+              if (e.key === "Escape") { setCreating(false); setNewName(""); }
+            }}
+            style={{
+              flex: 1, fontSize: 13,
+              border: "1px solid var(--border)", borderRadius: 4,
+              padding: "2px 6px", outline: "none", minWidth: 0,
+              background: "var(--surface, #fff)", color: "var(--text-1)",
+            }}
+          />
+          <button
+            onClick={() => void handleCreate()}
+            style={{
+              background: "#6c44f6", color: "#fff", border: 0,
+              borderRadius: 4, padding: "4px 8px", fontSize: 12, cursor: "pointer",
+            }}
+          >
+            Add
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setCreating(true)}
+          style={{
+            width: "100%",
+            padding: "10px 0",
+            background: "transparent",
+            border: "1px dashed var(--border-2, #bdb7d0)",
+            borderRadius: 8,
+            fontSize: 12,
+            color: "var(--text-2, #4b556b)",
+            cursor: "pointer",
+          }}
+        >
+          + New category
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/gantt/GanttBar.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttBar.tsx
@@ -1,74 +1,171 @@
 "use client";
-import type { GanttTask } from "./gantt-types";
-import { dateToPct, type TimelineRange } from "./gantt-utils";
+import type { CSSProperties } from "react";
+import type { GanttTask, GanttTaskStatus } from "./gantt-types";
+import { contrastTextFor, dateToPct, type TimelineRange } from "./gantt-utils";
 
-type Variant = "category" | "project" | "task" | "subtask" | "rollup";
+export type GanttBarVariant = "category" | "project" | "task" | "subtask";
 
 interface Props {
-  variant: Variant;
+  variant: GanttBarVariant;
   start: string;
   end: string;
   progressPercent: number;
   range: TimelineRange;
+  categoryColor: string;
+  status?: GanttTaskStatus; // only meaningful for task/subtask
   label?: string;
   task?: GanttTask;
   highlighted?: boolean;
+  selected?: boolean;
   dimmed?: boolean;
   onClick?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
 }
 
-const VARIANT_CSS: Record<Variant, { height: number; bg: string; bar: string; bold?: boolean }> = {
-  category: { height: 20, bg: "rgba(108, 68, 246, 0.06)", bar: "rgba(108, 68, 246, 0.18)", bold: true },
-  project:  { height: 16, bg: "rgba(108, 68, 246, 0.18)", bar: "#6c44f6" },
-  task:     { height: 16, bg: "var(--tl-not-started)", bar: "var(--tl-in-progress-dark, #6c44f6)" },
-  subtask:  { height: 10, bg: "var(--tl-not-started)", bar: "var(--tl-in-progress-dark, #6c44f6)" },
-  rollup:   { height: 6,  bg: "rgba(108, 68, 246, 0.15)", bar: "rgba(108, 68, 246, 0.40)" },
+const HEIGHT_BY_VARIANT: Record<GanttBarVariant, number> = {
+  category: 6,
+  project: 10,
+  task: 16,
+  subtask: 10,
 };
 
-export function GanttBar({ variant, start, end, progressPercent, range, label, highlighted, dimmed, onClick, onMouseEnter, onMouseLeave }: Props) {
+const ROLLUP_OPACITY = 0.45;
+
+export function GanttBar({
+  variant, start, end, progressPercent, range, categoryColor, status, label, highlighted, selected, dimmed,
+  onClick, onMouseEnter, onMouseLeave,
+}: Props) {
   const s = new Date(start);
   const e = new Date(end);
   const left = dateToPct(s, range);
   const right = dateToPct(e, range);
   const width = Math.max(right - left, 0.5);
-  const cfg = VARIANT_CSS[variant];
-  const ring = highlighted ? "0 0 0 2px #6c44f6" : undefined;
+
+  const height = HEIGHT_BY_VARIANT[variant];
+  const isRollup = variant === "category" || variant === "project";
+
+  const effectiveStatus: GanttTaskStatus | undefined = isRollup ? undefined : (status ?? "on_track");
+
+  // Base fill — transparent for not_started, categoryColor otherwise.
+  let background: string = categoryColor;
+  if (effectiveStatus === "not_started") background = "transparent";
+
+  // Status-driven border.
+  let border: CSSProperties["border"] = "none";
+  if (effectiveStatus === "not_started") border = `1.5px dashed ${categoryColor}`;
+  else if (effectiveStatus === "overdue") border = "2px solid var(--tl-overdue, #e87878)";
+
+  // Opacity.
+  let opacity = 1;
+  if (isRollup) opacity = ROLLUP_OPACITY;
+  else if (effectiveStatus === "completed") opacity = 0.5;
+  if (dimmed) opacity *= 0.35;
+
+  const ring = highlighted || selected ? "0 0 0 2px #6c44f6" : undefined;
+  const textColor = contrastTextFor(categoryColor);
+
+  const showLabel = !isRollup && variant !== "subtask" && label;
+  const labelSuffix = effectiveStatus === "completed" ? " ✓" : "";
+  const progressClamped = Math.min(100, Math.max(0, progressPercent));
 
   return (
     <div
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      title={label}
       style={{
         position: "absolute",
-        left: `${left}%`, width: `${width}%`,
-        top: `calc(50% - ${cfg.height / 2}px)`,
-        height: cfg.height,
-        background: cfg.bg,
-        borderRadius: cfg.height >= 14 ? 6 : 4,
-        overflow: "hidden",
+        left: `${left}%`,
+        width: `${width}%`,
+        top: `calc(50% - ${height / 2}px)`,
+        height,
         cursor: onClick ? "pointer" : "default",
         boxShadow: ring,
-        opacity: dimmed ? 0.3 : 1,
+        opacity,
         transition: "box-shadow 120ms",
       }}
-      title={label}
     >
-      <div style={{
-        width: `${Math.min(100, Math.max(0, progressPercent))}%`,
-        height: "100%",
-        background: cfg.bar,
-      }} />
-      {label && variant !== "subtask" && variant !== "category" && (
-        <span style={{
-          position: "absolute", left: 8, top: "50%", transform: "translateY(-50%)",
-          fontSize: 11, fontWeight: cfg.bold ? 700 : 500,
-          color: "#fff",
-          whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
-          maxWidth: "calc(100% - 16px)", mixBlendMode: "normal",
-        }}>{label}</span>
+      {/* Base fill + border (status modifier) */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background,
+          border,
+          borderRadius: height >= 14 ? 4 : 3,
+          boxSizing: "border-box",
+        }}
+      />
+      {/* Progress fill for task bars with solid background */}
+      {variant === "task" && effectiveStatus !== "not_started" && (
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: `${progressClamped}%`,
+            background: "rgba(255, 255, 255, 0.18)",
+            mixBlendMode: "screen",
+            borderTopLeftRadius: height >= 14 ? 4 : 3,
+            borderBottomLeftRadius: height >= 14 ? 4 : 3,
+            pointerEvents: "none",
+          }}
+        />
+      )}
+      {/* at_risk top stripe */}
+      {effectiveStatus === "at_risk" && (
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 3,
+            background: "var(--tl-at-risk, #d4b84a)",
+            borderTopLeftRadius: height >= 14 ? 4 : 3,
+            borderTopRightRadius: height >= 14 ? 4 : 3,
+            pointerEvents: "none",
+          }}
+        />
+      )}
+      {/* Overdue right-end dot */}
+      {effectiveStatus === "overdue" && (
+        <div
+          style={{
+            position: "absolute",
+            right: -3,
+            top: `calc(50% - 3px)`,
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            background: "var(--tl-overdue, #e87878)",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+      {/* Label */}
+      {showLabel && (
+        <span
+          style={{
+            position: "absolute",
+            left: 8,
+            top: "50%",
+            transform: "translateY(-50%)",
+            fontSize: 11,
+            fontWeight: 500,
+            color: effectiveStatus === "not_started" ? "var(--text-2, #4b556b)" : textColor,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            maxWidth: "calc(100% - 16px)",
+            pointerEvents: "none",
+          }}
+        >
+          {label}{labelSuffix}
+        </span>
       )}
     </div>
   );

--- a/apps/web/src/components/workspace/gantt/GanttContainer.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { GanttNode, GanttTask, ZoomLevel } from "./gantt-types";
-import { computeRange, flattenVisible, dateToPct } from "./gantt-utils";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import type { CategoryColorMap, GanttNode, GanttTask, ZoomLevel } from "./gantt-types";
+import { computeRange, flattenVisible, dateToPct, injectInlineAdds } from "./gantt-utils";
 import { GanttOutline } from "./GanttOutline";
 import { GanttGrid } from "./GanttGrid";
 import { GanttToolbar } from "./GanttToolbar";
@@ -12,12 +12,23 @@ interface Props {
   onOpenDetail?: (key: string) => void;
   onAdd?: (context: { selectedKey: string | null }) => void;
   addLabel?: string;
+  categoryColorMap?: CategoryColorMap;
+  rootCategoryColor?: string;
+  onInlineAdd?: (ctx: { mode: "category" | "project" | "task" | "subtask"; parentKey: string | null }) => void;
+  outlineHeader?: ReactNode;
+  outlineHeaderActions?: ReactNode;
+  outlineFooter?: ReactNode;
+  outlineOverlay?: ReactNode;
 }
 
-export function GanttContainer({ root, defaultZoom = "month", onOpenDetail, onAdd, addLabel = "+ Add" }: Props) {
+export function GanttContainer({
+  root, defaultZoom = "month", onOpenDetail, onAdd, addLabel = "+ Add",
+  categoryColorMap, rootCategoryColor,
+  onInlineAdd, outlineHeader, outlineHeaderActions, outlineFooter, outlineOverlay,
+}: Props) {
   const [zoom, setZoom] = useState<ZoomLevel>(defaultZoom);
   const [search, setSearch] = useState("");
-  const [outlineWidth, setOutlineWidth] = useState(320);
+  const [outlineWidth, setOutlineWidth] = useState(260);
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(() => collectAllKeys(root));
@@ -27,11 +38,17 @@ export function GanttContainer({ root, defaultZoom = "month", onOpenDetail, onAd
   const range = useMemo(() => computeRange(allTasks, zoom), [allTasks, zoom]);
 
   const rows = useMemo(() => {
-    const base = flattenVisible(root, expanded);
-    if (!search.trim()) return base;
-    const q = search.toLowerCase();
-    return base.map((r) => ({ ...r, dimmed: !nodeLabel(r.node).toLowerCase().includes(q) }));
-  }, [root, expanded, search]);
+    const base = flattenVisible(root, expanded, { categoryColorMap, rootCategoryColor });
+    const withSearch = (!search.trim())
+      ? base
+      : (() => {
+          const q = search.toLowerCase();
+          return base.map((r) => r.kind === "node"
+            ? { ...r, dimmed: !nodeLabel(r.node).toLowerCase().includes(q) }
+            : r);
+        })();
+    return onInlineAdd ? injectInlineAdds(withSearch, expanded) : withSearch;
+  }, [root, expanded, search, categoryColorMap, rootCategoryColor, onInlineAdd]);
 
   const allCollapsed = expanded.size === 0;
 
@@ -75,7 +92,7 @@ export function GanttContainer({ root, defaultZoom = "month", onOpenDetail, onAd
         canAdd={Boolean(onAdd)}
         addLabel={addLabel}
       />
-      <div style={{ display: "flex", flex: 1, minHeight: 0, border: "1px solid var(--border, #eaeaea)", borderRadius: 12, background: "#fff", overflow: "hidden" }}>
+      <div style={{ display: "flex", flex: 1, minHeight: 0, border: "1px solid var(--border, #f0edfa)", borderRadius: 12, background: "#fff", overflow: "hidden" }}>
         <GanttOutline
           rows={rows}
           expanded={expanded}
@@ -86,6 +103,11 @@ export function GanttContainer({ root, defaultZoom = "month", onOpenDetail, onAd
           onToggle={toggle}
           onSelect={(k) => { setSelectedKey(k); onOpenDetail?.(k); }}
           onHover={setHoveredKey}
+          onInlineAdd={onInlineAdd}
+          header={outlineHeader}
+          headerActions={outlineHeaderActions}
+          footer={outlineFooter}
+          overlay={outlineOverlay}
         />
         <GanttGrid
           ref={gridRef}

--- a/apps/web/src/components/workspace/gantt/GanttDateHeader.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttDateHeader.tsx
@@ -1,0 +1,82 @@
+"use client";
+import type { ZoomLevel } from "./gantt-types";
+import type { TimelineRange } from "./gantt-utils";
+import { generateDateAxis } from "./gantt-utils";
+
+interface Props {
+  range: TimelineRange;
+  zoom: ZoomLevel;
+}
+
+export const GANTT_HEADER_HEIGHT = 48;
+
+export function GanttDateHeader({ range, zoom }: Props) {
+  const axis = generateDateAxis(range, zoom);
+
+  return (
+    <div
+      style={{
+        position: "sticky",
+        top: 0,
+        height: GANTT_HEADER_HEIGHT,
+        background: "var(--surface, #fff)",
+        borderBottom: "1px solid var(--border, #f0edfa)",
+        zIndex: 2,
+      }}
+    >
+      {/* Month row */}
+      <div
+        style={{
+          position: "relative",
+          height: 20,
+          borderBottom: "1px solid var(--border, #f0edfa)",
+        }}
+      >
+        {axis.months.map((m, i) => (
+          <div
+            key={`${m.label}-${i}`}
+            style={{
+              position: "absolute",
+              left: `${m.startPct}%`,
+              width: `${Math.max(0, m.endPct - m.startPct)}%`,
+              top: 0,
+              bottom: 0,
+              padding: "4px 0 0 8px",
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "var(--text-2, #4b556b)",
+              borderRight: i < axis.months.length - 1 ? "1px solid var(--border-2, #bdb7d0)" : "none",
+              boxSizing: "border-box",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+            }}
+          >
+            {m.label}
+          </div>
+        ))}
+      </div>
+
+      {/* Day row */}
+      <div style={{ position: "relative", height: 28 }}>
+        {axis.days.map((d, i) => (
+          <span
+            key={`${d.label}-${i}`}
+            style={{
+              position: "absolute",
+              left: `${d.pct}%`,
+              transform: "translateX(-50%)",
+              top: 8,
+              fontSize: 10,
+              color: "var(--text-2, #4b556b)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {d.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/gantt/GanttGrid.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttGrid.tsx
@@ -3,8 +3,10 @@ import { forwardRef, useMemo } from "react";
 import type { FlatRow } from "./gantt-utils";
 import type { ZoomLevel } from "./gantt-types";
 import type { TimelineRange } from "./gantt-utils";
-import { dateToPct } from "./gantt-utils";
+import { dateToPct, generateDateAxis } from "./gantt-utils";
 import { GanttRow } from "./GanttRow";
+import { GanttDateHeader, GANTT_HEADER_HEIGHT } from "./GanttDateHeader";
+import { ROW_HEIGHT } from "./gantt-types";
 
 interface Props {
   rows: FlatRow[];
@@ -19,64 +21,103 @@ interface Props {
 export const GanttGrid = forwardRef<HTMLDivElement, Props>(function GanttGrid(
   { rows, range, zoom, hoveredKey, selectedKey, onHoverKey, onSelectKey }, ref,
 ) {
-  const markers = useMemo(() => generateMarkers(range, zoom), [range, zoom]);
+  const axis = useMemo(() => generateDateAxis(range, zoom), [range, zoom]);
   const todayPct = dateToPct(new Date(), range);
+  const todayInRange = todayPct >= 0 && todayPct <= 100;
 
   return (
     <div ref={ref} style={{ position: "relative", overflowX: "auto", flex: 1, minHeight: 0 }}>
       <div style={{ minWidth: "max-content", position: "relative" }}>
-        {/* Header */}
-        <div style={{ position: "sticky", top: 0, height: 34, background: "#fff", borderBottom: "1px solid var(--border, #eaeaea)", zIndex: 1 }}>
-          {markers.map((m, i) => (
-            <span key={i} style={{ position: "absolute", left: `${m.pct}%`, top: 10, fontSize: 10, color: "var(--text-muted)" }}>
-              {m.label}
-            </span>
+        <GanttDateHeader range={range} zoom={zoom} />
+
+        {/* Vertical gridlines — render before rows so row content stacks on top */}
+        <div style={{ position: "absolute", top: GANTT_HEADER_HEIGHT, left: 0, right: 0, bottom: 0, pointerEvents: "none", zIndex: 0 }}>
+          {axis.days.map((d, i) => (
+            <div
+              key={`grid-${i}`}
+              style={{
+                position: "absolute",
+                left: `${d.pct}%`,
+                top: 0,
+                bottom: 0,
+                width: 1,
+                background: d.isMonthStart
+                  ? "var(--border-2, #bdb7d0)"
+                  : "var(--surface-2, #f6f2fc)",
+                opacity: d.isMonthStart ? 0.6 : 1,
+              }}
+            />
           ))}
         </div>
 
-        {/* Today line */}
-        <div style={{ position: "absolute", left: `${todayPct}%`, top: 34, bottom: 0, width: 1, background: "rgba(108, 68, 246, 0.4)", pointerEvents: "none", zIndex: 1 }} />
+        {/* Today line (below the header, runs full height of rows) */}
+        {todayInRange && (
+          <>
+            <div
+              style={{
+                position: "absolute",
+                left: `${todayPct}%`,
+                top: GANTT_HEADER_HEIGHT,
+                bottom: 0,
+                width: 1,
+                background: "rgba(108, 68, 246, 0.4)",
+                pointerEvents: "none",
+                zIndex: 1,
+              }}
+            />
+            {/* Today pill */}
+            <div
+              style={{
+                position: "absolute",
+                left: `${todayPct}%`,
+                top: GANTT_HEADER_HEIGHT - 18,
+                transform: "translateX(-50%)",
+                padding: "2px 6px",
+                fontSize: 10,
+                fontWeight: 600,
+                color: "#6c44f6",
+                background: "var(--surface, #fff)",
+                border: "1px solid rgba(108, 68, 246, 0.35)",
+                borderRadius: 4,
+                pointerEvents: "none",
+                zIndex: 3,
+                whiteSpace: "nowrap",
+              }}
+            >
+              Today
+            </div>
+          </>
+        )}
 
         {/* Rows */}
-        {rows.map((r) => (
-          <GanttRow key={r.key} row={r} range={range} hoveredKey={hoveredKey} selectedKey={selectedKey}
-            onHoverKey={onHoverKey} onSelectKey={onSelectKey} />
-        ))}
+        <div style={{ position: "relative", zIndex: 1 }}>
+          {rows.map((r) => {
+            if (r.kind === "add") {
+              return (
+                <div
+                  key={r.key}
+                  style={{
+                    height: r.height,
+                    borderBottom: "1px solid var(--border, #f0edfa)",
+                  }}
+                />
+              );
+            }
+            return (
+              <div key={r.key} style={{ height: r.height ?? ROW_HEIGHT }}>
+                <GanttRow
+                  row={r}
+                  range={range}
+                  hoveredKey={hoveredKey}
+                  selectedKey={selectedKey}
+                  onHoverKey={onHoverKey}
+                  onSelectKey={onSelectKey}
+                />
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
 });
-
-function generateMarkers(range: TimelineRange, zoom: ZoomLevel): Array<{ pct: number; label: string }> {
-  const markers: Array<{ pct: number; label: string }> = [];
-  const cursor = new Date(range.start);
-
-  if (zoom === "week") {
-    while (cursor <= range.end) {
-      markers.push({
-        pct: dateToPct(cursor, range),
-        label: cursor.toLocaleDateString("en-GB", { weekday: "short", day: "numeric" }),
-      });
-      cursor.setDate(cursor.getDate() + 1);
-    }
-  } else if (zoom === "month") {
-    cursor.setDate(cursor.getDate() + ((8 - cursor.getDay()) % 7 || 7));
-    while (cursor <= range.end) {
-      markers.push({
-        pct: dateToPct(cursor, range),
-        label: cursor.toLocaleDateString("en-GB", { day: "numeric", month: "short" }),
-      });
-      cursor.setDate(cursor.getDate() + 7);
-    }
-  } else {
-    cursor.setDate(1); cursor.setMonth(cursor.getMonth() + 1);
-    while (cursor <= range.end) {
-      markers.push({
-        pct: dateToPct(cursor, range),
-        label: cursor.toLocaleDateString("en-GB", { month: "short", year: "2-digit" }),
-      });
-      cursor.setMonth(cursor.getMonth() + 1);
-    }
-  }
-  return markers;
-}

--- a/apps/web/src/components/workspace/gantt/GanttInlineAdd.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttInlineAdd.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState } from "react";
+import type { InlineAddMode } from "./gantt-utils";
+import { CategoryDot } from "./CategoryDot";
+
+interface Props {
+  mode: InlineAddMode;
+  parentKey: string | null;
+  depth: number;
+  categoryColor: string;
+  height: number;
+  onClick?: () => void;
+}
+
+const LABEL_BY_MODE: Record<InlineAddMode, string> = {
+  category: "Add category",
+  project: "Add project",
+  task: "Add task",
+  subtask: "Add subtask",
+};
+
+export function GanttInlineAdd({ mode, depth, categoryColor, height, onClick }: Props) {
+  const [hovered, setHovered] = useState(false);
+  const indent = 14 + depth * 14;
+
+  return (
+    <div
+      role="button"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={onClick}
+      style={{
+        height,
+        paddingLeft: indent,
+        paddingRight: 14,
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        fontSize: 11,
+        fontStyle: "italic",
+        color: "var(--text-muted, #bdb7d0)",
+        borderBottom: "1px solid var(--border, #f0edfa)",
+        cursor: onClick ? "pointer" : "default",
+        opacity: hovered ? 1 : 0.55,
+        transition: "opacity 120ms",
+        userSelect: "none",
+        background: hovered ? "var(--surface-2, #f6f2fc)" : "transparent",
+      }}
+    >
+      <span style={{ width: 16, flexShrink: 0 }} />
+      <CategoryDot color={categoryColor} tier="task" />
+      <span style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+        + {LABEL_BY_MODE[mode]}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/gantt/GanttOutline.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttOutline.tsx
@@ -1,7 +1,10 @@
 "use client";
-import { useRef, useCallback, useEffect } from "react";
-import type { FlatRow } from "./gantt-utils";
+import { useRef, useCallback, useEffect, type ReactNode } from "react";
+import type { FlatRow, InlineAddMode } from "./gantt-utils";
 import { GanttOutlineRow } from "./GanttOutlineRow";
+import { GanttInlineAdd } from "./GanttInlineAdd";
+import { ROW_HEIGHT } from "./gantt-types";
+import { GANTT_HEADER_HEIGHT } from "./GanttDateHeader";
 
 interface Props {
   rows: FlatRow[];
@@ -13,12 +16,20 @@ interface Props {
   onToggle: (key: string) => void;
   onSelect: (key: string) => void;
   onHover: (key: string | null) => void;
+  onInlineAdd?: (ctx: { mode: InlineAddMode; parentKey: string | null }) => void;
+  header?: ReactNode;        // optional: full replacement for the default header
+  headerActions?: ReactNode; // optional: right-aligned actions inside default header (e.g. gear icon)
+  footer?: ReactNode;
+  overlay?: ReactNode;       // optional: absolutely-positioned child (e.g. CategoryManagerPanel)
 }
 
 const MIN_WIDTH = 220;
-const MAX_WIDTH = 520;
+const MAX_WIDTH = 420;
 
-export function GanttOutline({ rows, expanded, selectedKey, hoveredKey, width, onWidthChange, onToggle, onSelect, onHover }: Props) {
+export function GanttOutline({
+  rows, expanded, selectedKey, hoveredKey, width, onWidthChange,
+  onToggle, onSelect, onHover, onInlineAdd, header, headerActions, footer, overlay,
+}: Props) {
   const dragging = useRef(false);
   const startX = useRef(0);
   const startW = useRef(width);
@@ -46,21 +57,73 @@ export function GanttOutline({ rows, expanded, selectedKey, hoveredKey, width, o
   }, [onWidthChange]);
 
   return (
-    <div style={{ position: "sticky", left: 0, zIndex: 2, background: "#fff", width, flexShrink: 0, borderRight: "1px solid var(--border, #eaeaea)" }}>
-      <div style={{ overflow: "hidden" }}>
-        {rows.map((row) => (
-          <GanttOutlineRow
-            key={row.key}
-            row={row}
-            expanded={expanded.has(row.key)}
-            selected={selectedKey === row.key}
-            hovered={hoveredKey === row.key}
-            onToggle={() => onToggle(row.key)}
-            onSelect={() => onSelect(row.key)}
-            onHover={(h) => onHover(h ? row.key : null)}
-          />
-        ))}
+    <div style={{
+      position: "sticky", left: 0, zIndex: 2, background: "#fff",
+      width, flexShrink: 0,
+      borderRight: "1px solid var(--border, #f0edfa)",
+      display: "flex", flexDirection: "column",
+    }}>
+      {header ?? (
+        <div
+          style={{
+            position: "sticky",
+            top: 0,
+            height: GANTT_HEADER_HEIGHT,
+            display: "flex",
+            alignItems: "flex-end",
+            justifyContent: "space-between",
+            padding: "0 14px 10px 20px",
+            borderBottom: "1px solid var(--border, #f0edfa)",
+            background: "var(--surface, #fff)",
+            zIndex: 2,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 500,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              color: "var(--text-2, #4b556b)",
+            }}
+          >
+            Task / Groups
+          </span>
+          {headerActions}
+        </div>
+      )}
+      <div style={{ flex: 1, overflow: "hidden" }}>
+        {rows.map((row) => {
+          if (row.kind === "add") {
+            return (
+              <GanttInlineAdd
+                key={row.key}
+                mode={row.mode}
+                parentKey={row.parentKey}
+                depth={row.depth}
+                categoryColor={row.categoryColor}
+                height={row.height}
+                onClick={() => onInlineAdd?.({ mode: row.mode, parentKey: row.parentKey })}
+              />
+            );
+          }
+          return (
+            <div key={row.key} style={{ height: row.height ?? ROW_HEIGHT }}>
+              <GanttOutlineRow
+                row={row}
+                expanded={expanded.has(row.key)}
+                selected={selectedKey === row.key}
+                hovered={hoveredKey === row.key}
+                onToggle={() => onToggle(row.key)}
+                onSelect={() => onSelect(row.key)}
+                onHover={(h) => onHover(h ? row.key : null)}
+              />
+            </div>
+          );
+        })}
       </div>
+      {footer}
+      {overlay}
       <div
         onMouseDown={onMouseDown}
         style={{ position: "absolute", right: -3, top: 0, bottom: 0, width: 6, cursor: "col-resize" }}

--- a/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
@@ -2,9 +2,12 @@
 import { ChevronRight } from "lucide-react";
 import type { FlatRow } from "./gantt-utils";
 import { ROW_HEIGHT } from "./gantt-types";
+import { CategoryDot, type CategoryDotTier } from "./CategoryDot";
+
+type NodeRow = Extract<FlatRow, { kind: "node" }>;
 
 interface Props {
-  row: FlatRow;
+  row: NodeRow;
   expanded: boolean;
   selected: boolean;
   hovered: boolean;
@@ -13,21 +16,59 @@ interface Props {
   onHover?: (hovered: boolean) => void;
 }
 
-function iconForKind(kind: FlatRow["node"]["kind"]) {
-  return kind === "category" ? "C" : kind === "project" ? "P" : kind === "task" ? "·" : "◦";
+type Tier = CategoryDotTier;
+
+const TYPOGRAPHY_BY_TIER: Record<Tier, React.CSSProperties> = {
+  category: {
+    fontSize: 11,
+    fontWeight: 500,
+    letterSpacing: "0.06em",
+    textTransform: "uppercase",
+    color: "var(--text-1)",
+  },
+  project: {
+    fontSize: 13,
+    fontWeight: 500,
+    color: "var(--text-1)",
+  },
+  task: {
+    fontSize: 12,
+    fontWeight: 400,
+    color: "var(--text-1)",
+  },
+  subtask: {
+    fontSize: 11,
+    fontWeight: 400,
+    color: "var(--text-2)",
+  },
+};
+
+function tierOf(kind: NodeRow["node"]["kind"]): Tier {
+  return kind;
 }
 
 export function GanttOutlineRow({ row, expanded, selected, hovered, onToggle, onSelect, onHover }: Props) {
-  const indent = 12 + row.depth * 12;
   const n = row.node;
+  const tier = tierOf(n.kind);
+  const indent = 14 + row.depth * 14;
   const label =
     n.kind === "category" ? n.name :
     n.kind === "project"  ? n.name :
-    n.kind === "task"     ? n.task.title :
-                             n.task.title;
+    n.task.title;
+
+  const isCategory = n.kind === "category";
+
+  const background = isCategory
+    ? "var(--surface-2, #f6f2fc)"
+    : selected
+      ? "rgba(108, 68, 246, 0.04)"
+      : hovered
+        ? "var(--surface-2, #f6f2fc)"
+        : "transparent";
 
   return (
     <div
+      role="row"
       onMouseEnter={() => onHover?.(true)}
       onMouseLeave={() => onHover?.(false)}
       onClick={onSelect}
@@ -35,41 +76,50 @@ export function GanttOutlineRow({ row, expanded, selected, hovered, onToggle, on
         height: ROW_HEIGHT,
         display: "flex",
         alignItems: "center",
+        gap: 8,
         paddingLeft: indent,
-        paddingRight: 8,
-        borderBottom: "1px solid var(--border, #eaeaea)",
+        paddingRight: 14,
+        borderBottom: "1px solid var(--border, #f0edfa)",
         borderLeft: selected ? "3px solid #6c44f6" : "3px solid transparent",
-        background: hovered ? "var(--surface-2, #fafafa)" : "transparent",
+        background,
         cursor: onSelect ? "pointer" : "default",
         opacity: row.dimmed ? 0.35 : 1,
-        fontSize: n.kind === "category" ? 12 : 13,
-        fontWeight: n.kind === "category" ? 700 : n.kind === "project" ? 600 : 500,
-        textTransform: n.kind === "category" ? "uppercase" : "none",
-        letterSpacing: n.kind === "category" ? 0.4 : 0,
-        color: n.kind === "subtask" ? "var(--text-2)" : "var(--text-1)",
         userSelect: "none",
       }}
     >
       {row.hasChildren ? (
         <button
           onClick={(e) => { e.stopPropagation(); onToggle?.(); }}
-          style={{
-            width: 18, height: 18, marginRight: 4,
-            background: "transparent", border: 0, padding: 0,
-            display: "flex", alignItems: "center", justifyContent: "center",
-            color: "var(--text-muted)",
-            transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
-            transition: "transform 120ms", cursor: "pointer",
-          }}
           aria-label={expanded ? "Collapse" : "Expand"}
+          style={{
+            width: 16, height: 16, flexShrink: 0,
+            background: "transparent", border: 0, padding: 0,
+            display: "inline-flex", alignItems: "center", justifyContent: "center",
+            color: "var(--text-muted, #bdb7d0)",
+            transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+            transition: "transform 120ms",
+            cursor: "pointer",
+          }}
         >
-          <ChevronRight size={14} />
+          <ChevronRight size={10} />
         </button>
       ) : (
-        <span style={{ width: 22 }} />
+        <span style={{ width: 16, flexShrink: 0 }} />
       )}
-      <span style={{ width: 14, fontSize: 10, color: "var(--text-muted)" }}>{iconForKind(n.kind)}</span>
-      <span style={{ marginLeft: 6, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1 }}>
+
+      <CategoryDot color={row.categoryColor} tier={tier} />
+
+      <span
+        title={label}
+        style={{
+          ...TYPOGRAPHY_BY_TIER[tier],
+          flex: 1,
+          minWidth: 0,
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
         {label}
       </span>
     </div>

--- a/apps/web/src/components/workspace/gantt/GanttRow.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttRow.tsx
@@ -3,10 +3,12 @@ import type { FlatRow } from "./gantt-utils";
 import { ROW_HEIGHT } from "./gantt-types";
 import { GanttBar } from "./GanttBar";
 import { rollUpBar, type TimelineRange } from "./gantt-utils";
-import type { GanttTask } from "./gantt-types";
+import type { GanttNode, GanttTask } from "./gantt-types";
+
+type NodeRow = Extract<FlatRow, { kind: "node" }>;
 
 interface Props {
-  row: FlatRow;
+  row: NodeRow;
   range: TimelineRange;
   hoveredKey: string | null;
   selectedKey: string | null;
@@ -14,13 +16,13 @@ interface Props {
   onSelectKey: (k: string | null) => void;
 }
 
-function gatherDescendantTasks(row: FlatRow["node"]): GanttTask[] {
+function gatherDescendantTasks(node: GanttNode): GanttTask[] {
   const out: GanttTask[] = [];
-  function walk(n: FlatRow["node"]) {
+  function walk(n: GanttNode) {
     if (n.kind === "task" || n.kind === "subtask") out.push(n.task);
     if (n.kind !== "subtask") for (const c of n.children) walk(c);
   }
-  walk(row);
+  walk(node);
   return out;
 }
 
@@ -28,13 +30,13 @@ export function GanttRow({ row, range, hoveredKey, selectedKey, onHoverKey, onSe
   const n = row.node;
   const highlighted = hoveredKey === row.key;
   const selected = selectedKey === row.key;
+  const isCategory = n.kind === "category";
 
   let content: React.ReactNode = null;
   if (n.kind === "task" || n.kind === "subtask") {
     const t = n.task;
     const todayIso = new Date().toISOString().slice(0, 10);
     const end = t.endDate ?? t.dueDate;
-    // Normalize end to yyyy-mm-dd (API can return full ISO timestamps like 2026-04-16T00:00:00.000Z)
     const endNorm = end ? String(end).slice(0, 10) : null;
     const startNorm = t.startDate
       ? String(t.startDate).slice(0, 10)
@@ -47,9 +49,12 @@ export function GanttRow({ row, range, hoveredKey, selectedKey, onHoverKey, onSe
           end={endNorm}
           progressPercent={t.progressPercent}
           range={range}
+          categoryColor={row.categoryColor}
+          status={t.status}
           label={t.title}
           task={t}
           highlighted={highlighted}
+          selected={selected}
           dimmed={row.dimmed ?? false}
           onClick={() => onSelectKey(row.key)}
           onMouseEnter={() => onHoverKey(row.key)}
@@ -57,7 +62,7 @@ export function GanttRow({ row, range, hoveredKey, selectedKey, onHoverKey, onSe
         />
       );
     }
-  } else {
+  } else if (n.kind === "category" || n.kind === "project") {
     const r = rollUpBar(gatherDescendantTasks(n));
     if (r) {
       content = (
@@ -67,8 +72,10 @@ export function GanttRow({ row, range, hoveredKey, selectedKey, onHoverKey, onSe
           end={r.end}
           progressPercent={r.progressPercent}
           range={range}
-          label={n.kind === "category" ? n.name : n.kind === "project" ? n.name : ""}
+          categoryColor={row.categoryColor}
+          label={n.name}
           highlighted={highlighted}
+          selected={selected}
           dimmed={row.dimmed ?? false}
           onMouseEnter={() => onHoverKey(row.key)}
           onMouseLeave={() => onHoverKey(null)}
@@ -81,8 +88,12 @@ export function GanttRow({ row, range, hoveredKey, selectedKey, onHoverKey, onSe
     <div style={{
       height: ROW_HEIGHT,
       position: "relative",
-      borderBottom: "1px solid var(--border, #eaeaea)",
-      background: selected ? "rgba(108, 68, 246, 0.04)" : "transparent",
+      borderBottom: "1px solid var(--border, #f0edfa)",
+      background: isCategory
+        ? "var(--surface-2, #f6f2fc)"
+        : selected
+          ? "rgba(108, 68, 246, 0.04)"
+          : "transparent",
     }}>
       {content}
     </div>

--- a/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+++ b/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { WorkspaceTimelineTask, WorkspaceTimeline } from "@/app/dashboard/types";
-import type { GanttTask } from "./gantt-types";
-import { buildProjectTree, normalizeGanttStatus } from "./gantt-utils";
+import type { GanttTask, ProjectCategory } from "./gantt-types";
+import { DEFAULT_CATEGORY_COLOUR } from "./gantt-types";
+import { buildProjectTree, buildCategoryColorMap, normalizeGanttStatus } from "./gantt-utils";
 import { GanttContainer } from "./GanttContainer";
 import { AddNodeModal } from "./AddNodeModal";
 
@@ -13,6 +14,8 @@ interface Props {
   timeline: WorkspaceTimeline | null;
   refresh: () => Promise<void>;
 }
+
+type ProjectSummary = { id: string; categoryId: string | null };
 
 function toGanttTask(t: WorkspaceTimelineTask): GanttTask {
   return {
@@ -40,6 +43,31 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
   );
 
   const [addCtx, setAddCtx] = useState<{ mode: "task" | "subtask"; parentTaskId?: string } | null>(null);
+  const [categoryColour, setCategoryColour] = useState<string>(DEFAULT_CATEGORY_COLOUR);
+
+  // One-shot lookup of this project's category colour. Defaults to Larry purple until resolved.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [projectsRes, categoriesRes] = await Promise.all([
+          fetch("/api/workspace/projects?status=all", { cache: "no-store" }),
+          fetch("/api/workspace/categories", { cache: "no-store" }),
+        ]);
+        if (!projectsRes.ok || !categoriesRes.ok) return;
+        const projectsBody = await projectsRes.json() as { items?: ProjectSummary[] };
+        const categoriesBody = await categoriesRes.json() as { categories?: ProjectCategory[] };
+        const project = (projectsBody.items ?? []).find((p) => p.id === projectId);
+        const categoryId = project?.categoryId ?? null;
+        const map = buildCategoryColorMap(categoriesBody.categories?.map((c) => ({ id: c.id, colour: c.colour })) ?? []);
+        const colour = categoryId ? (map.get(`cat:${categoryId}`) ?? DEFAULT_CATEGORY_COLOUR) : DEFAULT_CATEGORY_COLOUR;
+        if (!cancelled) setCategoryColour(colour);
+      } catch {
+        // fallback stays Larry purple
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [projectId]);
 
   function handleAdd(context: { selectedKey: string | null }) {
     if (context.selectedKey?.startsWith("task:")) {
@@ -51,7 +79,13 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
 
   return (
     <>
-      <GanttContainer root={root} defaultZoom="month" addLabel={addCtx?.mode === "subtask" ? "+ Subtask" : "+ Task"} onAdd={handleAdd} />
+      <GanttContainer
+        root={root}
+        defaultZoom="month"
+        addLabel={addCtx?.mode === "subtask" ? "+ Subtask" : "+ Task"}
+        onAdd={handleAdd}
+        rootCategoryColor={categoryColour}
+      />
       {addCtx && (
         <AddNodeModal
           mode={addCtx.mode}

--- a/apps/web/src/components/workspace/gantt/gantt-types.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-types.ts
@@ -10,3 +10,9 @@ export type GanttNode =
 
 export type ZoomLevel = "week" | "month" | "quarter";
 export const ROW_HEIGHT = 36;
+
+// Key format: "cat:<uuid>" for a real category, "cat:uncat" for the synthetic bucket.
+export type CategoryColorMap = Map<string, string>;
+
+// Larry purple — used when a category has no colour or a row has no category.
+export const DEFAULT_CATEGORY_COLOUR = "#6c44f6";

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { buildPortfolioTree, buildProjectTree, flattenVisible, normalizeGanttStatus, rollUpBar } from "./gantt-utils";
+import {
+  buildCategoryColorMap,
+  buildPortfolioTree, buildProjectTree,
+  contrastTextFor,
+  computeRange,
+  flattenVisible,
+  generateDateAxis,
+  normalizeGanttStatus,
+  resolveCategoryColor,
+  rollUpBar,
+  tinyTint,
+} from "./gantt-utils";
 import type { PortfolioTimelineResponse, GanttTask, GanttNode } from "./gantt-types";
 
 const baseTask = (over: Partial<GanttTask> = {}): GanttTask => ({
@@ -112,5 +123,126 @@ describe("rollUpBar", () => {
     expect(r).not.toBeNull();
     expect(r!.start).toBeTruthy();
     expect(r!.end).toBe(futureIso);
+  });
+});
+
+/* ─── Category colour map + resolution ─────────────────────────────── */
+
+describe("buildCategoryColorMap", () => {
+  it("maps real categories by id and the synthetic Uncategorised bucket by 'uncat'", () => {
+    const map = buildCategoryColorMap([
+      { id: "c1", colour: "#ff0000" },
+      { id: "c2", colour: "#00ff00" },
+      { id: null, colour: null },
+    ]);
+    expect(map.get("cat:c1")).toBe("#ff0000");
+    expect(map.get("cat:c2")).toBe("#00ff00");
+    expect(map.get("cat:uncat")).toBe("#6c44f6");
+  });
+
+  it("falls back to Larry purple when a category has null colour", () => {
+    const map = buildCategoryColorMap([{ id: "c1", colour: null }]);
+    expect(map.get("cat:c1")).toBe("#6c44f6");
+  });
+});
+
+describe("resolveCategoryColor", () => {
+  const task1: GanttNode = { kind: "task", id: "t1", task: baseTask({ id: "t1" }), children: [] };
+  const project: GanttNode = { kind: "project", id: "p1", name: "P", status: "active", children: [task1] };
+  const category: GanttNode = { kind: "category", id: "c1", name: "Marketing", colour: "#ff0000", children: [project] };
+  const root: GanttNode = { kind: "category", id: "__root__", name: "", colour: null, children: [category] };
+
+  it("walks up to find the ancestor category's colour", () => {
+    expect(resolveCategoryColor("task:t1", root)).toBe("#ff0000");
+  });
+
+  it("prefers the categoryColorMap entry over the tree's inline colour", () => {
+    const map = buildCategoryColorMap([{ id: "c1", colour: "#0000ff" }]);
+    expect(resolveCategoryColor("task:t1", root, map)).toBe("#0000ff");
+  });
+
+  it("returns the Larry purple default when the node isn't in the tree", () => {
+    expect(resolveCategoryColor("task:missing", root)).toBe("#6c44f6");
+  });
+});
+
+describe("flattenVisible populates categoryColor", () => {
+  const sub: GanttNode = { kind: "subtask", id: "t2", task: baseTask({ id: "t2", parentTaskId: "t1" }) };
+  const task1: GanttNode = { kind: "task", id: "t1", task: baseTask({ id: "t1" }), children: [sub] };
+  const project: GanttNode = { kind: "project", id: "p1", name: "P", status: "active", children: [task1] };
+  const category: GanttNode = { kind: "category", id: "c1", name: "C", colour: "#123456", children: [project] };
+  const syntheticRoot: GanttNode = { kind: "category", id: "__root__", name: "", colour: null, children: [category] };
+
+  it("inherits the resolved category colour down to tasks and subtasks", () => {
+    const expanded = new Set<string>(["cat:c1", "proj:p1", "task:t1"]);
+    const map = buildCategoryColorMap([{ id: "c1", colour: "#abcdef" }]);
+    const rows = flattenVisible(syntheticRoot, expanded, { categoryColorMap: map });
+    for (const r of rows) expect(r.categoryColor).toBe("#abcdef");
+  });
+
+  it("uses rootCategoryColor when the root is a bare project node", () => {
+    const proj: GanttNode = { kind: "project", id: "p1", name: "P", status: "active", children: [task1] };
+    const rows = flattenVisible(proj, new Set(["proj:p1"]), { rootCategoryColor: "#ff00aa" });
+    expect(rows.every((r) => r.categoryColor === "#ff00aa")).toBe(true);
+  });
+});
+
+/* ─── Date axis ────────────────────────────────────────────────────── */
+
+describe("generateDateAxis", () => {
+  const range = computeRange(
+    [baseTask({ id: "x", startDate: "2026-04-01", endDate: "2026-06-30", dueDate: "2026-06-30" })],
+    "month",
+  );
+
+  it("month zoom produces month spans plus weekly day markers", () => {
+    const axis = generateDateAxis(range, "month");
+    expect(axis.months.length).toBeGreaterThan(0);
+    expect(axis.months[0].label).toMatch(/^[A-Z]{3} \d{4}$/);
+    // Months must cover the full axis width in order and non-overlapping.
+    let prevEnd = 0;
+    for (const m of axis.months) {
+      expect(m.endPct).toBeGreaterThan(m.startPct);
+      expect(m.startPct).toBeGreaterThanOrEqual(prevEnd - 0.001);
+      prevEnd = m.endPct;
+    }
+    expect(axis.days.length).toBeGreaterThan(2);
+  });
+
+  it("week zoom produces one marker per day", () => {
+    const axis = generateDateAxis(range, "week");
+    // Every marker label is in "Mon 23" / "Tue 24" format (a weekday short + number).
+    for (const d of axis.days) expect(d.label).toMatch(/^\w{3} \d{1,2}$/);
+    // Should be roughly `totalDays + 1` markers.
+    expect(axis.days.length).toBeGreaterThan(range.totalDays - 2);
+  });
+
+  it("quarter zoom produces biweekly markers", () => {
+    const axis = generateDateAxis(range, "quarter");
+    for (const d of axis.days) expect(d.label).toMatch(/^\d{1,2}$/);
+    // Biweekly → fewer markers than daily.
+    expect(axis.days.length).toBeLessThan(range.totalDays / 10);
+  });
+});
+
+/* ─── Colour helpers ───────────────────────────────────────────────── */
+
+describe("contrastTextFor", () => {
+  it("returns white for dark background colours", () => {
+    expect(contrastTextFor("#000000")).toBe("#ffffff");
+    expect(contrastTextFor("#6c44f6")).toBe("#ffffff");
+    expect(contrastTextFor("#123456")).toBe("#ffffff");
+  });
+
+  it("returns dark text for light background colours", () => {
+    expect(contrastTextFor("#ffffff")).toBe("#11172c");
+    expect(contrastTextFor("#ffe47a")).toBe("#11172c");
+  });
+});
+
+describe("tinyTint", () => {
+  it("returns an rgba() string with the given alpha", () => {
+    expect(tinyTint("#ff0000", 0.2)).toBe("rgba(255, 0, 0, 0.2)");
+    expect(tinyTint("#6c44f6")).toMatch(/^rgba\(108, 68, 246, 0\.15\)$/);
   });
 });

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -1,6 +1,8 @@
 import type {
+  CategoryColorMap,
   GanttNode, GanttTask, GanttTaskStatus, PortfolioTimelineResponse, ZoomLevel,
 } from "./gantt-types";
+import { DEFAULT_CATEGORY_COLOUR } from "./gantt-types";
 
 /* ─── DB status normalisation ──────────────────────────────────────── */
 
@@ -84,16 +86,42 @@ function buildTaskForest(tasks: GanttTask[]): GanttNode[] {
 
 /* ─── Flatten for rendering ────────────────────────────────────────── */
 
-export interface FlatRow {
-  key: string;        // stable id, e.g. "cat:c1", "proj:p1", "task:t1", "sub:t2"
-  depth: number;      // 0..3
-  node: GanttNode;
-  hasChildren: boolean;
-  dimmed?: boolean;
+export type InlineAddMode = "category" | "project" | "task" | "subtask";
+
+export type FlatRow =
+  | {
+      kind: "node";
+      key: string;         // stable id, e.g. "cat:c1", "proj:p1", "task:t1", "sub:t2"
+      depth: number;       // 0..3
+      node: GanttNode;
+      hasChildren: boolean;
+      categoryColor: string; // resolved category colour; fallback to Larry purple
+      dimmed?: boolean;
+      height?: number;     // optional override; defaults to ROW_HEIGHT
+    }
+  | {
+      kind: "add";
+      key: string;         // e.g. "add:cat:c1", "add:proj:p1", "add:root"
+      depth: number;
+      mode: InlineAddMode;
+      parentKey: string | null;
+      categoryColor: string;
+      height: number;      // typically 28
+    };
+
+export interface FlattenOptions {
+  categoryColorMap?: CategoryColorMap;
+  rootCategoryColor?: string; // used when root is a project (per-project view)
 }
 
-export function flattenVisible(root: GanttNode, expanded: Set<string>): FlatRow[] {
+export function flattenVisible(
+  root: GanttNode,
+  expanded: Set<string>,
+  options: FlattenOptions = {},
+): FlatRow[] {
   const rows: FlatRow[] = [];
+  const map = options.categoryColorMap;
+  const rootColour = options.rootCategoryColor ?? DEFAULT_CATEGORY_COLOUR;
 
   function keyOf(node: GanttNode): string {
     if (node.kind === "category") return `cat:${node.id ?? "uncat"}`;
@@ -102,21 +130,124 @@ export function flattenVisible(root: GanttNode, expanded: Set<string>): FlatRow[
     return `sub:${node.id}`;
   }
 
-  function walk(node: GanttNode, depth: number, isSyntheticRoot: boolean) {
+  function colourFor(node: GanttNode, inherited: string): string {
+    if (node.kind !== "category" || node.id === "__root__") return inherited;
+    const key = `cat:${node.id ?? "uncat"}`;
+    const fromMap = map?.get(key);
+    if (fromMap) return fromMap;
+    // Fall back to the node's own colour, then root colour, then default.
+    return node.colour ?? inherited ?? DEFAULT_CATEGORY_COLOUR;
+  }
+
+  function walk(node: GanttNode, depth: number, isSyntheticRoot: boolean, inherited: string) {
     const children: GanttNode[] = (node.kind === "subtask") ? [] : node.children;
     const hasChildren = children.length > 0;
     const key = keyOf(node);
+    const categoryColor = colourFor(node, inherited);
 
-    if (!isSyntheticRoot) rows.push({ key, depth, node, hasChildren });
+    if (!isSyntheticRoot) rows.push({ kind: "node", key, depth, node, hasChildren, categoryColor });
 
     if (!isSyntheticRoot && !expanded.has(key)) return;
-    for (const child of children) walk(child, depth + (isSyntheticRoot ? 0 : 1), false);
+    for (const child of children) {
+      walk(child, depth + (isSyntheticRoot ? 0 : 1), false, categoryColor);
+    }
   }
 
-  // Always treat the node passed as root as the invisible tree root —
-  // it is never emitted as a visible row; its children start at depth 0.
-  walk(root, 0, true);
+  walk(root, 0, true, rootColour);
   return rows;
+}
+
+/* ─── Inline add-row injection ─────────────────────────────────────── */
+
+const INLINE_ADD_HEIGHT = 28;
+
+// Inject "+ Add project / task" rows under expanded Category / Project rows.
+// The injection preserves the row-alignment invariant by being consumed by
+// both GanttOutline (which renders the affordance) and GanttGrid (which
+// renders a blank spacer of the same height).
+export function injectInlineAdds(rows: FlatRow[], expanded: Set<string>): FlatRow[] {
+  const out: FlatRow[] = [];
+  for (const r of rows) {
+    out.push(r);
+    if (r.kind !== "node") continue;
+    if (!expanded.has(r.key)) continue;
+    const n = r.node;
+    if (n.kind === "category" && n.id !== "__root__") {
+      out.push({
+        kind: "add",
+        key: `add:${r.key}`,
+        depth: r.depth + 1,
+        mode: "project",
+        parentKey: r.key,
+        categoryColor: r.categoryColor,
+        height: INLINE_ADD_HEIGHT,
+      });
+    } else if (n.kind === "project") {
+      out.push({
+        kind: "add",
+        key: `add:${r.key}`,
+        depth: r.depth + 1,
+        mode: "task",
+        parentKey: r.key,
+        categoryColor: r.categoryColor,
+        height: INLINE_ADD_HEIGHT,
+      });
+    }
+  }
+  return out;
+}
+
+/* ─── Category colour resolution ───────────────────────────────────── */
+
+export function buildCategoryColorMap(
+  categories: ReadonlyArray<{ id: string | null; colour: string | null }>,
+): CategoryColorMap {
+  const map: CategoryColorMap = new Map();
+  for (const c of categories) {
+    const key = c.id ? `cat:${c.id}` : "cat:uncat";
+    map.set(key, c.colour ?? DEFAULT_CATEGORY_COLOUR);
+  }
+  return map;
+}
+
+// Walk up the tree to find the Category colour for any node key.
+// Consulted ad-hoc (render-path uses FlatRow.categoryColor instead).
+export function resolveCategoryColor(
+  nodeKey: string,
+  root: GanttNode,
+  map?: CategoryColorMap,
+): string {
+  function colourOf(node: GanttNode): string {
+    if (node.kind !== "category") return DEFAULT_CATEGORY_COLOUR;
+    const key = `cat:${node.id ?? "uncat"}`;
+    return map?.get(key) ?? node.colour ?? DEFAULT_CATEGORY_COLOUR;
+  }
+
+  function keyOf(node: GanttNode): string {
+    if (node.kind === "category") return `cat:${node.id ?? "uncat"}`;
+    if (node.kind === "project") return `proj:${node.id}`;
+    if (node.kind === "task") return `task:${node.id}`;
+    return `sub:${node.id}`;
+  }
+
+  function find(node: GanttNode, ancestors: GanttNode[]): GanttNode[] | null {
+    if (keyOf(node) === nodeKey) return [...ancestors, node];
+    if (node.kind === "subtask") return null;
+    for (const c of node.children) {
+      const hit = find(c, [...ancestors, node]);
+      if (hit) return hit;
+    }
+    return null;
+  }
+
+  const path = find(root, []);
+  if (!path) return DEFAULT_CATEGORY_COLOUR;
+  for (let i = path.length - 1; i >= 0; i--) {
+    if (path[i].kind === "category" && (path[i] as { id: string | null }).id !== "__root__") {
+      return colourOf(path[i]);
+    }
+  }
+  return DEFAULT_CATEGORY_COLOUR;
 }
 
 /* ─── Rollup (parent bar spans children's min→max, progress weighted) ─── */
@@ -187,4 +318,122 @@ export function computeRange(tasks: GanttTask[], zoom: ZoomLevel): TimelineRange
 
 export function dateToPct(d: Date, range: TimelineRange): number {
   return (daysBetween(range.start, d) / range.totalDays) * 100;
+}
+
+/* ─── Date-axis generation (two-row month/day header) ───────────────── */
+
+export interface DateAxisMonth {
+  label: string;     // "APR 2026"
+  startPct: number;  // left edge as % of axis width
+  endPct: number;    // right edge as % (capped at 100)
+}
+
+export interface DateAxisDay {
+  label: string;     // "23" or "Mon 23"
+  pct: number;       // centre position as %
+  isMonthStart: boolean;
+}
+
+export interface DateAxis {
+  months: DateAxisMonth[];
+  days: DateAxisDay[];
+}
+
+// Generate the date-axis markers for a given range and zoom.
+// Week: every day. Month: every 7 days (from Mondays). Quarter: every 14 days.
+export function generateDateAxis(range: TimelineRange, zoom: ZoomLevel): DateAxis {
+  const months: DateAxisMonth[] = [];
+  const days: DateAxisDay[] = [];
+
+  // Months: walk month-starts, each span ends at the next month-start or range end.
+  const monthCursor = new Date(range.start.getFullYear(), range.start.getMonth(), 1);
+  while (monthCursor <= range.end) {
+    const nextMonth = new Date(monthCursor.getFullYear(), monthCursor.getMonth() + 1, 1);
+    const spanStart = monthCursor < range.start ? range.start : monthCursor;
+    const spanEnd = nextMonth > range.end ? range.end : nextMonth;
+    const startPct = Math.max(0, dateToPct(spanStart, range));
+    const endPct = Math.min(100, dateToPct(spanEnd, range));
+    if (endPct > startPct) {
+      months.push({
+        label: monthCursor.toLocaleDateString("en-GB", { month: "short", year: "numeric" }).toUpperCase(),
+        startPct,
+        endPct,
+      });
+    }
+    monthCursor.setMonth(monthCursor.getMonth() + 1);
+  }
+
+  // Days: cadence by zoom.
+  const dayCursor = new Date(range.start);
+  if (zoom === "week") {
+    while (dayCursor <= range.end) {
+      days.push({
+        label: dayCursor.toLocaleDateString("en-GB", { weekday: "short", day: "numeric" }),
+        pct: dateToPct(dayCursor, range),
+        isMonthStart: dayCursor.getDate() === 1,
+      });
+      dayCursor.setDate(dayCursor.getDate() + 1);
+    }
+  } else if (zoom === "month") {
+    // Advance to the first Monday in range.
+    const dow = dayCursor.getDay(); // 0 Sun..6 Sat
+    const daysToMonday = (8 - dow) % 7 || 7; // always moves forward to next Monday
+    dayCursor.setDate(dayCursor.getDate() + daysToMonday);
+    while (dayCursor <= range.end) {
+      days.push({
+        label: String(dayCursor.getDate()),
+        pct: dateToPct(dayCursor, range),
+        isMonthStart: dayCursor.getDate() <= 7, // first week of a month
+      });
+      dayCursor.setDate(dayCursor.getDate() + 7);
+    }
+  } else {
+    // quarter: every 14 days starting at the first of the month after range.start
+    dayCursor.setDate(1);
+    dayCursor.setMonth(dayCursor.getMonth() + 1);
+    while (dayCursor <= range.end) {
+      days.push({
+        label: String(dayCursor.getDate()),
+        pct: dateToPct(dayCursor, range),
+        isMonthStart: dayCursor.getDate() === 1,
+      });
+      dayCursor.setDate(dayCursor.getDate() + 14);
+    }
+  }
+
+  return { months, days };
+}
+
+/* ─── Colour helpers ───────────────────────────────────────────────── */
+
+function parseHex(hex: string): { r: number; g: number; b: number } | null {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex);
+  if (!m) return null;
+  let s = m[1];
+  if (s.length === 3) s = s[0] + s[0] + s[1] + s[1] + s[2] + s[2];
+  return {
+    r: parseInt(s.slice(0, 2), 16),
+    g: parseInt(s.slice(2, 4), 16),
+    b: parseInt(s.slice(4, 6), 16),
+  };
+}
+
+// Returns "#ffffff" or "#11172c" based on WCAG relative luminance.
+// White text when the background luminance < 0.55 (dark), dark text otherwise.
+export function contrastTextFor(hex: string): string {
+  const rgb = parseHex(hex);
+  if (!rgb) return "#ffffff";
+  const toLinear = (c: number) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  const L = 0.2126 * toLinear(rgb.r) + 0.7152 * toLinear(rgb.g) + 0.0722 * toLinear(rgb.b);
+  return L < 0.55 ? "#ffffff" : "#11172c";
+}
+
+// 10%-alpha rgba version of a hex colour — used for the CategoryDot ring.
+export function tinyTint(hex: string, alpha = 0.15): string {
+  const rgb = parseHex(hex);
+  if (!rgb) return `rgba(108, 68, 246, ${alpha})`;
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
 }

--- a/docs/reports/2026-04-16-gantt-restructure-plan.md
+++ b/docs/reports/2026-04-16-gantt-restructure-plan.md
@@ -1,0 +1,610 @@
+# Gantt restructure plan
+
+**For:** implementation agent (next Claude session)
+**Context doc:** the brief at the top of this chat
+**Reviewed screenshots:** sketch + current production (`/workspace/projects/<id>` → Timeline tab, Nordvik Bank)
+**Date:** 2026-04-16
+**Target branch:** `feat/gantt-v2-category-colour`
+
+---
+
+## 1. The gap in one paragraph
+
+The current Gantt has the right data model (category → project → task → subtask) but renders it as a flat indented list where bars are all status-coloured variants of the same blue. Hierarchy reads as whitespace, not as grouping. The user's three complaints — "no subcategories", "doesn't look different", "task labels too big" — and the hand-drawn sketch all point at the same fix: **make category the dominant visual signal**. Colour a row by its category, not by its status. Give every row a category-coloured dot so you can track grouping at a glance. Separate the date header into month + day rows so it stops reading as one jumbled string. Shrink the outline labels. Add inline `+ add task` rows so creating work doesn't always route through a modal. That is the restructure.
+
+---
+
+## 2. Design decisions
+
+### 2.1 Colour semantics (the big one)
+
+Today: bars are coloured by status (`--tl-in-progress`, `--tl-overdue`, etc.) regardless of category.
+New: **bars are coloured by category. Status becomes a modifier.**
+
+Resolution walk for any task's colour:
+
+```
+task → parent project → parent category → colour
+```
+
+If the category's `colour` field is null or the task is in the Uncategorised bucket, fall back to Larry purple `#6c44f6`. Every row in the outline and every bar in the grid uses this same resolved colour — the colour dot, the rollup bar for the Category/Project row, the task bar, and the subtask bar all inherit it.
+
+Status modifiers layer on top of that base colour:
+
+| Status | Modifier | Rationale |
+|---|---|---|
+| `on_track` | none — solid fill | default |
+| `completed` | opacity 0.5 + trailing `✓` glyph in the bar label | muted, clearly done |
+| `not_started` | transparent fill + 1.5px dashed border in category colour | visually "planned, not started" |
+| `at_risk` | solid fill + 3px amber stripe along bar's top edge | warning flag that reads from distance |
+| `overdue` | solid fill + 2px coral outline + coral dot at bar's right end | more alarming than at_risk |
+
+All modifier values already exist as Larry tokens (`--tl-at-risk`, `--tl-overdue`). No new colours.
+
+### 2.2 Outline hierarchy
+
+Four visual tiers, tuned so a glance answers "is this a group or a task":
+
+| Level | Font | Weight | Case | Size | Colour | Dot size |
+|---|---|---|---|---|---|---|
+| Category | system | 500 | UPPERCASE, letter-spacing 0.06em | 11px | `--text-1` | 8px, 2px ring in category-50 |
+| Project (sub-category) | system | 500 | Sentence | 13px | `--text-1` | 7px, 80% opacity |
+| Task | system | 400 | Sentence | 12px | `--text-1` | 5px, 60% opacity |
+| Subtask | system | 400 | Sentence | 11px | `--text-2` | 4px, 50% opacity |
+
+Category rows get a **soft lavender background** (`--surface-2`) spanning the full row width — in outline AND in grid — so they visually band across the whole Gantt. Project rows stay white but bold. Task and subtask rows stay white.
+
+Labels truncate with CSS ellipsis at the column width; the full title lives in a `title=` attribute for hover tooltip. No more `[DM]` prefix hacks.
+
+### 2.3 Dimensions
+
+| Token | Old | New | Why |
+|---|---|---|---|
+| Row height | 36px | 36px | keep the alignment invariant |
+| Outline default width | 320px | 260px | give the timeline more room |
+| Outline min / max | 220 / 520 | 220 / 420 | cap the lateral intrusion |
+| Grid header height | 34px | 48px | two-row month/day header needs it |
+| Indent per depth | 12px | 14px | slightly more obvious stair-step |
+| Category colour dot | — | 8px | new |
+| Project colour dot | — | 7px | new |
+| Task colour dot | — | 5px | new |
+| Subtask colour dot | — | 4px | new |
+
+Bar heights unchanged: category rollup 6px, project rollup 10px, task 16px, subtask 10px.
+
+### 2.4 Date header
+
+Two rows, 48px total.
+
+- **Top row (20px):** month label, bold small-caps 11px in `--text-2`, letter-spacing 0.08em, left-aligned inside the span of days belonging to that month, with a 1px right border at the month boundary in `--border-2`.
+- **Bottom row (28px):** day numbers only (no repeated month words), 10px regular in `--text-2`, centered over their positions.
+
+Day marker cadence by zoom:
+- Week zoom: every day shown, `Mon 23`, `Tue 24`, etc. on bottom row, week label on top.
+- Month zoom (default): every 7 days (`2, 9, 16, 23, 30`) on bottom row, month label on top. This is the view in the screenshot the user complained about.
+- Quarter zoom: every 14 days on bottom row, month label on top, `Q1 2026`-style on a third-row band.
+
+Vertical gridlines at every day marker, 1px in `--surface-2` (almost invisible — just enough to anchor the eye). Month-boundary gridlines are stronger, in `--border`.
+
+### 2.5 Today line
+
+Keep the existing vertical purple line at `rgba(108,68,246,0.4)`, but add a small `Today` label pill at the top of the line, 10px bold purple text on white bg with 4px horizontal padding, sitting just above the grid rows. Visible even when scrolled.
+
+### 2.6 Milestones
+
+New concept. A task marked as a milestone renders as a **10px rotated square** (diamond) at its `dueDate`, not as a bar. Diamond fill = category colour. Label floats to the right of the diamond in 11px.
+
+Data: add `is_milestone BOOLEAN NOT NULL DEFAULT false` to `tasks`. Minimal migration, no backfill needed.
+
+### 2.7 Inline add affordances
+
+Under every Category row and every Project row, when expanded, render a 28px-tall `+ add task` (or `+ add project` / `+ add subtask`) row in `--text-muted` 11px italic, only visible on hover of the parent group. Click opens the same `AddNodeModal` already built, pre-scoped to the correct parent. No new modal code.
+
+This replaces the toolbar `+ Task` button being the only path. The toolbar button stays for keyboard-first flows.
+
+---
+
+## 3. Reference aesthetic
+
+The sketch. Then, for the classic-Gantt feel the user wants: **TeamGantt's timeline view** and **Notion's timeline database** are the closest references. Specifically:
+
+- From TeamGantt: coloured bars per group, milestone diamonds, month-over-days header, soft gridlines.
+- From Notion: restrained typography, generous whitespace, no chrome.
+- From Linear (Larry's prior reference): the hover/selection states, the subtle left-border-on-selection pattern.
+
+What to consciously NOT copy: MS Project's grey density, Jira's traffic-light dots, Monday's rainbow saturation, Asana's Android-style card chunks. Those are the anti-patterns the brief flags in §1 and §13.7.
+
+---
+
+## 4. Component diff
+
+| File | Status | Notes |
+|---|---|---|
+| `gantt-types.ts` | **Modify** | Add `categoryColor: string` on `FlatRow`, add `isMilestone?: boolean` on `GanttTask`, add `GanttMilestone` type |
+| `gantt-utils.ts` | **Modify** | Add `resolveCategoryColor(node, tree)`, `generateDateAxis(range, zoom)`, `formatMonthSpans(markers)`, `isMilestone(task)` |
+| `gantt-utils.test.ts` | **Modify** | Cover the new utilities; existing 8 tests stay |
+| `GanttContainer.tsx` | **Modify** | Build `categoryColorMap` memo from tree; pass down; nothing else changes |
+| `GanttToolbar.tsx` | **Modify** | Slightly shorter buttons; no other changes |
+| `GanttOutline.tsx` | **Modify** | Add sticky "TASK / GROUPS" header row at 48px; smaller default width (260px) |
+| `GanttOutlineRow.tsx` | **Rewrite** | New layout: chevron (10px) + `<CategoryDot />` + truncated label with `title=` tooltip; tier-specific typography; category rows get `--surface-2` band |
+| `GanttGrid.tsx` | **Modify** | Delegate header to `<GanttDateHeader />`; add vertical gridlines via absolutely-positioned background div; keep everything else |
+| `GanttRow.tsx` | **Modify** | Accept `categoryColor` prop; pass to `<GanttBar />`; category rows get `--surface-2` band |
+| `GanttBar.tsx` | **Rewrite** | Category colour base + status modifier overlay + milestone variant; `variant` prop now `'category' \| 'project' \| 'task' \| 'subtask' \| 'milestone'` |
+| `PortfolioGanttClient.tsx` | **Modify** | Build `categoryColorMap` from API response; fallback to Larry purple for null/Uncategorised |
+| `ProjectGanttClient.tsx` | **Modify** | Fetch parent project's `category` field from `/api/workspace/projects/:id` (already in response); use its colour for all bars in this view; fallback to Larry purple |
+| `AddNodeModal.tsx` | **Keep** | No changes — already parametric on `mode` and parent ID |
+| **NEW** `GanttDateHeader.tsx` | Create | Two-row month/day header; exports `generateMarkersByZoom` helper |
+| **NEW** `GanttInlineAdd.tsx` | Create | 28px row shown under expanded Category/Project nodes on hover; opens `AddNodeModal` |
+| **NEW** `CategoryDot.tsx` | Create | 8/7/5/4px round dot in category colour; optional 2px ring for Category-tier |
+| **NEW** `GanttMilestone.tsx` | Create | 10px rotated square, absolutely positioned in grid row |
+| **NEW** `CategoryManagerPanel.tsx` | Create | Slide-over panel for listing, creating, renaming, recolouring, deleting, and reordering categories |
+
+15 files total: 4 new, 8 modified, 2 rewritten, 1 kept.
+
+---
+
+## 5. File-level proposals
+
+Paths relative to `apps/web/src/components/workspace/gantt/`.
+
+### 5.1 `gantt-types.ts`
+
+Append (do not modify existing exports):
+
+```typescript
+export type CategoryColorMap = Map<string, string>; // key: "cat:<id>" | "cat:uncategorised" → hex
+
+export type FlatRow = {
+  // existing fields...
+  categoryColor: string; // resolved colour, never null; Uncategorised → '#6c44f6'
+};
+
+export type GanttMilestone = {
+  id: string;
+  taskId: string;
+  date: string; // YYYY-MM-DD
+  title: string;
+  categoryColor: string;
+};
+
+// GanttTask gets one optional field:
+export type GanttTask = {
+  // existing fields...
+  isMilestone?: boolean;
+};
+```
+
+### 5.2 `gantt-utils.ts`
+
+Add three pure helpers:
+
+```typescript
+// Walk up the tree to find the Category colour for any node.
+// Task → Project → Category → colour. Returns Larry purple if nothing found.
+export function resolveCategoryColor(nodeKey: string, tree: GanttNode[]): string;
+
+// Generate the date-axis markers for a given range and zoom.
+// Returns { months: [{label, startPct, endPct}], days: [{label, pct}] }.
+export function generateDateAxis(range: DateRange, zoom: ZoomLevel): DateAxis;
+
+// Derive milestones from the flattened rows.
+export function extractMilestones(rows: FlatRow[]): GanttMilestone[];
+```
+
+Move the existing inline marker generation OUT of `GanttGrid.tsx` into `generateDateAxis`. Write four unit tests for each new helper (12 tests total added). Existing `rollUpBar` and `flattenVisible` untouched.
+
+### 5.3 `GanttContainer.tsx`
+
+One new memo, passed through to children:
+
+```typescript
+const categoryColorMap = useMemo(
+  () => buildCategoryColorMap(allTasks, tree),
+  [allTasks, tree]
+);
+```
+
+Pass `categoryColorMap` to `<GanttOutline>` and `<GanttGrid>`. State count unchanged (still 6 `useState`).
+
+### 5.4 `GanttOutlineRow.tsx` (rewrite)
+
+Layout:
+
+```tsx
+<div
+  role="row"
+  style={{
+    height: 36,
+    paddingLeft: 14 + depth * 14,
+    paddingRight: 14,
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    background: isCategory ? 'var(--surface-2)' : isSelected ? 'rgba(108,68,246,0.03)' : 'transparent',
+    borderBottom: '1px solid var(--border)',
+    borderLeft: isSelected ? '3px solid var(--brand)' : '3px solid transparent',
+  }}
+>
+  {hasChildren && <Chevron expanded={expanded} />}
+  <CategoryDot color={categoryColor} tier={kind} />
+  <span style={typographyByTier[kind]} title={title}>
+    {truncate(title, outlineWidth)}
+  </span>
+</div>
+```
+
+Typography map in the same file:
+
+```typescript
+const typographyByTier = {
+  category:  { fontSize: 11, fontWeight: 500, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--text-1)' },
+  project:   { fontSize: 13, fontWeight: 500, color: 'var(--text-1)' },
+  task:      { fontSize: 12, fontWeight: 400, color: 'var(--text-1)' },
+  subtask:   { fontSize: 11, fontWeight: 400, color: 'var(--text-2)' },
+} as const;
+```
+
+Truncation: use `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` on the span. Don't compute truncation in JS — let CSS do it. The column width flexes via the resizable outline.
+
+### 5.5 `GanttBar.tsx` (rewrite)
+
+New prop signature:
+
+```typescript
+type GanttBarProps = {
+  variant: 'category' | 'project' | 'task' | 'subtask' | 'milestone';
+  status: GanttStatus;
+  categoryColor: string; // always present now, never undefined
+  startPct: number;
+  widthPct: number;
+  progressPct: number;
+  label: string;
+  isSelected: boolean;
+};
+```
+
+Body structure (task variant shown; others are variations):
+
+```tsx
+<div style={{ position: 'absolute', left: `${startPct}%`, width: `${widthPct}%`, top: 10, height: 16 }}>
+  <div style={{
+    position: 'absolute', inset: 0,
+    background: status === 'not_started' ? 'transparent' : categoryColor,
+    opacity: status === 'completed' ? 0.5 : 1,
+    border: status === 'not_started' ? `1.5px dashed ${categoryColor}` : status === 'overdue' ? `2px solid var(--tl-overdue)` : 'none',
+    borderRadius: 4,
+  }} />
+  {status === 'at_risk' && (
+    <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 3, background: 'var(--tl-at-risk)', borderTopLeftRadius: 4, borderTopRightRadius: 4 }} />
+  )}
+  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', paddingLeft: 8, fontSize: 11, fontWeight: 500, color: contrastTextFor(categoryColor) }}>
+    {label}{status === 'completed' && ' ✓'}
+  </div>
+</div>
+```
+
+`contrastTextFor(hex)` is a pure helper in `gantt-utils.ts` that returns white for dark colours, category-900 for light ones. Use WCAG luminance, not eyeballing. Two unit tests.
+
+Category and project variants are rollup bars: shorter (6px / 10px), lower opacity (0.45), no label inside the bar, no status modifiers.
+
+Milestone variant:
+
+```tsx
+<div style={{
+  position: 'absolute', left: `calc(${pct}% - 10px)`, top: 8,
+  width: 20, height: 20, background: categoryColor,
+  transform: 'rotate(45deg)', borderRadius: 2,
+}} />
+```
+
+### 5.6 `GanttDateHeader.tsx` (new)
+
+```tsx
+export function GanttDateHeader({ range, zoom, outlineWidth }: Props) {
+  const axis = generateDateAxis(range, zoom);
+  return (
+    <div style={{ height: 48, position: 'sticky', top: 0, background: 'var(--surface)', borderBottom: '1px solid var(--border)', zIndex: 2 }}>
+      <div style={{ height: 20, display: 'flex' }}>
+        {axis.months.map(m => (
+          <div key={m.label} style={{ width: `${m.endPct - m.startPct}%`, padding: '4px 0 0 8px', fontSize: 11, fontWeight: 500, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-2)', borderRight: '1px solid var(--border-2)' }}>
+            {m.label}
+          </div>
+        ))}
+      </div>
+      <div style={{ height: 28, position: 'relative' }}>
+        {axis.days.map(d => (
+          <span key={d.pct} style={{ position: 'absolute', left: `${d.pct}%`, transform: 'translateX(-50%)', top: 8, fontSize: 10, color: 'var(--text-2)' }}>
+            {d.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+### 5.7 `GanttInlineAdd.tsx` (new)
+
+```tsx
+type Props = { mode: 'category' | 'project' | 'task' | 'subtask'; parentKey: string; onAdd(): void };
+
+export function GanttInlineAdd({ mode, onAdd }: Props) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={onAdd}
+      style={{
+        height: 28, paddingLeft: indentByMode[mode], paddingRight: 14,
+        display: 'flex', alignItems: 'center', gap: 6,
+        fontSize: 11, fontStyle: 'italic', color: 'var(--text-muted)',
+        borderBottom: '1px solid var(--border)',
+        cursor: 'pointer',
+        opacity: hovered ? 1 : 0.6,
+      }}
+    >
+      + Add {mode === 'project' ? 'project' : mode === 'subtask' ? 'subtask' : 'task'}
+    </div>
+  );
+}
+```
+
+Wire into `GanttOutline.tsx`: after rendering a Category or Project row, if it's in `expanded`, render a `<GanttInlineAdd>`. `onAdd` calls the container's existing `onAdd` callback.
+
+### 5.8 `CategoryDot.tsx` (new)
+
+```tsx
+type Tier = 'category' | 'project' | 'task' | 'subtask';
+const sizeByTier: Record<Tier, number> = { category: 8, project: 7, task: 5, subtask: 4 };
+const opacityByTier: Record<Tier, number> = { category: 1, project: 0.8, task: 0.6, subtask: 0.5 };
+
+export function CategoryDot({ color, tier }: { color: string; tier: Tier }) {
+  const size = sizeByTier[tier];
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: size, height: size, borderRadius: '50%',
+        background: color, opacity: opacityByTier[tier],
+        boxShadow: tier === 'category' ? `0 0 0 2px ${tinyTint(color)}` : 'none',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+```
+
+`tinyTint(hex)` returns a 10%-alpha version of the colour for the ring. Pure function, one test.
+
+### 5.9 `GanttMilestone.tsx` (new)
+
+Very small. Renders the diamond at a percentage-based x within the grid row.
+
+### 5.10 `PortfolioGanttClient.tsx`
+
+Build the colour map after the tree normalisation step:
+
+```typescript
+const categoryColorMap = useMemo(() => {
+  const map = new Map<string, string>();
+  for (const cat of data?.categories ?? []) {
+    const key = cat.id ? `cat:${cat.id}` : 'cat:uncategorised';
+    map.set(key, cat.colour ?? '#6c44f6');
+  }
+  return map;
+}, [data]);
+```
+
+Pass `categoryColorMap` into `<GanttContainer>`. Plumbing only; no other changes.
+
+### 5.11 `ProjectGanttClient.tsx`
+
+Per-project view doesn't have a Category-root node. Fetch the project's category from the existing `/api/workspace/projects/:id` response (the data is there, `category_id` and the join). Build a single-entry `categoryColorMap` and pass it down. Fallback to `'#6c44f6'` if no category.
+
+### 5.12 Migration
+
+New file `packages/db/src/migrations/022_task_milestones.sql`:
+
+```sql
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS is_milestone BOOLEAN NOT NULL DEFAULT false;
+```
+
+Expose on `GanttTask` in both timeline routes. Accept in `POST /v1/tasks` and `PATCH /v1/tasks/:id`. Three new lines in each route, plus the Zod schema.
+
+### 5.13 `CategoryManagerPanel.tsx` (new)
+
+A slide-over panel (280px wide, position absolute, right-aligned over the outline column) triggered by a small gear icon next to the "TASK / GROUPS" header in `GanttOutline`. It uses the existing category CRUD endpoints:
+
+- `GET /v1/categories` → list (already used by the timeline)
+- `POST /v1/categories` → create (name + colour)
+- `PATCH /v1/categories/:id` → rename / recolour
+- `DELETE /v1/categories/:id` → delete (projects go to Uncategorised via FK)
+- `POST /v1/categories/reorder` → drag-reorder
+
+Layout:
+
+```tsx
+<div style={{
+  position: 'absolute', top: 48, left: 0, width: 280, bottom: 0,
+  background: 'var(--surface)', borderRight: '1px solid var(--border)',
+  zIndex: 10, padding: '12px 14px',
+  boxShadow: '4px 0 12px rgba(0,0,0,0.04)',
+}}>
+  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+    <span style={{ fontSize: 12, fontWeight: 500, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--text-2)' }}>
+      Categories
+    </span>
+    <button onClick={onClose} style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: 14 }}>
+      ✕
+    </button>
+  </div>
+
+  {categories.map(cat => (
+    <div key={cat.id} style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      padding: '8px 0', borderBottom: '1px solid var(--border)',
+    }}>
+      <input type="color" value={cat.colour ?? '#6c44f6'}
+        onChange={e => handleRecolour(cat.id, e.target.value)}
+        style={{ width: 20, height: 20, border: 'none', borderRadius: 4, cursor: 'pointer', padding: 0 }}
+      />
+      <span style={{ flex: 1, fontSize: 13, color: 'var(--text-1)' }}>{cat.name}</span>
+      <button onClick={() => handleRename(cat.id)} style={iconBtnStyle}>✎</button>
+      <button onClick={() => handleDelete(cat.id)} style={iconBtnStyle}>✕</button>
+    </div>
+  ))}
+
+  <button onClick={handleCreate} style={{
+    marginTop: 8, width: '100%', padding: '8px 0',
+    background: 'var(--surface-2)', border: '1px dashed var(--border-2)',
+    borderRadius: 8, fontSize: 12, color: 'var(--text-2)', cursor: 'pointer',
+  }}>
+    + New category
+  </button>
+</div>
+```
+
+State: 2 `useState` — `isOpen: boolean` (lives in `GanttOutline`) and `editingId: string | null` (inline rename mode). Mutations call the proxy endpoints and then trigger `fetchTimeline()` via a callback prop from `PortfolioGanttClient`. No new state in `GanttContainer`.
+
+Rename UX: click the pencil → the label turns into a 13px inline `<input>` with the current name; blur or Enter saves via `PATCH /v1/categories/:id`.
+
+Delete UX: confirm via `window.confirm('Delete category "{name}"? Projects will move to Uncategorised.')` — no custom modal needed for MVP.
+
+Reorder: deferred to P1 (drag-reorder is a nice-to-have; `sort_order` already works via the API for manual callers).
+
+---
+
+## 6. State model
+
+`GanttContainer` stays at 6 `useState`:
+
+```typescript
+const [zoom, setZoom] = useState<ZoomLevel>('month');
+const [search, setSearch] = useState('');
+const [outlineWidth, setOutlineWidth] = useState(260); // was 320
+const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+const [selectedKey, setSelectedKey] = useState<string | null>(null);
+const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+```
+
+Derived (memo, not state):
+- `allTasks`
+- `range`
+- `rows` (flattened visible)
+- `categoryColorMap` ← new
+- `milestones` ← new (extracted from rows)
+- `dateAxis` ← new
+
+Lifted out of `GanttGrid` to `GanttContainer` for sharing. No new state elsewhere.
+
+---
+
+## 7. Priority order
+
+### MVP — first PR, target 2–3 days
+
+Everything the user explicitly named, plus the structural fixes that make the rest possible.
+
+1. `CategoryDot` component + `resolveCategoryColor` utility + `buildCategoryColorMap` (foundational)
+2. Rewritten `GanttOutlineRow`: chevron + dot + tier-typography + truncation + Category bands
+3. Rewritten `GanttBar`: category-colour base + status modifiers
+4. New `GanttDateHeader`: two-row month/day
+5. Vertical gridlines at day markers
+6. Outline default width 260px
+7. New `GanttInlineAdd` under expanded Category and Project rows + `+ Add category` at outline bottom
+8. Today-line label pill
+9. New `CategoryManagerPanel`: slide-over from the outline header, list/create/rename/recolour/delete/reorder categories
+10. Unit tests for new utils (12 added)
+
+### P1 — second PR, target 1–2 days
+
+11. Milestones: `is_milestone` column migration + API plumbing + `GanttMilestone` component
+12. Hover tooltip on bars: full title + due date + assignee + status — use native `<div>` positioned on hover, no library
+13. Selection state on bars (2px outline in `--brand`) matching selection state in outline
+
+### Later — not in this plan
+
+The brief's §9 gaps, triaged against whether they're needed for "feeling like a proper Gantt":
+
+| §9 item | MVP? | Notes |
+|---|---|---|
+| 1. Dependency lines | No | Visually busy; Linear/Notion don't have them; user didn't mention |
+| 2. Unscheduled panel | No but soon | Useful for the empty-state case; defer to a follow-up PR |
+| 3. Mobile fallback | No | Larry is a desktop PM tool primarily; not on the critical path |
+| 4. Drag bars | No | Big lift; revisit after category colour lands |
+| 5. In-bar tooltips | **P1** | Cheap, high value — listed above |
+| 6. Assignee avatars | No for now | Fits later; adds visual noise if done too early |
+| 7. Milestones | **P1** | Explicitly in the sketch — listed above |
+| 8. Baseline vs actual | No | Enterprise-PM territory; out of scope for Larry |
+| 9. Critical path | No | Same |
+| 10. Row reorder | No | Covered by category `sort_order` + project `sort_order` already in DB |
+| 11. Re-parent task by drag | No | Edit fields is fine for v1 |
+| 12. Re-parent project by drag | No | Same |
+
+---
+
+## 8. Scope limit
+
+This plan does NOT propose:
+
+- Any DB schema change except one `ALTER TABLE tasks ADD COLUMN is_milestone BOOLEAN DEFAULT false`
+- Any new npm dependency (no chart lib, no dnd lib, no tooltip lib)
+- Changes to the backend API contracts beyond serialising `isMilestone`
+- Changes to non-Gantt components or pages (the category panel lives inside the Gantt outline, not a new route)
+- Mobile responsive pass (the Gantt remains a desktop feature)
+- Weekend shading (explicitly skipped for cleanliness)
+- Drag-and-drop of bars, rows, or reparenting
+- Dependency arrow rendering
+- Unscheduled-tasks panel (deferred, see §7)
+- Critical path, baseline, or earned-value concepts
+- Assignee avatar rendering on bars
+
+If the implementation agent finds any of these are blockers for the MVP items, stop and escalate rather than scope-creep.
+
+---
+
+## 9. Acceptance criteria
+
+Run through these with the user on a screenshare before merging:
+
+1. Open `/workspace/timeline` on a tenant with ≥3 categories. Each category row's background is `--surface-2`, its label is uppercase, and its coloured dot is visible and matches the category's `colour` field.
+2. Projects under a category inherit that category's colour in their dot AND their rollup bar.
+3. Tasks under a project inherit the same colour in their dot AND their bar. Status shows as: solid (on_track), dashed outline (not_started), amber top stripe (at_risk), coral outline (overdue), 50% opacity + ✓ (completed).
+4. The date header shows two rows: month labels on top, day numbers on bottom, with the month boundary clearly separated.
+5. Hovering over an expanded Category or Project row shows a faded `+ Add task` / `+ Add project` line underneath; clicking it opens the existing `AddNodeModal` scoped to the right parent.
+6. At the bottom of the outline, a subtle `+ Add category` row is visible; clicking it opens the `AddNodeModal` in category mode.
+7. Clicking the gear icon in the outline header opens the `CategoryManagerPanel` slide-over. From there: create a new category with a name and colour, rename an existing one inline, change its colour via the colour swatch, and delete it (projects move to Uncategorised).
+8. A task with `is_milestone = true` renders as a rotated-square diamond at its due date instead of a bar.
+9. Creating an Uncategorised project, its tasks' bars are Larry purple `#6c44f6`.
+10. Per-project Timeline tab (`/workspace/projects/<id>`): all bars use the parent category's colour; if the project is uncategorised, all bars are Larry purple.
+11. The row-alignment invariant holds: outline row N lines up pixel-exactly with grid row N at every zoom.
+12. No task label in the outline overflows — long titles truncate with `…` and show the full title on hover.
+13. The today-line carries a `Today` pill label at the top of the grid.
+14. All 12 new unit tests + 8 existing tests pass.
+
+---
+
+## 10. Resolved decisions (user confirmed 2026-04-16)
+
+1. **Category management** → Ship a proper "Manage categories" panel in this PR (MVP). See §5.13 for spec.
+2. **Milestone data** → `is_milestone BOOLEAN` on `tasks`. Confirmed.
+3. **Inline add at the Category root** → A subtle `+ Add category` inline row at the very bottom of the outline (same style as other inline-add rows). Minimalistic, no toolbar clutter.
+4. **Completed-task treatment** → Faded same category colour at 50% opacity + `✓` glyph. No hide/toggle. Confirmed.
+5. **Weekend shading** → Skipped entirely for cleanliness. Not in any PR.
+
+---
+
+## 11. What gets shipped in which PR
+
+**PR #67 — Gantt v2: Category colour, hierarchy & category management**
+Items 1–10 from §7 MVP. Target ~800 LOC net, mostly in the Gantt folder. Includes the `CategoryManagerPanel` slide-over for full category CRUD. Unit-test coverage ≥ 80% on new helpers. No DB migration. No backend changes. Should be reviewable in one sitting.
+
+**PR #68 — Gantt v2: Milestones & polish**
+Items 11–13 from §7 P1. ~200 LOC net. One small migration. Three lines of backend per timeline route. Ship behind a `feature_gantt_milestones` flag if you want to stage it.
+
+Both PRs together are the full restructure the user asked for.
+
+---
+
+*End of plan. Attach to the brief as a companion doc and hand both to the implementation session.*

--- a/docs/reports/gantt-redesign-brief.md
+++ b/docs/reports/gantt-redesign-brief.md
@@ -1,0 +1,401 @@
+# Gantt Chart Redesign Brief
+
+**For:** a reasoning agent tasked with proposing a restructure plan for Larry's Gantt chart.
+**Date:** 2026-04-16
+**Written by:** Claude (implementation agent, shipping the current Gantt)
+**Status of current work:** Shipped to production at www.larry-pm.com (PRs #65 + #66 merged). User reviewed and rejected the current design — wants a full restructure.
+
+---
+
+## 1. Larry — What it is
+
+Larry is an **AI-powered project management tool** aimed at small-to-mid-size teams that currently struggle with Monday.com / Asana / ClickUp — too many fields, not enough AI. The product bet: an AI "PM in a box" that watches Slack/email/calendar, proposes tasks and next actions, and handles most of the tracking work itself, so humans can just *run projects* instead of *maintaining project-tracking software*.
+
+**Target user:** a project manager or team lead at a 5–50-person company running 3–30 concurrent projects. They want to see what's happening, what's blocked, and what Larry recommends — without data-entry chore.
+
+**Key product surfaces (sidebar order today):**
+- Home
+- My tasks
+- **Timeline** ← this doc
+- Actions (AI-suggested next actions)
+- Notifications
+- Meetings (transcript ingest)
+- Calendar (monthly calendar, Google/Outlook sync)
+- Documents
+- Mail (email drafts)
+- Chats
+- Larry (the AI chat panel)
+- Settings
+
+**Visual identity**
+- Brand colour: **#6c44f6** (Larry purple). All CTAs, the brand mark, active nav states.
+- Neutrals lean lavender-white: surfaces are `#FFFFFF` over `#f6f2fc`, borders `#f0edfa`.
+- Text: `#11172c` (primary), `#4b556b` (secondary), `#bdb7d0` (muted).
+- Status palette for task bars/dots (kept from before this redesign):
+  - Not started: `#d0d0d0` / dark `#b0b0b0`
+  - In progress: `#7ab0d8` / dark `#5a94be` (cool blue)
+  - At risk: `#d4b84a` / dark `#b89e3a` (amber)
+  - Overdue: `#e87878` / dark `#c75a5a` (coral)
+  - Completed: `#6ab86a` / dark `#52a352` (green)
+- Radii: card 12px, button 8px, input 8px, badge 20px, dropdown 10px.
+- Design philosophy: soft, lavender-tinted, low-contrast, lots of whitespace. Clean and modern — **not** Monday-style loud traffic-light boards. Think Linear / Notion / Superhuman, *not* Jira.
+
+All the above are defined as CSS custom properties in `apps/web/src/app/globals.css` — use the variable, not the literal colour, when styling.
+
+---
+
+## 2. Stack & repo layout
+
+Monorepo at `C:\Dev\larry\site-deploys\larry-site` (npm workspaces).
+
+| Workspace | What |
+|---|---|
+| `apps/web` | Next.js 16 App Router, React 19, TypeScript. Tailwind v4 exists but is barely used — most styling is **inline styles** via `style={{ ... }}` against the CSS variables. Deploy target: Vercel. |
+| `apps/api` | Fastify 5 + Zod + Vitest. Deploys on Railway at `larry-site-production.up.railway.app`. Auth via `@fastify/jwt`. |
+| `apps/worker` | BullMQ job consumer (not relevant to Gantt). |
+| `packages/shared` | Cross-workspace TypeScript types (`GanttTask`, `ProjectCategory`, `PortfolioTimelineResponse`, etc.). |
+| `packages/db` | Postgres client + migrations. Schema applied on every API boot via idempotent `CREATE TABLE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS`. |
+| `packages/ai` | Vercel AI SDK + Gemini. Not touched by Gantt work. |
+
+**Routing pattern:** Next.js (web) exposes `/api/workspace/*` proxy routes that forward to the Fastify API under `/v1/*`. The proxy (`apps/web/src/lib/workspace-proxy.ts`) handles token refresh and session rotation. Do NOT expose `larry-site-production.up.railway.app` directly to the browser.
+
+---
+
+## 3. Current Gantt — entry points
+
+Two entry points, one shared component.
+
+### 3.1 Portfolio view — `/workspace/timeline`
+- **Page:** `apps/web/src/app/workspace/timeline/page.tsx` (server component — just renders client).
+- **Client:** `apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx`.
+- Fetches `/api/workspace/timeline` → `/v1/timeline` (tenant-wide tree).
+- Tree root is synthetic `"__root__"` category; its children are real categories (including a synthetic "Uncategorised" bucket if any project has `category_id = null`).
+- Nav link added to `WORKSPACE_NAV` in `apps/web/src/components/dashboard/Sidebar.tsx` between "My tasks" and "Actions", using `lucide-react` icon `GanttChartSquare`.
+
+### 3.2 Per-project view — `/workspace/projects/[projectId]` → Timeline tab
+- The project page `apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx` is a giant 1800-line client component with tabs (Overview / Timeline / Task center / Action center / Calendar / Dashboard / Files / Teams / Settings).
+- When the Timeline tab is active, it renders `<ProjectGanttClient projectId={...} projectName={...} tasks={...} timeline={...} refresh={...} />` at line ~1797.
+- `ProjectGanttClient` at `apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx` builds a `project`-kind root (no Category level shown here) and renders the same `<GanttContainer>`.
+
+---
+
+## 4. Data model
+
+### 4.1 `projects`
+Already existed. New column added by this work:
+```sql
+category_id UUID REFERENCES project_categories(id) ON DELETE SET NULL
+```
+
+### 4.2 `project_categories` (NEW)
+```sql
+id UUID PK,
+tenant_id UUID NOT NULL (tenants FK, CASCADE),
+name TEXT NOT NULL,
+colour TEXT,                -- user-chosen hex, nullable
+sort_order INT NOT NULL DEFAULT 0,
+created_at / updated_at TIMESTAMPTZ
+-- Row-level security enabled + tenant_isolation_project_categories policy
+```
+
+### 4.3 `tasks`
+Already existed. New column:
+```sql
+parent_task_id UUID REFERENCES tasks(id) ON DELETE CASCADE
+```
+**Depth limit: 1** — a task can have subtasks, but a subtask cannot have its own sub-subtask. Enforced at the API layer in `POST/PATCH /v1/tasks`.
+
+### 4.4 `task_dependencies`
+Already existed. Pre-existing table. `task_id` → `depends_on_task_id`, tenant-scoped. **Currently fetched by the timeline endpoints but NOT rendered anywhere in the UI** — known gap.
+
+---
+
+## 5. API endpoints
+
+All under `/v1/*` in Fastify, proxied through `/api/workspace/*` in Next.js.
+
+| Method + Path | Handler file | Purpose |
+|---|---|---|
+| `GET /v1/categories` | `apps/api/src/routes/v1/categories.ts` | List tenant's categories sorted by `sort_order`. |
+| `POST /v1/categories` | same | Create — `{ name, colour?, sortOrder? }`. |
+| `PATCH /v1/categories/:id` | same | Update. |
+| `DELETE /v1/categories/:id` | same | Delete (projects re-parent to NULL via FK). |
+| `POST /v1/categories/reorder` | same | `{ ids: [] }` — persists new `sort_order`. |
+| `GET /v1/timeline` | `apps/api/src/routes/v1/timeline.ts` | **Portfolio tree.** Returns `{ categories: [...], dependencies: [...] }`. Synthetic "Uncategorised" bucket appended if needed. |
+| `GET /v1/projects/:id/timeline` | `apps/api/src/routes/v1/projects.ts` | Per-project — returns `{ gantt: [tasks with parentTaskId], dependencies: [] }`. |
+| `POST /v1/tasks` | `apps/api/src/routes/v1/tasks.ts` | Accepts `parentTaskId` with depth + same-project + same-tenant validation. |
+| `PATCH /v1/tasks/:id` | same | Accepts `parentTaskId` for re-parenting. Rejects self-parent. |
+| `POST /v1/projects` | `apps/api/src/routes/v1/projects.ts` | Accepts `categoryId`. |
+| `PATCH /v1/projects/:id` | same | Accepts `categoryId` (including null to uncategorise). |
+
+### API response shapes
+
+```ts
+// GET /v1/timeline
+type PortfolioTimelineResponse = {
+  categories: Array<{
+    id: string | null;          // null = Uncategorised synthetic bucket
+    name: string;
+    colour: string | null;
+    sortOrder: number;
+    projects: Array<{
+      id: string;
+      name: string;
+      status: "active" | "archived";
+      startDate: string | null;
+      targetDate: string | null;
+      tasks: GanttTask[];       // flat; client re-builds parent/child tree
+    }>;
+  }>;
+  dependencies: Array<{ taskId: string; dependsOnTaskId: string }>;
+};
+
+type GanttTask = {
+  id: string;
+  projectId: string;
+  parentTaskId: string | null;
+  title: string;
+  status: "not_started" | "on_track" | "at_risk" | "overdue" | "completed";
+  priority: "low" | "medium" | "high" | "critical";
+  assigneeUserId: string | null;
+  assigneeName: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  dueDate: string | null;
+  progressPercent: number;
+};
+```
+
+Types live in `packages/shared/src/index.ts` and are re-exported from `apps/web/src/components/workspace/gantt/gantt-types.ts`.
+
+**Important data-quirk:** the DB `task_status` enum has more values than `GanttTask.status` (`backlog`, `in_progress`, `waiting`, `blocked`, `completed`). The per-project timeline route returns raw enum values. A helper `normalizeGanttStatus()` in `gantt-utils.ts` maps them to the 5-status Gantt palette:
+- backlog / not_started → `not_started`
+- in_progress / on_track → `on_track`
+- waiting / at_risk → `at_risk`
+- blocked / overdue → `overdue`
+- completed / done → `completed`
+
+---
+
+## 6. Component architecture — `apps/web/src/components/workspace/gantt/`
+
+One folder, all the Gantt pieces. **All styling is inline `style={{ ... }}` using CSS vars.** No Tailwind, no CSS modules.
+
+| File | Role |
+|---|---|
+| `gantt-types.ts` | Re-exports shared types. Defines `GanttNode` discriminated union (category / project / task / subtask), `ZoomLevel` (`week` / `month` / `quarter`), `ROW_HEIGHT = 36`. |
+| `gantt-utils.ts` | Pure functions: `buildPortfolioTree`, `buildProjectTree`, `buildTaskForest` (parent/child nesting), `flattenVisible` (returns `FlatRow[]` respecting expand set; skips the root node), `rollUpBar` (parent bar math — min start / max end / progress-weighted by duration), `computeRange` (W/M/Q axis padding), `dateToPct`, `addDays`, `daysBetween`, `normalizeGanttStatus`, `normalizePortfolioStatuses`. |
+| `gantt-utils.test.ts` | Vitest tests for the above. 8 tests. |
+| `GanttContainer.tsx` | Top-level orchestrator. Owns state: `zoom`, `search`, `outlineWidth` (resizable 220–520px, default 320), `hoveredKey`, `selectedKey`, `expanded: Set<string>`. Memo-builds `allTasks`, `range`, `rows`. Passes down to `<GanttToolbar>`, `<GanttOutline>`, `<GanttGrid>`. Exposes `onAdd`, `onOpenDetail` callbacks. |
+| `GanttToolbar.tsx` | Top bar with `W` / `M` / `Q` zoom pills (active = filled purple), `Today` button, `Expand/Collapse all` button, 240px search input, and a trailing purple "+ Add" button (shown only when `canAdd`). |
+| `GanttOutline.tsx` | Left sidebar. Sticky left, 320px default. Renders `<GanttOutlineRow>` per visible row. Has a drag handle on the right edge to resize. |
+| `GanttOutlineRow.tsx` | Per-row outline item. Height 36px, indent `12 + depth*12`, chevron if hasChildren (rotates 90° on expand), 14px kind icon (`C` / `P` / `·` / `◦`), title. Selected row gets a 3px left purple border; hovered row gets `surface-2` bg. Label weight varies by kind — category 700 uppercase 12px, project 600 13px, task 500 13px, subtask 400 12px in `text-2`. |
+| `GanttGrid.tsx` | Right time-axis pane. `forwardRef`d so parent can scroll-jump to today. Sticky header row (34px) with markers generated by `generateMarkers(range, zoom)` — days when zoom=week, weekly Monday labels when month, monthly labels when quarter. Single vertical **today line** at `rgba(108,68,246,0.4)`. Renders `<GanttRow>` per visible flat row. |
+| `GanttRow.tsx` | Per-row bar area. If the node is a task/subtask and has dates, renders `<GanttBar>`. If a container node, gathers all descendant tasks, computes `rollUpBar` and renders a rollup `<GanttBar variant="category"|"project">`. 36px tall, bottom border, selected row has faint purple tint. |
+| `GanttBar.tsx` | The bar itself. 5 variants with different heights/colours: `category` (20px, bold, surface-2 band), `project` (16px, Larry purple), `task` (16px, status-var), `subtask` (10px, status-var lower opacity), `rollup` (6px, thin purple). Progress fill is a solid inner div sized to `progressPercent`. Label rendered inside bar unless variant is `subtask` or `category` (categories show the name in the outline row instead). |
+| `ProjectGanttClient.tsx` | Per-project wrapper. Maps `WorkspaceTimelineTask` → `GanttTask`. Uses `buildProjectTree`. `onAdd` opens the `AddNodeModal` in `task` or `subtask` mode depending on whether a task row is selected. |
+| `PortfolioGanttClient.tsx` | Portfolio wrapper. Fetches, normalises statuses, builds tree. `onAdd` opens the modal in `category` or `project` mode depending on whether a category is selected. Error state = `"Couldn't load timeline: HTTP <code>"` text. Loading state = `"Loading…"` text. |
+| `AddNodeModal.tsx` | Centred modal, 380px wide. 4 modes: `category` (name + colour picker), `project` (name + hidden categoryId), `task` (title + optional due date, project context), `subtask` (same + parent task context). Primary button is Larry purple. POSTs to the matching proxy, then calls `onCreated` to refetch. |
+
+### Flow of a click on "+" in the portfolio view with "Client work" category selected:
+
+1. User clicks `+` in `GanttToolbar`.
+2. `GanttContainer` calls `onAdd({ selectedKey: "cat:<uuid>" })`.
+3. `PortfolioGanttClient.handleAdd` sets local state `addCtx = { mode: "project", parentCategoryId: "<uuid>" }`.
+4. `<AddNodeModal mode="project" parentCategoryId=... />` renders.
+5. User types name, clicks "Create".
+6. Modal POSTs to `/api/workspace/projects` with `{ name, categoryId }`.
+7. Next.js proxy forwards to `/v1/projects` on Railway.
+8. On success, modal calls `fetchTimeline()` on `PortfolioGanttClient`, closes itself.
+9. `setData(...)` triggers a re-render → `buildPortfolioTree` → tree shows the new project under "Client work".
+
+---
+
+## 7. What the user sees today (screenshots reviewed this session)
+
+Two production screenshots from the user on 2026-04-16:
+
+### Screenshot 1: error state ("client-side exception")
+Happened because the user clicked the Timeline nav before the merge had fully propagated on Vercel — stale JS bundle, module resolution for `@larry/shared` missed. **Fixed** by adding `@larry/shared` as a dep of `@larry/web` and building it in `vercel-build`. No longer reproduces.
+
+### Screenshot 2: Nordvik Bank project — Timeline tab
+Showed a toolbar with `W / M / Q | Today | Group: Phase ▾ | Colour: Status ▾ | Search | Collapse all | + Add task` and a single flat swimlane labelled "Uncategorised (22 tasks)" with green/grey bars on dates. **This was the OLD `ProjectTimeline` component** — the user's browser was showing a cached pre-merge bundle. The NEW toolbar (what's actually deployed now) is different:
+- No "Group by" dropdown
+- No "Colour by" dropdown
+- "Expand all" / "Collapse all" toggle (not just "Collapse all")
+- "+ Add" / "+ Task" / "+ Subtask" depending on context
+- No swimlane header — instead, a collapsible tree in the **left sidebar** with chevrons
+
+### What the live Gantt actually looks like now (verified on prod by Playwright):
+- Left: tree with chevrons. Portfolio view shows `▾ C UNCATEGORISED → ▾ P QA Test — Customer Onboarding Re… → · task rows (indented)`.
+- Right: sparse grid with month headers (`6 Apr | 13 Apr | 20 Apr | ...`) and a faint vertical purple today-line. Mostly empty because the seed data has `startDate: null` on most tasks (only `dueDate` is set).
+- No bars were visible for most tasks until PR #66 (shipped minutes ago) added `startDate = today` synthesis when only `dueDate` exists.
+
+---
+
+## 8. The user's actual complaint
+
+Direct quotes from the conversation:
+
+> "the timeline loads now. But as you can see in this screenshot, there's no option to make subcategories like Gantt doesn't look very different. Can you investigate this?"
+
+> "The gantt chart is really not what i want it to be, it is really far off."
+
+Unpacking what this likely means:
+
+1. **"No option to make subcategories"** — legitimate gap. The `AddNodeModal` was missing at the time of the screenshot. It was shipped in PR #66 minutes before the user declared the whole thing "really far off", so they may not have tested it. The modal works but is very minimal (modal + form + submit). There is no in-tree "+" on each row, no context-menu, no drag-to-reorder, no drag-to-reparent. Creating a subtask requires: click a task row in the outline → the `+` label changes to `+ Subtask` → click it → modal.
+
+2. **"Gantt doesn't look very different"** — likely a mix of:
+   - Empty grid (seed tasks have no start dates, so no bars; PR #66 fixed this but user may not have refreshed).
+   - The overall **visual feels flat and minimal** compared to a "proper" Gantt. Earlier user framing in the brainstorm (quoting the original request verbatim):
+     > *"there should be a sidebar on the left where you can collapse everything. And fold out everything. And then you should also be able to see, you know, like, this time or this group of projects or tasks and then this group of projects"*
+   - User rejected a "Linear-style simpler timeline" earlier in this same session (their own prior decision from 2026-04-04, superseded on 2026-04-15). They want a **proper, dense, Gantt** — more like MS Project / Smartsheet / TeamGantt than Linear's roadmap view.
+   - Possibly missing visual things that make a Gantt feel Gantt-y:
+     - **Dependency arrows between bars** — data is fetched but not rendered
+     - **Drag bars to move / drag edges to resize** — not implemented
+     - **Milestone diamonds** — not implemented
+     - **Critical path highlighting** — not implemented
+     - **Unscheduled tasks panel** — was in the old component, removed, not replaced
+     - **Assignee avatars on bars** — data available, not shown
+     - **Progress fill inside bars** — implemented but subtle
+     - **Weekend / non-working-day shading** — not implemented
+     - **Sticky column headers that follow horizontal scroll** — partially (header is sticky top, not left)
+     - **Inline "+ row" affordances** — no in-line "add task here" rows between bars like MS Project
+     - **Column header sticky on scroll horizontally** — currently only vertically sticky
+     - **Expand/collapse a group by clicking the summary bar itself** — only the outline chevron works
+     - **The category/project rollup bar is thin (6–20px) and translucent** — may read as "nothing" rather than "parent span"
+     - **Bars are labelled with task title, but truncated aggressively** — long titles become `[DM …]`-style ellipses because the bar is narrow
+
+3. **Implicit gap — it doesn't tell a story**. A user opening the portfolio Gantt should immediately see *where the company is this quarter*. The current empty-grid-with-tiny-bars does not convey that. It needs more visual density, maybe status pills, risk indicators, assignee avatars, dependency arrows, today highlighting beyond one vertical line.
+
+---
+
+## 9. Known feature gaps documented at ship time (in PR #65 body)
+
+These were explicitly deferred in the plan and listed as follow-ups:
+
+1. **Dependency lines** — `task_dependencies` is fetched (both endpoints return it) but **no SVG overlay renders arrows** between dependent bars. A file `GanttDependencyLines.tsx` was specified in the spec but never written.
+2. **Unscheduled panel** — old `ProjectTimeline` had an `<UnscheduledPanel>` at the bottom listing tasks with no dates. It was deleted with the rest of the `timeline/` folder and never re-added. Tasks without dates currently appear in the outline (left) but have no bar (right).
+3. **Mobile fallback** — old `ProjectTimeline` swapped to `<TimelineMobileList>` on viewport < 1024px. Deleted. Current Gantt is not mobile-responsive; on a phone it just horizontally scrolls a tiny grid.
+4. **Drag bars** — no drag-to-move, no drag-edge-to-resize. The old component supported drag-from-unscheduled-to-grid; this is also gone.
+5. **In-bar labels are truncated aggressively** — long titles become `[...]`. No hover tooltip.
+6. **Status pills on rows / assignee avatar strips** — not rendered, even though data is available.
+7. **Milestones** — no diamond marker rendering.
+8. **Baseline vs actual** — not implemented.
+9. **Critical path** — not implemented.
+10. **Reorder rows (drag in outline)** — not implemented.
+11. **Re-parent a task by drag** — not implemented; has to be done by editing fields.
+12. **Re-parent a project to a different category by drag** — not implemented.
+
+---
+
+## 10. What works well today (don't break these)
+
+- The 4-level tree builds correctly from the flat API response.
+- Expand/collapse is per-node via chevron; "Expand all" toggles the whole tree.
+- The row-alignment invariant (outline and grid share the same `flattenVisible` array, both use `ROW_HEIGHT = 36`) means outline row N lines up with grid row N exactly. Any restructure should preserve this.
+- Search dims non-matches (opacity 0.35) rather than removing them, so the hierarchy stays visible.
+- Rollup math (weighted-average progress, min-start / max-end) is correct and tested.
+- Status-normalisation handles the DB↔UI enum mismatch — the `normalizeGanttStatus` helper must remain.
+- API layer has good tenant isolation and depth validation. Backend is solid.
+- DB has RLS on `project_categories`.
+
+---
+
+## 11. Design-token + layout cheat sheet for a restructure
+
+If you redesign, **use these tokens**, not literals:
+
+```css
+--brand: #6c44f6;             /* PRIMARY everything — CTAs, active states, accent */
+--brand-hover: #5b38d4;
+--cta: #6c44f6;
+--surface: #FFFFFF;            /* card/panel bg */
+--surface-2: #f6f2fc;          /* hover/zebra bg, lavender tint */
+--border: #f0edfa;             /* default border */
+--border-2: #bdb7d0;           /* emphasised border */
+--text-1: #11172c;             /* primary text */
+--text-2: #4b556b;             /* secondary text */
+--text-muted: #bdb7d0;         /* disabled-ish, helper text */
+
+--tl-not-started: #d0d0d0;     /* task bar fills (and their -dark variants) */
+--tl-in-progress: #7ab0d8;
+--tl-at-risk: #d4b84a;
+--tl-overdue: #e87878;
+--tl-completed: #6ab86a;
+
+--radius-card: 12px;
+--radius-btn: 8px;
+--radius-input: 8px;
+```
+
+Typography: system sans stack (no custom font loaded). Text sizes in the Gantt currently: 10–13px (dense). Line-height default.
+
+Dimensions in current Gantt:
+- Row height: **36px** (all rows, all depths)
+- Outline default width: 320px, min 220, max 520
+- Depth indent: 12px + depth × 12px → depth 3 = 48px left padding
+- Grid header height: 34px
+- Today line: 1px `rgba(108, 68, 246, 0.4)`
+- Bar heights: category 20, project 16, task 16, subtask 10, rollup 6
+
+---
+
+## 12. How to read the codebase quickly
+
+Read in this order:
+
+1. `docs/superpowers/specs/2026-04-15-portfolio-gantt-design.md` — the design spec this work was built against (370 lines).
+2. `docs/superpowers/plans/2026-04-15-portfolio-gantt.md` — the implementation plan (2670 lines, fully annotated with exact file paths and code).
+3. `apps/web/src/components/workspace/gantt/gantt-types.ts` (20 lines) then `gantt-utils.ts` (~180 lines) — the data layer.
+4. `apps/web/src/components/workspace/gantt/GanttContainer.tsx` (~130 lines) — the orchestrator; start here to understand the state flow.
+5. `GanttOutline.tsx`, `GanttGrid.tsx`, `GanttRow.tsx`, `GanttBar.tsx`, `GanttOutlineRow.tsx`, `GanttToolbar.tsx` — render layer.
+6. `PortfolioGanttClient.tsx` + `ProjectGanttClient.tsx` + `AddNodeModal.tsx` — page wrappers.
+7. `apps/api/src/routes/v1/timeline.ts`, `categories.ts`, `tasks.ts`, `projects.ts` — backend.
+8. `packages/db/src/migrations/021_portfolio_gantt.sql` — DB migration.
+
+Reference existing patterns (not Gantt-specific) that represent Larry's visual language:
+- `apps/web/src/app/workspace/WorkspaceHome.tsx` — project-card grid on the home page
+- `apps/web/src/app/workspace/projects/[projectId]/overview/` — the Project Overview tab, which the user has NOT complained about — this is a good template for the visual weight they expect.
+- `apps/web/src/app/workspace/calendar/page.tsx` — the monthly calendar, also well-liked.
+
+---
+
+## 13. Constraints on any proposed restructure
+
+1. **Don't touch the DB schema unless necessary.** The hierarchy (category → project → task → subtask) works; the depth-1 subtask limit is deliberate.
+2. **Don't remove the portfolio-wide view.** It was the primary ask.
+3. **Keep the shared-component pattern.** Portfolio and project views share one tree component.
+4. **Keep the row-alignment invariant.** Outline row N must visually line up with grid row N.
+5. **Use Larry palette variables.** No new brand colours.
+6. **No external charting library.** Current implementation is hand-rolled inline styles; any replacement should not add dependencies (react-gantt, gantt-task-react, DHTMLX, etc.) unless strongly justified — Larry is sensitive to bundle size.
+7. **Match Larry's visual tone.** Soft, lavender, low-contrast, Notion-ish. Not Microsoft Project's grey density. Not Jira's busy-ness.
+8. **Must remain testable.** `gantt-utils.ts` has unit tests — pure-function helpers are preferred over in-component logic.
+9. **Preserve existing API endpoints and types** in `packages/shared`. Backend is considered stable.
+10. **Must work for an empty tenant** (zero categories, zero projects) — no crashes on `data.categories = []`.
+
+---
+
+## 14. What a good plan from you would contain
+
+- A crisp articulation of **what aesthetic / interaction gap** the user is actually feeling (point 8 above is my best guess).
+- A **new visual mock** — either an ASCII sketch or a reference to a named product ("like TeamGantt", "like ClickUp's Gantt", "like Airtable's timeline"). Include colours, row densities, which affordances live where.
+- A **diff against the current implementation** — which components to keep, which to rewrite, which new ones to add.
+- **File-level proposals** with exact paths under `apps/web/src/components/workspace/gantt/`.
+- **State model** — what React state goes in which component. Stay under 10 useState in any one component.
+- **Priority order** — what's MVP vs nice-to-have.
+- A note on whether any of the known gaps (§9) are part of "making it feel like a proper Gantt" and therefore need to be in the first cut.
+- An explicit **scope limit** — say what you're NOT proposing, to keep the plan shippable.
+
+---
+
+## 15. Relevant PR numbers and SHAs (for reference)
+
+- **PR #65** (merged, initial Gantt): `d21a142`. Squashed into 29 commits on a feature branch.
+- **PR #66** (merged, fixes): `3946ee9`. Added `AddNodeModal` + fixed empty-bar rendering + added `@larry/shared` to `@larry/web` deps for Vercel build.
+
+Branch history lives in the repo at `C:\Dev\larry\site-deploys\larry-site`. Latest master SHA at time of writing: `3946ee9`.
+
+---
+
+*End of brief. Feel free to ask for more data — raw task samples, DB query results, additional screenshots — before drafting the plan.*


### PR DESCRIPTION
## Summary

PR #67 of the Gantt v2 restructure plan (MVP items 1–10 from `docs/reports/2026-04-16-gantt-restructure-plan.md`).

- Category becomes the dominant visual signal: bars + dots inherit category colour, status layers as modifiers (dashed / amber stripe / coral outline / 50% + ✓)
- New two-row month/day date header, vertical gridlines, Today pill
- New \`CategoryManagerPanel\` slide-over (list/create/rename/recolour/delete) + hover-revealed inline \"+ Add\" rows under expanded Category / Project rows
- Per-project view fetches its project's category colour; portfolio view builds a colour map from the timeline response
- \`FlatRow\` is now a discriminated union (\`node\` | \`add\`) so inline-add rows keep the outline ↔ grid row-alignment invariant

## Test plan

- [x] \`npx vitest run\` in apps/web — 25 tests pass (13 new in gantt-utils.test.ts)
- [x] \`npx tsc --noEmit\` in apps/web — clean
- [ ] Vercel preview loads \`/workspace/timeline\` and \`/workspace/projects/<id>\` (Timeline tab) without errors
- [ ] Category colour inheritance visible on portfolio view with ≥2 categories
- [ ] \"+ Add\" inline rows appear on hover of expanded Category/Project rows
- [ ] Gear icon in outline header opens \`CategoryManagerPanel\`; create / rename / recolour / delete round-trip

Milestones, bar tooltips, and bar selection are in the follow-up PR #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)