### PR TITLE
Gantt v4 Slice 2A — subcategories, project-scoped categories, inline colour/rename

### DIFF
--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -7,13 +7,17 @@ import { GanttContainer } from "@/components/workspace/gantt/GanttContainer";
 import { AddNodeModal } from "@/components/workspace/gantt/AddNodeModal";
 import { CategoryManagerPanel } from "@/components/workspace/gantt/CategoryManagerPanel";
 import { GanttEmptyState } from "@/components/workspace/gantt/GanttEmptyState";
+import { CategoryColourPopover } from "@/components/workspace/gantt/CategoryColourPopover";
 import type { CategoryOption } from "@/components/workspace/gantt/GanttContextMenu";
 
 type AddCtx =
   | { mode: "category" }
+  | { mode: "subcategory"; parentCategoryId: string }
   | { mode: "project"; parentCategoryId?: string }
   | { mode: "task"; parentProjectId: string }
   | { mode: "subtask"; parentProjectId: string; parentTaskId: string };
+
+type ColourPopover = { categoryId: string; currentColour: string | null; x: number; y: number };
 
 export function PortfolioGanttClient() {
   const [data, setData] = useState<PortfolioTimelineResponse | null>(null);
@@ -21,6 +25,7 @@ export function PortfolioGanttClient() {
   const [addCtx, setAddCtx] = useState<AddCtx | null>(null);
   const [managerOpen, setManagerOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [colourPopover, setColourPopover] = useState<ColourPopover | null>(null);
 
   const fetchTimeline = useCallback(async () => {
     try {
@@ -273,10 +278,67 @@ export function PortfolioGanttClient() {
       return;
     }
 
-    if ((action === "rename" || action === "changeColour") && rowKind === "category") {
-      // Open the Categories drawer — user finishes the edit there.
-      setManagerOpen(true);
+    if (action === "addSubcategory" && rowKind === "category") {
+      const id = rowKey.slice(4);
+      if (id === "uncat") return;
+      setAddCtx({ mode: "subcategory", parentCategoryId: id });
       return;
+    }
+
+    if (action === "changeColour" && rowKind === "category") {
+      const id = rowKey.slice(4);
+      if (id === "uncat") return;
+      const cat = data?.categories.find((c) => c.id === id);
+      setColourPopover({
+        categoryId: id,
+        currentColour: cat?.colour ?? null,
+        x: 0, y: 0,  // centred modal — position not used currently
+      });
+      return;
+    }
+
+    if (action === "rename" && rowKind === "category") {
+      const id = rowKey.slice(4);
+      if (id === "uncat") return;
+      const cat = data?.categories.find((c) => c.id === id);
+      const next = window.prompt("Rename category to:", cat?.name ?? "");
+      if (next === null) return;
+      const trimmed = next.trim();
+      if (!trimmed || trimmed === cat?.name) return;
+      try {
+        const res = await fetch(`/api/workspace/categories/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: trimmed }),
+        });
+        if (!res.ok) {
+          setError(await extractApiError(res, "Couldn't rename this category"));
+          return;
+        }
+        await fetchTimeline();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to rename category");
+      }
+      return;
+    }
+  }
+
+  async function applyCategoryColour(hex: string) {
+    if (!colourPopover) return;
+    try {
+      const res = await fetch(`/api/workspace/categories/${colourPopover.categoryId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ colour: hex }),
+      });
+      if (!res.ok) {
+        setError(await extractApiError(res, "Couldn't change colour"));
+        return;
+      }
+      setColourPopover(null);
+      await fetchTimeline();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to change colour");
     }
   }
 
@@ -349,12 +411,24 @@ export function PortfolioGanttClient() {
 
       {addCtx && (
         <AddNodeModal
-          mode={addCtx.mode}
-          parentCategoryId={addCtx.mode === "project" ? addCtx.parentCategoryId : undefined}
+          mode={addCtx.mode === "subcategory" ? "category" : addCtx.mode}
+          parentCategoryId={
+            addCtx.mode === "project" ? addCtx.parentCategoryId :
+            addCtx.mode === "subcategory" ? addCtx.parentCategoryId :
+            undefined
+          }
           parentProjectId={addCtx.mode === "task" || addCtx.mode === "subtask" ? addCtx.parentProjectId : undefined}
           parentTaskId={addCtx.mode === "subtask" ? addCtx.parentTaskId : undefined}
           onClose={() => setAddCtx(null)}
           onCreated={async () => { await fetchTimeline(); }}
+        />
+      )}
+
+      {colourPopover && (
+        <CategoryColourPopover
+          currentColour={colourPopover.currentColour}
+          onApply={applyCategoryColour}
+          onClose={() => setColourPopover(null)}
         />
       )}
     </div>

--- a/apps/web/src/components/workspace/gantt/AddNodeModal.tsx
+++ b/apps/web/src/components/workspace/gantt/AddNodeModal.tsx
@@ -9,7 +9,8 @@ interface Props {
   mode: Mode;
   parentProjectId?: string;   // for task
   parentTaskId?: string;      // for subtask
-  parentCategoryId?: string;  // for project
+  parentCategoryId?: string;  // for project AND subcategory (category-nested-under-category)
+  scopedProjectId?: string;   // v4 — for category mode: creates a project-scoped category
   onClose: () => void;
   onCreated: () => Promise<void> | void;
 }
@@ -19,7 +20,10 @@ const inputStyle: React.CSSProperties = {
   background: "var(--surface-2)", color: "var(--text-1)", fontSize: 13, outline: "none", boxSizing: "border-box",
 };
 
-export function AddNodeModal({ mode, parentProjectId, parentTaskId, parentCategoryId, onClose, onCreated }: Props) {
+export function AddNodeModal({
+  mode, parentProjectId, parentTaskId, parentCategoryId, scopedProjectId,
+  onClose, onCreated,
+}: Props) {
   const [title, setTitle] = useState("");
   const [colour, setColour] = useState<string>(DEFAULT_SWATCH_HEX);
   const [dueDate, setDueDate] = useState("");
@@ -34,9 +38,15 @@ export function AddNodeModal({ mode, parentProjectId, parentTaskId, parentCatego
     setSaving(true); setErr(null);
     try {
       if (mode === "category") {
+        const payload: Record<string, unknown> = { name: title.trim(), colour };
+        // parentCategoryId → subcategory nested under another category.
+        // scopedProjectId  → category scoped to a specific project.
+        // API enforces single-parent (only one of parentCategoryId / projectId non-null).
+        if (parentCategoryId) payload.parentCategoryId = parentCategoryId;
+        else if (scopedProjectId) payload.projectId = scopedProjectId;
         const res = await fetch("/api/workspace/categories", {
           method: "POST", headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: title.trim(), colour }),
+          body: JSON.stringify(payload),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
       } else if (mode === "project") {
@@ -66,7 +76,18 @@ export function AddNodeModal({ mode, parentProjectId, parentTaskId, parentCatego
     }
   }
 
-  const label = mode === "category" ? "New category" : mode === "project" ? "New project" : mode === "task" ? "New task" : "New subtask";
+  const label =
+    mode === "category"
+      ? (parentCategoryId ? "New subcategory" : scopedProjectId ? "New category in project" : "New category")
+      : mode === "project" ? "New project"
+      : mode === "task" ? "New task"
+      : "New subtask";
+
+  const placeholder =
+    mode === "category"
+      ? (parentCategoryId ? "Subcategory name..." : "Category name...")
+      : mode === "project" ? "Project name..."
+      : "Task title...";
 
   return (
     <div style={{ position: "fixed", inset: 0, zIndex: 50, display: "flex", alignItems: "center", justifyContent: "center" }}>
@@ -83,7 +104,7 @@ export function AddNodeModal({ mode, parentProjectId, parentTaskId, parentCatego
               ref={titleRef} type="text" value={title}
               onChange={(e) => setTitle(e.target.value)}
               onKeyDown={(e) => { if (e.key === "Enter") void handleSave(); if (e.key === "Escape") onClose(); }}
-              placeholder={mode === "category" ? "Category name..." : mode === "project" ? "Project name..." : "Task title..."}
+              placeholder={placeholder}
               style={inputStyle}
             />
           </div>

--- a/apps/web/src/components/workspace/gantt/CategoryColourPopover.tsx
+++ b/apps/web/src/components/workspace/gantt/CategoryColourPopover.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { CategorySwatchPicker, DEFAULT_SWATCH_HEX } from "./CategorySwatchPicker";
+
+interface Props {
+  currentColour: string | null;
+  onApply: (hex: string) => Promise<void> | void;
+  onClose: () => void;
+}
+
+export function CategoryColourPopover({ currentColour, onApply, onClose }: Props) {
+  const [colour, setColour] = useState<string>(currentColour ?? DEFAULT_SWATCH_HEX);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  async function handleApply() {
+    if (saving) return;
+    setSaving(true);
+    try { await onApply(colour); }
+    finally { setSaving(false); }
+  }
+
+  return (
+    <div style={{ position: "fixed", inset: 0, zIndex: 60, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div onClick={onClose} style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.35)", backdropFilter: "blur(2px)" }} />
+      <div style={{ position: "relative", background: "var(--surface, #fff)", border: "1px solid var(--border, #eaeaea)", borderRadius: 12, padding: 20, width: 300, boxShadow: "0 8px 32px rgba(0,0,0,0.16)" }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+          <h3 style={{ fontSize: 14, fontWeight: 700, margin: 0, color: "var(--text-1)" }}>Category colour</h3>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            style={{ background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: 6, padding: 4, cursor: "pointer", color: "var(--text-muted)" }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+        <CategorySwatchPicker value={colour} onChange={setColour} />
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 18, paddingTop: 12, borderTop: "1px solid var(--border)" }}>
+          <button
+            onClick={onClose}
+            style={{ padding: "8px 14px", fontSize: 13, fontWeight: 500, background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: 8, color: "var(--text-2)", cursor: "pointer" }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleApply()}
+            disabled={saving}
+            style={{ padding: "8px 14px", fontSize: 13, fontWeight: 500, background: "#6c44f6", border: 0, borderRadius: 8, color: "#fff", cursor: "pointer", opacity: saving ? 0.5 : 1 }}
+          >
+            {saving ? "Saving..." : "Apply"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+++ b/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import { Plus } from "lucide-react";
 import type { WorkspaceTimelineTask, WorkspaceTimeline } from "@/app/dashboard/types";
 import type { GanttTask, ProjectCategory, ContextMenuAction, GanttNode } from "./gantt-types";
 import { DEFAULT_CATEGORY_COLOUR } from "./gantt-types";
@@ -16,6 +17,11 @@ interface Props {
 }
 
 type ProjectSummary = { id: string; categoryId: string | null };
+
+type AddCtx =
+  | { mode: "task" }
+  | { mode: "subtask"; parentTaskId: string }
+  | { mode: "category" };
 
 function toGanttTask(t: WorkspaceTimelineTask): GanttTask {
   return {
@@ -42,7 +48,7 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
     [projectId, projectName, ganttTasks],
   );
 
-  const [addCtx, setAddCtx] = useState<{ mode: "task" | "subtask"; parentTaskId?: string } | null>(null);
+  const [addCtx, setAddCtx] = useState<AddCtx | null>(null);
   const [categoryColour, setCategoryColour] = useState<string>(DEFAULT_CATEGORY_COLOUR);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -113,9 +119,8 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
     }
   }
 
-  const addLabel =
-    selectedKey?.startsWith("task:") ? "+ Subtask" :
-    "+ Task";
+  // Label text only — GanttToolbar provides the leading <Plus /> icon.
+  const addLabel = selectedKey?.startsWith("task:") ? "Subtask" : "Task";
 
   return (
     <>
@@ -154,12 +159,40 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
         rootCategoryColor={categoryColour}
         onContextMenuAction={handleContextMenuAction}
         categoriesForSubmenu={[]}
+        outlineHeaderActions={
+          <button
+            type="button"
+            onClick={() => setAddCtx({ mode: "category" })}
+            aria-label="New category in this project"
+            title="New category in this project"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              height: 24,
+              padding: "0 8px",
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              background: "var(--brand)",
+              color: "#fff",
+              border: 0,
+              borderRadius: 6,
+              cursor: "pointer",
+            }}
+          >
+            <Plus size={12} strokeWidth={2.5} />
+            Category
+          </button>
+        }
       />
       {addCtx && (
         <AddNodeModal
-          mode={addCtx.mode}
-          parentProjectId={projectId}
-          parentTaskId={addCtx.parentTaskId}
+          mode={addCtx.mode === "subtask" ? "subtask" : addCtx.mode === "task" ? "task" : "category"}
+          parentProjectId={addCtx.mode === "task" || addCtx.mode === "subtask" ? projectId : undefined}
+          parentTaskId={addCtx.mode === "subtask" ? addCtx.parentTaskId : undefined}
+          scopedProjectId={addCtx.mode === "category" ? projectId : undefined}
           onClose={() => setAddCtx(null)}
           onCreated={async () => { await refresh(); }}
         />

--- a/apps/web/src/components/workspace/gantt/gantt-types.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-types.ts
@@ -32,6 +32,7 @@ export type ContextMenuAction =
   | "moveToCategory"   // submenu → category id payload
   | "removeFromTimeline"
   | "addChild"
+  | "addSubcategory"   // v4 — only on category rows; creates category with parentCategoryId
   | "rename"
   | "changeColour"
   | "delete";

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -276,10 +276,10 @@ describe("contextMenuItemsFor", () => {
     ]);
   });
 
-  it("category row gets Rename, Change colour, Delete", () => {
+  it("category row gets Add subcategory, Rename, Change colour, Delete", () => {
     const items = contextMenuItemsFor({ rowKind: "category", isUncategorised: false });
     expect(items.map((i) => i.id)).toEqual([
-      "rename", "changeColour", "delete",
+      "addSubcategory", "rename", "changeColour", "delete",
     ]);
   });
 

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -404,9 +404,10 @@ export function contextMenuItemsFor(args: {
       }];
     }
     return [
-      { id: "rename",       label: "Rename" },
-      { id: "changeColour", label: "Change colour" },
-      { id: "delete",       label: "Delete", destructive: true },
+      { id: "addSubcategory", label: "Add subcategory" },
+      { id: "rename",         label: "Rename" },
+      { id: "changeColour",   label: "Change colour" },
+      { id: "delete",         label: "Delete", destructive: true },
     ];
   }
   if (args.rowKind === "project") {


### PR DESCRIPTION
## Summary

Slice 2A of Gantt v4. Uses the Slice 1 API surface (PR #101 + PR #103) — `parentCategoryId` and `projectId` on categories plus the single-parent refinement — to land three user-visible features in the Timeline UI. No backend changes.

| Spec bug | What it does now |
|----------|------------------|
| **#4 Add subcategory** | Right-click any category → **Add subcategory** → `AddNodeModal` opens in subcategory mode, POSTs with `parentCategoryId`. Inline in the existing menu above Rename / Change colour / Delete. |
| **#5 Change colour** | Right-click any category → **Change colour** → `CategoryColourPopover` opens (centred modal, Escape closes) with the current colour pre-selected. Apply PATCHes `/v1/categories/:id` and refetches the timeline. No more detour to the Categories drawer. |
| **Rename (bonus)** | Same menu item now actually renames — `window.prompt` + PATCH — instead of opening the drawer. Small bonus; the plumbing was already there. |
| **#3 Project-scoped category** | Project timeline gets a **+ Category** button in the outline header (same visual as the org timeline's). Opens `AddNodeModal` with `scopedProjectId`, POSTs with `projectId` so the category lives under that project. |
| **#1 Bug re-catch** | `ProjectGanttClient`'s `addLabel` had the same leading "+ " doubling that Slice 1 fixed for `PortfolioGanttClient`. Stripped here too. |

### Implementation notes

- `AddCtx` union in `PortfolioGanttClient` extended with `{ mode: "subcategory"; parentCategoryId }`. The modal always gets `mode="category"` — the `parentCategoryId` / `scopedProjectId` props disambiguate.
- `AddNodeModal` header text adapts: "New category" / "New subcategory" / "New category in project".
- `CategoryColourPopover` is a new ~50-line component — reuses `CategorySwatchPicker` (no duplication of the palette logic), centred modal shell matching `AddNodeModal`.
- Context menu for category rows in `contextMenuItemsFor` now lists: Add subcategory → Rename → Change colour → Delete. Uncategorised sentinel unchanged.

### Test plan

- [x] `apps/web` typecheck clean
- [x] 40 gantt unit tests pass (one expected list updated to include `addSubcategory`)
- [ ] Vercel preview — verify right-click > Add subcategory creates a subcategory under the clicked parent
- [ ] Vercel preview — verify right-click > Change colour swaps the dot + bars cascade
- [ ] Vercel preview — verify project timeline "+ Category" creates a project-scoped category

### Deferred

- **DnD** — the right-click menu is complete for this slice; drag-and-drop for reordering / reparenting still waits for Slice 3 (needs shared state layer).
- **Subtask CRUD in Task Center** (Bug #8) — Slice 2C.
- **Required-dates modal** (Bug #7 frontend half) — Slice 2B.
- **Sync layer / React Query** (Bug #9) — Slice 3. This PR still uses ad-hoc `fetchTimeline()` refresh after each mutation.

Spec: `docs/superpowers/specs/2026-04-18-gantt-v4-subcategories-sync-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)