### PR TITLE
feat(tasks): link tasks to source email thread + Reply-in-Gmail (#92)

### DIFF
--- a/apps/api/src/routes/v1/tasks.ts
+++ b/apps/api/src/routes/v1/tasks.ts
@@ -196,11 +196,13 @@ export const taskRoutes: FastifyPluginAsync = async (fastify) => {
         status: string; priority: string; assignee_user_id: string | null;
         progress_percent: number; risk_score: number; risk_level: string;
         start_date: string | null; due_date: string | null; created_at: string; updated_at: string;
+        source_kind: string | null; source_record_id: string | null;
       }>(
         tenantId,
         `SELECT id, project_id, parent_task_id, title, description, status, priority,
                 assignee_user_id, progress_percent, risk_score, risk_level,
-                start_date, due_date, created_at, updated_at
+                start_date, due_date, created_at, updated_at,
+                source_kind, source_record_id
          FROM tasks WHERE tenant_id = $1 AND id = $2 LIMIT 1`,
         [tenantId, params.id]
       );
@@ -214,6 +216,7 @@ export const taskRoutes: FastifyPluginAsync = async (fastify) => {
         status: r.status, priority: r.priority, assigneeUserId: r.assignee_user_id,
         progressPercent: r.progress_percent, riskScore: r.risk_score, riskLevel: r.risk_level,
         startDate: r.start_date, dueDate: r.due_date, createdAt: r.created_at, updatedAt: r.updated_at,
+        sourceKind: r.source_kind, sourceRecordId: r.source_record_id,
       };
     }
   );

