### PR TITLE
Gantt v4 Slice 3A — TanStack Query for org timeline (read side)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@larry/shared": "file:../../packages/shared",
+    "@tanstack/react-query": "^5.59.20",
     "framer-motion": "^12.35.0",
     "html2canvas-pro": "^2.0.2",
     "ioredis": "^5.8.0",

--- a/apps/web/src/app/workspace/WorkspaceShell.tsx
+++ b/apps/web/src/app/workspace/WorkspaceShell.tsx
@@ -9,6 +9,8 @@ import type { WorkspaceProject } from "@/app/dashboard/types";
 import { MeetingTranscriptModal } from "./MeetingTranscriptModal";
 import { WorkspaceChromeProvider } from "./WorkspaceChromeContext";
 import { WorkspaceTopBar } from "./WorkspaceTopBar";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { getQueryClient } from "@/lib/query-client";
 import { ToastProvider } from "@/components/toast/ToastContext";
 import { ToastContainer } from "@/components/toast/ToastContainer";
 import { triggerBoundedWorkspaceRefresh } from "./refresh";
@@ -146,6 +148,7 @@ export function WorkspaceShell({ children, userEmail, emailVerified, avatarUrl, 
   }, [chatProjectId, startTranscriptProcessing, transcript]);
 
   return (
+    <QueryClientProvider client={getQueryClient()}>
     <ToastProvider>
     <WorkspaceChromeProvider
       value={{
@@ -242,5 +245,6 @@ export function WorkspaceShell({ children, userEmail, emailVerified, avatarUrl, 
     <ToastContainer />
     <GlobalSearch />
     </ToastProvider>
+    </QueryClientProvider>
   );
 }

--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Plus, X } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { PortfolioTimelineResponse, ContextMenuAction, GanttNode } from "@/components/workspace/gantt/gantt-types";
 import { buildPortfolioTree, buildCategoryColorMap, normalizePortfolioStatuses } from "@/components/workspace/gantt/gantt-utils";
 import { GanttContainer } from "@/components/workspace/gantt/GanttContainer";
@@ -9,6 +10,10 @@ import { CategoryManagerPanel } from "@/components/workspace/gantt/CategoryManag
 import { GanttEmptyState } from "@/components/workspace/gantt/GanttEmptyState";
 import { CategoryColourPopover } from "@/components/workspace/gantt/CategoryColourPopover";
 import type { CategoryOption } from "@/components/workspace/gantt/GanttContextMenu";
+
+// v4 Slice 3A — React Query keys for this surface. Mutations invalidate
+// these so every view reading the same data stays in sync across tabs.
+const QK_TIMELINE_ORG = ["timeline", "org"] as const;
 
 type AddCtx =
   | { mode: "category" }
@@ -20,28 +25,43 @@ type AddCtx =
 type ColourPopover = { categoryId: string; currentColour: string | null; x: number; y: number };
 
 export function PortfolioGanttClient() {
-  const [data, setData] = useState<PortfolioTimelineResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const qc = useQueryClient();
   const [addCtx, setAddCtx] = useState<AddCtx | null>(null);
   const [managerOpen, setManagerOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [colourPopover, setColourPopover] = useState<ColourPopover | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
 
-  const fetchTimeline = useCallback(async () => {
-    try {
+  // v4 Slice 3A — the timeline read is now React Query. Mutations invalidate
+  // QK_TIMELINE_ORG to trigger a refetch; the cached payload stays mounted
+  // during refetch so the Gantt never blanks between writes.
+  const { data, error: queryError, isError: isFetchError, refetch } = useQuery({
+    queryKey: QK_TIMELINE_ORG,
+    queryFn: async (): Promise<PortfolioTimelineResponse> => {
       const res = await fetch("/api/workspace/timeline", { cache: "no-store" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setData(await res.json());
-      setError(null);
-    } catch (e) {
-      // Never blank the Gantt on fetch error — surface the message in the
-      // dismissible banner and keep the last good `data` mounted. A transient
-      // 409/5xx no longer wipes the user's view.
-      setError(e instanceof Error ? e.message : "Failed to load");
-    }
-  }, []);
+      return res.json() as Promise<PortfolioTimelineResponse>;
+    },
+  });
 
-  useEffect(() => { void fetchTimeline(); }, [fetchTimeline]);
+  // Merge query-error and mutation-error into a single banner stream.
+  const error =
+    mutationError
+      ?? (isFetchError ? (queryError instanceof Error ? queryError.message : "Failed to load") : null);
+
+  // Fire-and-forget invalidation — used after every mutation. Consumers of
+  // these keys (Task Center, My Tasks, etc.) refetch automatically when they
+  // become active again.
+  const invalidateAll = () => {
+    void qc.invalidateQueries({ queryKey: QK_TIMELINE_ORG });
+    void qc.invalidateQueries({ queryKey: ["tasks"] });
+    void qc.invalidateQueries({ queryKey: ["projects"] });
+  };
+
+  // Keep the legacy callback-name for existing consumers (modal onCreated,
+  // CategoryManagerPanel onChanged). Invalidate + rely on React Query to
+  // refetch, rather than the old per-page `fetchTimeline()` ad-hoc refetch.
+  const fetchTimeline = async () => { invalidateAll(); };
 
   const categoryColorMap = useMemo(
     () => data ? buildCategoryColorMap(data.categories.map((c) => ({ id: c.id, colour: c.colour }))) : undefined,
@@ -59,7 +79,7 @@ export function PortfolioGanttClient() {
   if (!data && error) {
     return (
       <div style={{ padding: 24 }}>
-        <ErrorBanner message={error} onDismiss={() => setError(null)} onRetry={() => void fetchTimeline()} />
+        <ErrorBanner message={error} onDismiss={() => setMutationError(null)} onRetry={() => void refetch()} />
       </div>
     );
   }
@@ -165,7 +185,7 @@ export function PortfolioGanttClient() {
       const projectId = taskProjectLookup.get(taskId);
       if (!projectId) return;
       if (isArchived(projectId)) {
-        setError("That task's project is archived — unarchive it first to move it between categories.");
+        setMutationError("That task's project is archived — unarchive it first to move it between categories.");
         return;
       }
       try {
@@ -175,12 +195,12 @@ export function PortfolioGanttClient() {
           body: JSON.stringify({ categoryId: categoryId ?? null }),
         });
         if (!res.ok) {
-          setError(await extractApiError(res, "Couldn't move this project"));
+          setMutationError(await extractApiError(res, "Couldn't move this project"));
           return;
         }
         await fetchTimeline();
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to move project");
+        setMutationError(e instanceof Error ? e.message : "Failed to move project");
       }
       return;
     }
@@ -188,7 +208,7 @@ export function PortfolioGanttClient() {
     if (action === "moveToCategory" && rowKind === "project") {
       const projectId = rowKey.slice(5);
       if (isArchived(projectId)) {
-        setError("That project is archived — unarchive it first to move it between categories.");
+        setMutationError("That project is archived — unarchive it first to move it between categories.");
         return;
       }
       try {
@@ -198,12 +218,12 @@ export function PortfolioGanttClient() {
           body: JSON.stringify({ categoryId: categoryId ?? null }),
         });
         if (!res.ok) {
-          setError(await extractApiError(res, "Couldn't move this project"));
+          setMutationError(await extractApiError(res, "Couldn't move this project"));
           return;
         }
         await fetchTimeline();
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to move project");
+        setMutationError(e instanceof Error ? e.message : "Failed to move project");
       }
       return;
     }
@@ -212,7 +232,7 @@ export function PortfolioGanttClient() {
       const taskId = rowKey.startsWith("task:") ? rowKey.slice(5) : rowKey.slice(4);
       const projectId = taskProjectLookup.get(taskId);
       if (isArchived(projectId)) {
-        setError("That task's project is archived — unarchive it first to edit task dates.");
+        setMutationError("That task's project is archived — unarchive it first to edit task dates.");
         return;
       }
       try {
@@ -222,12 +242,12 @@ export function PortfolioGanttClient() {
           body: JSON.stringify({ startDate: null, dueDate: null }),
         });
         if (!res.ok) {
-          setError(await extractApiError(res, "Couldn't remove this task from the timeline"));
+          setMutationError(await extractApiError(res, "Couldn't remove this task from the timeline"));
           return;
         }
         await fetchTimeline();
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to remove task from timeline");
+        setMutationError(e instanceof Error ? e.message : "Failed to remove task from timeline");
       }
       return;
     }
@@ -246,7 +266,7 @@ export function PortfolioGanttClient() {
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           await fetchTimeline();
         } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to delete task");
+          setMutationError(e instanceof Error ? e.message : "Failed to delete task");
         }
       }
       if (rowKind === "project") {
@@ -260,7 +280,7 @@ export function PortfolioGanttClient() {
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           await fetchTimeline();
         } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to delete project");
+          setMutationError(e instanceof Error ? e.message : "Failed to delete project");
         }
       }
       if (rowKind === "category") {
@@ -272,7 +292,7 @@ export function PortfolioGanttClient() {
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           await fetchTimeline();
         } catch (e) {
-          setError(e instanceof Error ? e.message : "Failed to delete category");
+          setMutationError(e instanceof Error ? e.message : "Failed to delete category");
         }
       }
       return;
@@ -312,12 +332,12 @@ export function PortfolioGanttClient() {
           body: JSON.stringify({ name: trimmed }),
         });
         if (!res.ok) {
-          setError(await extractApiError(res, "Couldn't rename this category"));
+          setMutationError(await extractApiError(res, "Couldn't rename this category"));
           return;
         }
         await fetchTimeline();
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to rename category");
+        setMutationError(e instanceof Error ? e.message : "Failed to rename category");
       }
       return;
     }
