### PR TITLE
Gantt v4 Slice 3C-2 — nested category rendering in portfolio timeline

### DIFF
--- a/apps/api/src/routes/v1/timeline.ts
+++ b/apps/api/src/routes/v1/timeline.ts
@@ -4,7 +4,14 @@ import type {
   PortfolioTimelineProject, GanttTask,
 } from "@larry/shared";
 
-type CatRow = { id: string; name: string; colour: string | null; sortOrder: number };
+type CatRow = {
+  id: string;
+  name: string;
+  colour: string | null;
+  sortOrder: number;
+  parentCategoryId: string | null;
+  projectId: string | null;
+};
 type ProjRow = {
   id: string; name: string; status: "active" | "archived";
   startDate: string | null; targetDate: string | null; categoryId: string | null;
@@ -16,7 +23,9 @@ export const timelineRoutes: FastifyPluginAsync = async (fastify) => {
 
     const [categoriesRaw, projectsRaw, tasksRaw, depsRaw] = await Promise.all([
       fastify.db.queryTenant<CatRow>(tenantId,
-        `SELECT id, name, colour, sort_order AS "sortOrder"
+        `SELECT id, name, colour, sort_order AS "sortOrder",
+                parent_category_id AS "parentCategoryId",
+                project_id         AS "projectId"
            FROM project_categories WHERE tenant_id = $1
            ORDER BY sort_order ASC, created_at ASC`, [tenantId]),
       fastify.db.queryTenant<ProjRow>(tenantId,
@@ -70,6 +79,8 @@ export const timelineRoutes: FastifyPluginAsync = async (fastify) => {
 
     const categories: PortfolioTimelineCategory[] = categoriesRaw.map(c => ({
       id: c.id, name: c.name, colour: c.colour, sortOrder: c.sortOrder,
+      parentCategoryId: c.parentCategoryId,
+      projectId: c.projectId,
       projects: projectsByCategory.get(c.id) ?? [],
     }));
 

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -59,6 +59,37 @@ describe("buildPortfolioTree", () => {
     expect(t1.children).toHaveLength(1);
     expect((t1.children[0] as Extract<GanttNode, { kind: "subtask" }>).task.id).toBe("t2");
   });
+
+  it("nests subcategories under their parent category (v4)", () => {
+    const resp: PortfolioTimelineResponse = {
+      categories: [
+        { id: "c-parent", name: "Parent", colour: null, sortOrder: 0, parentCategoryId: null, projectId: null, projects: [] },
+        { id: "c-child",  name: "Child",  colour: null, sortOrder: 0, parentCategoryId: "c-parent", projectId: null, projects: [] },
+        { id: "c-peer",   name: "Peer",   colour: null, sortOrder: 1, parentCategoryId: null, projectId: null, projects: [] },
+      ],
+      dependencies: [],
+    };
+    const tree = buildPortfolioTree(resp);
+    const topLevel = (tree as Extract<GanttNode, { kind: "category" }>).children as Array<Extract<GanttNode, { kind: "category" }>>;
+    // Two top-level categories — the child is not here, it's under Parent.
+    expect(topLevel.map((n) => n.id)).toEqual(["c-parent", "c-peer"]);
+    const parent = topLevel.find((n) => n.id === "c-parent")!;
+    expect(parent.children).toHaveLength(1);
+    expect((parent.children[0] as Extract<GanttNode, { kind: "category" }>).id).toBe("c-child");
+  });
+
+  it("skips project-scoped categories (projectId set) from the portfolio tree (v4)", () => {
+    const resp: PortfolioTimelineResponse = {
+      categories: [
+        { id: "c-org",   name: "Org",          colour: null, sortOrder: 0, parentCategoryId: null, projectId: null,    projects: [] },
+        { id: "c-proj",  name: "Project-scoped", colour: null, sortOrder: 0, parentCategoryId: null, projectId: "p1",    projects: [] },
+      ],
+      dependencies: [],
+    };
+    const tree = buildPortfolioTree(resp);
+    const topLevel = (tree as Extract<GanttNode, { kind: "category" }>).children as Array<Extract<GanttNode, { kind: "category" }>>;
+    expect(topLevel.map((n) => n.id)).toEqual(["c-org"]);
+  });
 });
 
 describe("buildProjectTree", () => {

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -39,20 +39,50 @@ export function normalizePortfolioStatuses(data: PortfolioTimelineResponse): Por
   };
 }
 
+// v4 Slice 3C-2 — nested portfolio tree.
+//
+// Categories can now live at three places in the tree:
+//   • Top level (parentCategoryId=null, projectId=null) — "root" categories.
+//   • Under another category (parentCategoryId set) — subcategories, rendered
+//     as indented siblings of the parent's projects.
+//   • Scoped to a project (projectId set) — rendered in the project timeline,
+//     not the portfolio. Skipped from this function's output.
+//
+// Uncategorised (id=null) is a synthetic top-level bucket from the server and
+// never has a parentCategoryId, so it always lands top-level.
 export function buildPortfolioTree(resp: PortfolioTimelineResponse): GanttNode {
-  const categoryChildren: GanttNode[] = resp.categories.map((c) => ({
-    kind: "category",
-    id: c.id,
-    name: c.name,
-    colour: c.colour,
-    children: c.projects.map((p) => ({
+  // Index categories by id (skip project-scoped — not our view) and precompute
+  // each one's child-category list for O(N) tree construction.
+  const orgCategories = resp.categories.filter((c) => !c.projectId);
+  const childrenByParent = new Map<string | null, typeof orgCategories>();
+  for (const c of orgCategories) {
+    const key = c.parentCategoryId ?? null;
+    const list = childrenByParent.get(key) ?? [];
+    list.push(c);
+    childrenByParent.set(key, list);
+  }
+
+  function buildCategoryNode(c: typeof orgCategories[number]): GanttNode {
+    const projectNodes: GanttNode[] = c.projects.map((p) => ({
       kind: "project",
       id: p.id,
       name: p.name,
       status: p.status,
       children: buildTaskForest(p.tasks),
-    })),
-  }));
+    }));
+    const subcategoryNodes: GanttNode[] = (c.id != null ? (childrenByParent.get(c.id) ?? []) : []).map(buildCategoryNode);
+    return {
+      kind: "category",
+      id: c.id,
+      name: c.name,
+      colour: c.colour,
+      // Subcategories render above projects to match Asana/Linear ordering.
+      children: [...subcategoryNodes, ...projectNodes],
+    };
+  }
+
+  const topLevel = childrenByParent.get(null) ?? [];
+  const categoryChildren: GanttNode[] = topLevel.map(buildCategoryNode);
   return { kind: "category", id: "__root__", name: "", colour: null, children: categoryChildren };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -417,6 +417,11 @@ export interface PortfolioTimelineCategory {
   name: string;
   colour: string | null;
   sortOrder: number;
+  // v4 — nesting. parentCategoryId !== null: child of another category.
+  // projectId !== null: scoped to a specific project (rendered in the project
+  // timeline, skipped from the org portfolio view).
+  parentCategoryId?: string | null;
+  projectId?: string | null;
   projects: PortfolioTimelineProject[];
 }
 


### PR DESCRIPTION
## Summary

Closes a visualization gap: users could create subcategories via right-click (Slice 2A) but they rendered as peer categories because the timeline response was flat. This PR threads `parent_category_id` + `project_id` through the timeline response and nests the tree on the client.

**Scope revised from the original 3C-2 plan:** the PR was meant to land `@dnd-kit` wiring, but dragging onto a flat-category outline would produce drop targets that can't visually represent the hierarchy. With this rendering fix the tree is shaped right; `@dnd-kit` now lands cleanly in **3C-3** on top of it.

### Changes

**Backend (`apps/api/src/routes/v1/timeline.ts`)**
- Categories SELECT returns `parent_category_id` and `project_id` on every row
- `CatRow` type + response builder propagate both fields

**Shared types (`packages/shared`)**
- `PortfolioTimelineCategory` gains `parentCategoryId?: string | null` and `projectId?: string | null` (both optional for backward-compat with stored snapshots)

**Frontend (`apps/web`)**
- `buildPortfolioTree` rewritten:
  - Categories with `projectId` set → **skipped** (they belong in the project timeline)
  - Categories with `parentCategoryId` set → become children of their parent's node, rendered **above** projects (Asana / Linear ordering)
  - Top-level categories (both null) stay at the root
  - Uncategorised sentinel (id=null) stays top-level always

### Test plan
- [x] 42 gantt unit tests pass (2 new: nested subcategory placement + project-scoped category skip)
- [x] 2 timeline-portfolio integration tests pass
- [x] Typecheck clean across web + api
- [ ] Vercel preview: right-click a category → Add subcategory → verify the new row appears **indented** under its parent, not as a peer at top-level

Spec: `docs/superpowers/specs/2026-04-18-gantt-v4-subcategories-sync-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)