### PR TITLE
fix(email): stop silent drop in Compose — use verified sender + surface Resend errors

### DIFF
--- a/apps/api/src/routes/v1/connectors-email.ts
+++ b/apps/api/src/routes/v1/connectors-email.ts
@@ -537,19 +537,23 @@ export const emailConnectorRoutes: FastifyPluginAsync = async (fastify) => {
           const resendKey = fastify.config.RESEND_API_KEY;
           if (resendKey) {
             try {
-              await fetch("https://api.resend.com/emails", {
+              const res = await fetch("https://api.resend.com/emails", {
                 method: "POST",
                 headers: {
                   "Authorization": `Bearer ${resendKey}`,
                   "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                  from: "Larry <noreply@larry.app>",
+                  from: fastify.config.RESEND_FROM_LARRY,
                   to: [body.to],
                   subject: body.subject,
                   text: body.body,
                 }),
               });
+              if (!res.ok) {
+                const errBody = await res.text().catch(() => "<unreadable>");
+                throw new Error(`Resend responded ${res.status}: ${errBody.slice(0, 500)}`);
+              }
             } catch (err) {
               fastify.log.warn({ err }, "Resend email delivery failed — draft saved anyway");
             }

--- a/apps/api/tests/connectors-email-draft-send.test.ts
+++ b/apps/api/tests/connectors-email-draft-send.test.ts
@@ -38,6 +38,9 @@ async function createTestApp(params: {
     {
       MODEL_PROVIDER: "mock",
       EMAIL_CONNECTOR_PROVIDER: "generic",
+      RESEND_API_KEY: "re_test_key",
+      RESEND_FROM_LARRY: "Larry <larry@larry-pm.com>",
+      RESEND_FROM_NOREPLY: "Larry <noreply@larry-pm.com>",
     } as unknown as ApiEnv
   );
   app.decorate(
@@ -118,5 +121,100 @@ describe("POST /connectors/email/draft/send", () => {
       expect.stringContaining("INSERT INTO documents"),
       expect.any(Array)
     );
+  });
+
+  it("sends via Resend using the configured RESEND_FROM_LARRY address (regression: no hardcoded sender)", async () => {
+    const queryTenant = vi.fn(async (_tenantId: string, sql: string) => {
+      if (sql.includes("INSERT INTO email_outbound_drafts")) return [{ id: "draft-2" }];
+      if (sql.includes("INSERT INTO documents")) return [{ id: "doc-2" }];
+      return [];
+    });
+    const db = { queryTenant, tx: vi.fn() } as unknown as Db;
+    const queue = {
+      publish: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as QueuePublisher;
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "resend-1" }), { status: 200 }));
+
+    const app = await createTestApp({ db, queue });
+    appsToClose.push(app);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/connectors/email/draft/send",
+      payload: {
+        projectId: PROJECT_ID,
+        actionId: ACTION_ID,
+        to: "recipient@example.com",
+        subject: "Regression: sender address",
+        body: "Body",
+        sendNow: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({ success: true, state: "sent" });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.resend.com/emails",
+      expect.objectContaining({ method: "POST" })
+    );
+    const sentPayload = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(sentPayload.from).toBe("Larry <larry@larry-pm.com>");
+    expect(sentPayload.from).not.toMatch(/larry\.app/);
+    expect(sentPayload.to).toEqual(["recipient@example.com"]);
+    expect(sentPayload.subject).toBe("Regression: sender address");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("logs a warning when Resend responds non-ok (regression: no silent 403 swallow)", async () => {
+    const queryTenant = vi.fn(async (_tenantId: string, sql: string) => {
+      if (sql.includes("INSERT INTO email_outbound_drafts")) return [{ id: "draft-3" }];
+      if (sql.includes("INSERT INTO documents")) return [{ id: "doc-3" }];
+      return [];
+    });
+    const db = { queryTenant, tx: vi.fn() } as unknown as Db;
+    const queue = {
+      publish: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as QueuePublisher;
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ statusCode: 403, message: "domain not verified" }),
+          { status: 403 }
+        )
+      );
+
+    const app = await createTestApp({ db, queue });
+    appsToClose.push(app);
+    const warnSpy = vi.spyOn(app.log, "warn");
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/connectors/email/draft/send",
+      payload: {
+        projectId: PROJECT_ID,
+        to: "recipient@example.com",
+        subject: "Regression: non-ok must warn",
+        body: "Body",
+        sendNow: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(200); // draft still saved
+    const warnCalls = warnSpy.mock.calls.map((c) => JSON.stringify(c));
+    expect(warnCalls.some((c) => c.includes("Resend email delivery failed"))).toBe(true);
+
+    fetchSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- The Compose / `/v1/connectors/email/draft/send` Resend fallback hardcoded `from: Larry <noreply@larry.app>` — an unverified domain Resend rejects with 403.
- The surrounding `fetch` never checked `res.ok`, so the rejection was swallowed and the DB row / API response reported success. Every manual Compose on production looked fine but delivered nothing.
- Fix uses `fastify.config.RESEND_FROM_LARRY` (the verified `larry@larry-pm.com` sender already used by `lib/email.ts`) and throws on non-ok responses so the existing catch logs the warning.
- Adds two regression tests against the `sendNow: true` Resend path — red-green verified (both fail pre-fix, pass post-fix).

## Test plan
- [x] `npm run api:test` → 431/431 passing (60 files)
- [x] Red-green: reverted fix, new tests fail; restored fix, they pass
- [x] `tsc --noEmit` on `apps/api` — same 38 pre-existing errors (unchanged by this diff)
- [x] Production reproduction: direct Resend curl with `from: larry.app` → 403 restricted; `from: larry-pm.com` → 200 delivered (email id `23ccb362-f47d-41be-a312-e72c0d612fef` landed in `oreillferg@gmail.com`)
- [ ] Watch Railway Api deploy after merge
- [ ] Post-deploy: repeat the Compose→Send flow on larry-pm.com and confirm the email arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)