@@ -332,13 +352,13 @@ export function PortfolioGanttClient() {
         body: JSON.stringify({ colour: hex }),
       });
       if (!res.ok) {
-        setError(await extractApiError(res, "Couldn't change colour"));
+        setMutationError(await extractApiError(res, "Couldn't change colour"));
         return;
       }
       setColourPopover(null);
       await fetchTimeline();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to change colour");
+      setMutationError(e instanceof Error ? e.message : "Failed to change colour");
     }
   }
 
@@ -351,7 +371,7 @@ export function PortfolioGanttClient() {
 
       {error && (
         <div style={{ marginBottom: 12 }}>
-          <ErrorBanner message={error} onDismiss={() => setError(null)} onRetry={() => void fetchTimeline()} />
+          <ErrorBanner message={error} onDismiss={() => setMutationError(null)} onRetry={() => void refetch()} />
         </div>
       )}
 

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,34 @@
+"use client";
+
+// Singleton QueryClient for the workspace shell. Wrapped once in
+// WorkspaceShell, every child can use `useQuery` / `useMutation` / `useQueryClient`.
+//
+// Defaults chosen for Larry's ops profile:
+// - staleTime 30s: most views poll-refresh on user action, and 30s is below
+//   the median "I changed something elsewhere" gap. Tighter is noisy.
+// - refetchOnWindowFocus true: Fergus switches between windows constantly;
+//   stale data across tabs is the #9 bug source.
+// - retry 1: prod API hits transient 5xx occasionally; one retry masks them,
+//   more than one delays genuine error surfacing.
+// - mutations do not auto-retry — writes must be explicit.
+
+import { QueryClient } from "@tanstack/react-query";
+
+let _client: QueryClient | null = null;
+
+export function getQueryClient(): QueryClient {
+  if (_client) return _client;
+  _client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        refetchOnWindowFocus: true,
+        retry: 1,
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  });
+  return _client;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -791,6 +791,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@larry/shared": "file:../../packages/shared",
+        "@tanstack/react-query": "^5.59.20",
         "framer-motion": "^12.35.0",
         "html2canvas-pro": "^2.0.2",
         "ioredis": "^5.8.0",