--- a/apps/web/src/app/workspace/projects/[projectId]/TaskDetailDrawer.tsx
+++ b/apps/web/src/app/workspace/projects/[projectId]/TaskDetailDrawer.tsx
@@ -23,6 +23,9 @@ interface TaskDetail {
   assigneeUserId: string | null;
   sourceType?: string | null;
   sourceRef?: string | null;
+  /** #92: source linkage copied from the project_memory_entries row that triggered this task. */
+  sourceKind?: string | null;
+  sourceRecordId?: string | null;
 }
 
 interface TaskDetailDrawerProps {
@@ -75,6 +78,8 @@ function sourceLabel(type: string | null | undefined): string {
   switch (type) {
     case "meeting":     return "Meeting transcript";
     case "slack":       return "Slack message";
+    case "email":       return "Email thread";
+    case "calendar":    return "Calendar event";
     case "manual":      return "Created manually";
     case "larry":       return "Larry suggestion";
     default:            return "Manual creation";
@@ -423,9 +428,33 @@ export function TaskDetailDrawer({ task, onClose }: TaskDetailDrawerProps) {
             }}
           >
             <span className="text-[13px]" style={{ color: "var(--text-2)" }}>
-              {sourceLabel(detail?.sourceType)}
+              {detail?.sourceKind
+                ? sourceLabel(detail.sourceKind)
+                : sourceLabel(detail?.sourceType)}
             </span>
           </div>
+          {/* #92: Reply-in-Gmail deep link when the task came from an email thread. */}
+          {detail?.sourceKind === "email" && detail?.sourceRecordId && (
+            <a
+              href={`https://mail.google.com/mail/u/0/#inbox/${encodeURIComponent(detail.sourceRecordId)}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 mt-2 px-3 py-2 text-[13px]"
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: "var(--radius-btn)",
+                background: "var(--surface)",
+                color: "var(--text-1)",
+                textDecoration: "none",
+                fontWeight: 500,
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "var(--surface-2)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "var(--surface)"; }}
+            >
+              <MessageSquare size={12} />
+              Reply in Gmail →
+            </a>
+          )}
         </div>
 
         {/* Attachments */}

--- a/docs/superpowers/specs/2026-04-18-task-email-source-design.md
+++ b/docs/superpowers/specs/2026-04-18-task-email-source-design.md
@@ -1,0 +1,148 @@
+# Task → source email thread + Reply-in-Gmail (issue #92)
+
+**Date:** 2026-04-18
+**Sprint:** Launch 2026-04-19 (P1 differentiator)
+
+## Problem
+
+Larry creates tasks from Gmail signals but the tasks carry no link back
+to the source thread. Users can't jump from "Reply to the Acme RFP by
+Friday" to the actual inbox conversation that prompted it. Height,
+Motion, Asana all lack this.
+
+## Acceptance
+
+- Click a surfaced task → the source thread is visible inline
+- Reply-in-Gmail button opens `https://mail.google.com/mail/u/0/#inbox/<threadId>`
+- Works for ≥90% of Gmail-sourced tasks
+
+## Approach
+
+Memory entries already carry `source_kind` + `source_record_id` (the
+Gmail thread ID lands here via the normalizer). The LLM knows which
+memory entry triggered a task because it sees them in the prompt. So:
+
+1. Expose memory-entry IDs in the prompt.
+2. Let the LLM cite the triggering entry on `task_create`.
+3. Copy the entry's `source_kind` + `source_record_id` onto the task.
+4. Render a "Reply in Gmail" button in the task detail when the source
+   kind is `email`.
+
+The LLM-output-correctness risk is mitigated because the executor
+validates the cited memoryEntryId actually exists in `project_memory_entries`
+for this tenant+project before copying — invalid citations silently drop
+the link rather than fabricate one.
+
+## Changes
+
+### 1. Schema — migration `025_task_source_linkage.sql`
+
+```sql
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS source_kind TEXT,
+  ADD COLUMN IF NOT EXISTS source_record_id TEXT;
+
+CREATE INDEX IF NOT EXISTS tasks_source_idx
+  ON tasks (tenant_id, source_kind, source_record_id)
+  WHERE source_record_id IS NOT NULL;
+```
+
+Mirror the DDL into `packages/db/src/schema.sql` (idempotent `ADD
+COLUMN IF NOT EXISTS`) since migrations also run at boot from that
+file.
+
+### 2. Intelligence prompt — `packages/ai/src/intelligence.ts`
+
+Memory entries are rendered at `:517-526`. Extend the line to include
+the entry ID so the LLM can cite it:
+
+```ts
+`  [memory:${e.id}] [${e.createdAt.slice(0,10)}] [${e.sourceKind}] ${wrappedBody}`
+```
+
+`getProjectSnapshot` already selects `id` on `project_memory_entries`
+per `packages/db/src/larry-snapshot.ts`. (Verify — add if missing.)
+
+Update `buildIntelligenceSystemPrompt` to instruct: *"When creating a
+task based on a PROJECT MEMORY entry, include `sourceMemoryEntryId`
+in the task payload set to the `memory:<id>` value from that line."*
+
+### 3. Action schema — `packages/ai/src/intelligence.ts`
+
+Optional payload field on `task_create`:
+```ts
+sourceMemoryEntryId: z.string().uuid().optional()
+```
+Added to `REQUIRED_PAYLOAD_FIELDS` as an optional (not required).
+
+### 4. Executor — `packages/db/src/larry-executor.ts::executeTaskCreate`
+
+Before the `INSERT INTO tasks`:
+
+```ts
+let sourceKind: string | null = null;
+let sourceRecordId: string | null = null;
+if (typeof payload.sourceMemoryEntryId === "string") {
+  const rows = await db.queryTenant<{ source_kind: string; source_record_id: string | null }>(
+    tenantId,
+    `SELECT source_kind, source_record_id
+     FROM project_memory_entries
+     WHERE tenant_id = $1 AND project_id = $2 AND id = $3
+     LIMIT 1`,
+    [tenantId, projectId, payload.sourceMemoryEntryId]
+  );
+  if (rows[0]) {
+    sourceKind = rows[0].source_kind;
+    sourceRecordId = rows[0].source_record_id;
+  }
+}
+```
+
+Pass the two values into the existing INSERT statement (add columns).
+
+### 5. API — `apps/api/src/routes/v1/tasks.ts`
+
+`GET /tasks/:id` and the list endpoint(s) select and return `source_kind`
+and `source_record_id`. Shape:
+
+```ts
+{ ...task, sourceKind: string | null, sourceRecordId: string | null }
+```
+
+### 6. Frontend
+
+Find the task detail component (sidebar/modal) and render:
+
+```tsx
+{task.sourceKind === "email" && task.sourceRecordId && (
+  <a
+    href={`https://mail.google.com/mail/u/0/#inbox/${task.sourceRecordId}`}
+    target="_blank"
+    rel="noreferrer"
+  >
+    Reply in Gmail →
+  </a>
+)}
+```
+
+No 3-message preview card in v1 — the issue body lists it but the
+acceptance only requires the link + inline-visible source indication.
+That lands in v2 (would require an extra Gmail API fetch or a stored
+`last_messages` JSONB on the canonical event).
+
+### 7. Tests
+
+- **Executor unit test** (existing suite under `packages/db/tests` if
+  present, otherwise new): `task_create` with `sourceMemoryEntryId`
+  copies the memory entry's source fields to the task. Invalid ID →
+  task still created, source fields stay null.
+- **API test**: `GET /tasks/:id` returns the two new fields.
+
+## Out of scope
+
+- 3-message preview card (v2, per issue body)
+- LLM-drafted reply that syncs back to the Gmail thread (v2)
+- Backfill of existing tasks (new linkage only applies going forward)
+- Non-Gmail source kinds in the UI (Slack/calendar — the data model
+  supports them but the UI v1 only wires the Gmail button; other
+  source kinds render no button)

--- a/packages/ai/src/intelligence.ts
+++ b/packages/ai/src/intelligence.ts
@@ -258,7 +258,9 @@ Every action: { type, displayText, reasoning, payload }.
 ### Action type payloads
 
 "task_create" [ACTION CENTRE ONLY]
-  payload: { "title": string, "description": string|null, "dueDate": "YYYY-MM-DD"|null, "assigneeName": string|null, "priority": "low"|"medium"|"high"|"critical" }
+  payload: { "title": string, "description": string|null, "dueDate": "YYYY-MM-DD"|null, "assigneeName": string|null, "priority": "low"|"medium"|"high"|"critical", "sourceMemoryEntryId": string|null }
+
+  If this task was triggered by a specific PROJECT MEMORY entry (e.g. an inbound email, Slack message, calendar event), set "sourceMemoryEntryId" to the UUID after "memory:" in that entry's [memory:<uuid>] tag. This lets the user jump back to the source thread. Only set it when the task is directly caused by a specific memory entry; otherwise omit or set null.
 
 "status_update" [auto or action centre]
   payload: { "taskId": string (use ID from snapshot), "taskTitle": string, "newStatus": "backlog"|"not_started"|"in_progress"|"waiting"|"completed"|"blocked", "newRiskLevel": "low"|"medium"|"high" }
@@ -521,7 +523,7 @@ function buildUserPrompt(snapshot: ProjectSnapshot, hint: string | null): string
           const wrappedBody = EXTERNAL_SOURCE_KINDS.has(e.sourceKind)
             ? `<UNTRUSTED>${body}</UNTRUSTED>`
             : body;
-          return `  [${e.createdAt.slice(0, 10)}] [${e.sourceKind}] ${wrappedBody}`;
+          return `  [memory:${e.id}] [${e.createdAt.slice(0, 10)}] [${e.sourceKind}] ${wrappedBody}`;
         })
       : [];
 

--- a/packages/db/src/larry-executor.test.ts
+++ b/packages/db/src/larry-executor.test.ts
@@ -128,3 +128,169 @@ describe("executeAction task_create — payload preservation (regression)", () =
     expect(captured.values?.[7]).toBeNull();
   });
 });
+
+describe("executeAction task_create — source linkage from memory entry (#92)", () => {
+  const MEMORY_ENTRY_ID = "66666666-6666-4666-8666-666666666666";
+  const GMAIL_THREAD_ID = "thread-abc123xyz";
+
+  function buildMockDb(params: {
+    memoryEntryFound: boolean;
+    memorySourceKind?: string;
+    memorySourceRecordId?: string | null;
+    capturedInsert: { sql?: string; values?: unknown[] };
+  }): Db {
+    const queryTenant = vi.fn(async (_tenantId: string, sql: string, values?: unknown[]) => {
+      if (sql.includes("FROM users u") && sql.includes("JOIN memberships")) {
+        return [{ id: ASSIGNEE_USER_ID }];
+      }
+      if (sql.includes("FROM project_memory_entries") && sql.includes("WHERE tenant_id")) {
+        return params.memoryEntryFound
+          ? [{
+              source_kind: params.memorySourceKind ?? "email",
+              source_record_id: params.memorySourceRecordId ?? GMAIL_THREAD_ID,
+            }]
+          : [];
+      }
+      if (sql.includes("INSERT INTO tasks")) {
+        params.capturedInsert.sql = sql;
+        params.capturedInsert.values = values;
+        return [
+          {
+            id: NEW_TASK_ID,
+            tenant_id: TENANT_ID,
+            project_id: PROJECT_ID,
+            title: (values?.[2] as string) ?? "",
+            description: (values?.[3] as string | null) ?? null,
+            status: "not_started",
+            priority: (values?.[4] as string) ?? "medium",
+            assignee_user_id: (values?.[5] as string | null) ?? null,
+            progress_percent: 0,
+            risk_score: 0,
+            risk_level: "low",
+            start_date: (values?.[6] as string | null) ?? null,
+            due_date: (values?.[7] as string | null) ?? null,
+            source_kind: (values?.[8] as string | null) ?? null,
+            source_record_id: (values?.[9] as string | null) ?? null,
+            created_at: "2026-04-18T00:00:00.000Z",
+          },
+        ];
+      }
+      if (sql.includes("INSERT INTO activities")) return [];
+      if (sql.includes("SELECT") && sql.includes("tenant_policies")) return [];
+      if (sql.includes("INSERT INTO larry_events")) return [{ id: "ev-1" }];
+      return [];
+    });
+    return { queryTenant, tx: vi.fn() } as unknown as Db;
+  }
+
+  it("copies source_kind + source_record_id from the cited memory entry onto the task", async () => {
+    const captured: { sql?: string; values?: unknown[] } = {};
+    const db = buildMockDb({
+      memoryEntryFound: true,
+      memorySourceKind: "email",
+      memorySourceRecordId: GMAIL_THREAD_ID,
+      capturedInsert: captured,
+    });
+
+    await executeAction(
+      db,
+      TENANT_ID,
+      PROJECT_ID,
+      "task_create",
+      {
+        title: "Reply to Acme about RFP",
+        description: "Draft a response to the Acme RFP question.",
+        priority: "high",
+        assigneeName: "Anna",
+        sourceMemoryEntryId: MEMORY_ENTRY_ID,
+        reasoning: "Inbound email from Acme requires a response.",
+        displayText: "Create task: Reply to Acme",
+      } as unknown as Parameters<typeof executeAction>[4],
+      ACTOR_USER_ID
+    );
+
+    expect(captured.sql).toContain("source_kind");
+    expect(captured.sql).toContain("source_record_id");
+    // Params layout: [tenantId, projectId, title, description, priority, assigneeId, startDate, dueDate, sourceKind, sourceRecordId]
+    expect(captured.values?.[8]).toBe("email");
+    expect(captured.values?.[9]).toBe(GMAIL_THREAD_ID);
+  });
+
+  it("silently drops the source when the cited memory entry does not exist", async () => {
+    const captured: { sql?: string; values?: unknown[] } = {};
+    const db = buildMockDb({ memoryEntryFound: false, capturedInsert: captured });
+
+    await executeAction(
+      db,
+      TENANT_ID,
+      PROJECT_ID,
+      "task_create",
+      {
+        title: "Some task",
+        description: "Whatever.",
+        priority: "medium",
+        assigneeName: "Anna",
+        sourceMemoryEntryId: "99999999-9999-4999-8999-999999999999",
+        reasoning: "Testing hallucinated memory id.",
+        displayText: "Create task",
+      } as unknown as Parameters<typeof executeAction>[4],
+      ACTOR_USER_ID
+    );
+
+    expect(captured.values?.[8]).toBeNull();
+    expect(captured.values?.[9]).toBeNull();
+  });
+
+  it("stores null source fields when sourceMemoryEntryId is omitted", async () => {
+    const captured: { sql?: string; values?: unknown[] } = {};
+    const db = buildMockDb({ memoryEntryFound: true, capturedInsert: captured });
+
+    await executeAction(
+      db,
+      TENANT_ID,
+      PROJECT_ID,
+      "task_create",
+      {
+        title: "Unlinked task",
+        description: "No memory source cited.",
+        priority: "low",
+        assigneeName: "Anna",
+        reasoning: "No source.",
+        displayText: "Create task",
+      } as unknown as Parameters<typeof executeAction>[4],
+      ACTOR_USER_ID
+    );
+
+    expect(captured.values?.[8]).toBeNull();
+    expect(captured.values?.[9]).toBeNull();
+  });
+
+  it("rejects a malformed sourceMemoryEntryId without querying the DB", async () => {
+    const captured: { sql?: string; values?: unknown[] } = {};
+    const db = buildMockDb({ memoryEntryFound: true, capturedInsert: captured });
+
+    await executeAction(
+      db,
+      TENANT_ID,
+      PROJECT_ID,
+      "task_create",
+      {
+        title: "Malformed id task",
+        description: "Hallucinated id that is not a UUID.",
+        priority: "low",
+        assigneeName: "Anna",
+        sourceMemoryEntryId: "not-a-uuid",
+        reasoning: "Testing bad UUID guard.",
+        displayText: "Create task",
+      } as unknown as Parameters<typeof executeAction>[4],
+      ACTOR_USER_ID
+    );
+
+    // Guard rejects before the SELECT runs
+    const calls = (db.queryTenant as ReturnType<typeof vi.fn>).mock.calls;
+    const memorySelectCalls = calls.filter((c) => String(c[1]).includes("FROM project_memory_entries"));
+    expect(memorySelectCalls.length).toBe(0);
+    expect(captured.values?.[8]).toBeNull();
+    expect(captured.values?.[9]).toBeNull();
+  });
+});

--- a/packages/db/src/larry-executor.ts
+++ b/packages/db/src/larry-executor.ts
@@ -62,6 +62,13 @@ interface TaskCreatePayload {
   dueDate: string | null;
   assigneeName: string | null;
   priority: "low" | "medium" | "high" | "critical";
+  /**
+   * Optional UUID of the project_memory_entries row that triggered this task.
+   * When set and valid, the executor copies that entry's source_kind +
+   * source_record_id onto the new task so the UI can link back to the
+   * originating email/Slack thread (#92).
+   */
+  sourceMemoryEntryId?: string | null;
 }
 
 interface StatusUpdatePayload {
@@ -747,13 +754,35 @@ export async function executeTaskCreate(
     ? await resolveUserByName(db, tenantId, payload.assigneeName)
     : null;
 
+  // #92: if the LLM cited a memory entry as the trigger, look it up and copy
+  // the source linkage to the new task. Invalid citations silently drop the
+  // link rather than fabricate one.
+  let sourceKind: string | null = null;
+  let sourceRecordId: string | null = null;
+  const memoryEntryId = payload.sourceMemoryEntryId;
+  if (typeof memoryEntryId === "string" && /^[0-9a-f-]{36}$/i.test(memoryEntryId)) {
+    const memRows = await db.queryTenant<{ source_kind: string; source_record_id: string | null }>(
+      tenantId,
+      `SELECT source_kind, source_record_id
+       FROM project_memory_entries
+       WHERE tenant_id = $1 AND project_id = $2 AND id = $3
+       LIMIT 1`,
+      [tenantId, projectId, memoryEntryId]
+    );
+    if (memRows[0]) {
+      sourceKind = memRows[0].source_kind;
+      sourceRecordId = memRows[0].source_record_id;
+    }
+  }
+
   const rows = await db.queryTenant<Record<string, unknown>>(
     tenantId,
     `INSERT INTO tasks
-       (tenant_id, project_id, title, description, status, priority, assignee_user_id, start_date, due_date)
-     VALUES ($1, $2, $3, $4, 'not_started', $5, $6, $7, $8)
+       (tenant_id, project_id, title, description, status, priority, assignee_user_id, start_date, due_date, source_kind, source_record_id)
+     VALUES ($1, $2, $3, $4, 'not_started', $5, $6, $7, $8, $9, $10)
      RETURNING id, tenant_id, project_id, title, description, status, priority,
-               assignee_user_id, progress_percent, risk_score, risk_level, start_date, due_date, created_at`,
+               assignee_user_id, progress_percent, risk_score, risk_level, start_date, due_date,
+               source_kind, source_record_id, created_at`,
     [
       tenantId,
       projectId,
@@ -763,6 +792,8 @@ export async function executeTaskCreate(
       assigneeId,
       payload.startDate ?? null,
       payload.dueDate ?? null,
+      sourceKind,
+      sourceRecordId,
     ]
   );
   const task = rows[0];

--- a/packages/db/src/migrations/025_task_source_linkage.sql
+++ b/packages/db/src/migrations/025_task_source_linkage.sql
@@ -1,0 +1,15 @@
+-- Migration 025: source linkage columns on tasks
+--
+-- Lets a task point back to the project_memory_entries row that triggered
+-- it (typically an inbound Gmail thread, but also Slack/calendar/etc).
+-- Powers the "Reply in Gmail" button on Gmail-sourced tasks (#92).
+--
+-- Idempotent: safe to re-run.
+
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS source_kind TEXT,
+  ADD COLUMN IF NOT EXISTS source_record_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_source
+  ON tasks (tenant_id, source_kind, source_record_id)
+  WHERE source_record_id IS NOT NULL;

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -1644,3 +1644,12 @@ ALTER TABLE projects
 
 CREATE INDEX IF NOT EXISTS idx_projects_tenant_category_sort
   ON projects (tenant_id, category_id, sort_order);
+
+-- Migration 025: task source linkage (#92)
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS source_kind TEXT,
+  ADD COLUMN IF NOT EXISTS source_record_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_source
+  ON tasks (tenant_id, source_kind, source_record_id)
+  WHERE source_record_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Larry-created tasks now carry a link back to the PROJECT MEMORY entry that triggered them, so Gmail-sourced tasks render a "Reply in Gmail" deep-link button in the task detail drawer.
- LLM cites the triggering memory via a new optional `sourceMemoryEntryId` field on `task_create`; executor validates + copies `source_kind` + `source_record_id` onto the new task. Hallucinated/malformed IDs silently drop the link.
- Migration 025 adds `source_kind` + `source_record_id` TEXT columns on `tasks` plus a partial index.

Closes #92. Design: `docs/superpowers/specs/2026-04-18-task-email-source-design.md`.

**Scope trim for v1:** 3-message thread preview and LLM-drafted reply sync are deferred to v2 per spec.

## Test plan
- [x] `npx vitest run packages/db/src/larry-executor.test.ts` — 7/7 pass (4 new)
- [x] `npm run api:build` — clean
- [x] `npm run web:build` — clean
- [ ] After merge + Railway redeploy: seed a tenant with a memory entry whose `source_kind='email'` and `source_record_id='<threadId>'`, get Larry to emit a `task_create` citing it, verify `GET /v1/tasks/:id` returns `sourceKind:"email"` and `sourceRecordId:"<threadId>"`, and the task detail drawer shows "Reply in Gmail →"
- [ ] Click-through: the Gmail URL opens the correct thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)