@@ -3522,6 +3523,32 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {


### PR DESCRIPTION
## Summary

First slice of the bug #9 sync-layer work. Introduces **@tanstack/react-query** and migrates the org Timeline read to `useQuery`, so every tab viewing the Timeline refetches on window focus and every mutation in the same session stays in lock-step via `invalidateQueries`. No more stale data between tabs.

### Changes

- **New dep:** `@tanstack/react-query@^5.59.20` (~10kB gz, industry standard)
- **New file:** `apps/web/src/lib/query-client.ts` — singleton QueryClient with deliberately-chosen defaults (staleTime 30s, refetchOnWindowFocus true, retry 1 on queries, retry 0 on mutations)
- **`WorkspaceShell`** wraps its existing `ToastProvider` + chrome in `QueryClientProvider`. Every /workspace/* route has Query available.
- **`PortfolioGanttClient`**: `fetch("/api/workspace/timeline")` → `useQuery(QK_TIMELINE_ORG)`. Every mutation handler now calls `invalidateAll()` (invalidates `["timeline","org"]`, `["tasks"]`, `["projects"]`); the Gantt stays mounted during the background refetch.
- `setError` → `setMutationError`; query-error and mutation-error merged into a single banner stream so the existing `ErrorBanner` continues to work with no UX change.
- "Retry" button now calls `refetch()` explicitly.

### Why this ships first (and what it intentionally doesn't do)

**Ships:** the read-side migration for the org Timeline. That's enough to close the cross-tab-stale-data slice of bug #9 for the most-used view, and it's a small, reviewable diff.

**Doesn't yet:**
- `ProjectGanttClient` still uses the `refresh` prop from `useProjectData`. Works, just not cross-tab. Slice 3B will migrate `useProjectData` to `useQuery`.
- Mutations still fetch-then-invalidate (no `useMutation` optimistic updates yet). Optimistic + rollback comes in 3B — it's what makes DnD feel native without DnD having to own its own state.
- DnD itself — Slice 3C.

### Test plan
- [x] `apps/web` typecheck clean
- [x] 40 gantt unit tests pass
- [ ] Vercel preview: open Timeline in tab A and tab B; create a category in A; focus B → category appears within the next refetch window
- [ ] Move a task to a category; the Gantt does not blank during the refetch
- [ ] Trigger a fetch error (block /api/workspace/timeline) → banner shows; Retry button re-runs the query

Spec: `docs/superpowers/specs/2026-04-18-gantt-v4-subcategories-sync-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)