### PR TITLE
Gantt v4 Slice 3C-3 — @dnd-kit drag-to-reparent for categories

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "playwright test -c playwright.config.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
     "@larry/shared": "file:../../packages/shared",
     "@tanstack/react-query": "^5.59.20",
     "framer-motion": "^12.35.0",

--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -1,7 +1,11 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import { Plus, X } from "lucide-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import {
+  DndContext, PointerSensor, useSensor, useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
 import type { PortfolioTimelineResponse, ContextMenuAction, GanttNode } from "@/components/workspace/gantt/gantt-types";
 import { buildPortfolioTree, buildCategoryColorMap, normalizePortfolioStatuses } from "@/components/workspace/gantt/gantt-utils";
 import { GanttContainer } from "@/components/workspace/gantt/GanttContainer";
@@ -62,6 +66,94 @@ export function PortfolioGanttClient() {
   // CategoryManagerPanel onChanged). Invalidate + rely on React Query to
   // refetch, rather than the old per-page `fetchTimeline()` ad-hoc refetch.
   const fetchTimeline = async () => { invalidateAll(); };
+
+  // v4 Slice 3C-3 — drag-and-drop for category reparenting. Sensors with a
+  // 5px activation distance so ordinary clicks on rows don't accidentally
+  // start a drag.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  // Walk upward from `categoryId` via parentCategoryId. Used to reject a drop
+  // that would make the source a descendant of itself (cycle).
+  const ancestorIds = (categories: PortfolioTimelineResponse["categories"], startId: string): Set<string> => {
+    const byId = new Map(categories.filter((c) => c.id != null).map((c) => [c.id as string, c]));
+    const out = new Set<string>();
+    let cursor: string | null = startId;
+    while (cursor && !out.has(cursor)) {
+      out.add(cursor);
+      const row = byId.get(cursor);
+      cursor = row?.parentCategoryId ?? null;
+    }
+    return out;
+  };
+
+  const moveCategoryMutation = useMutation({
+    mutationFn: async (vars: { id: string; parentCategoryId: string | null; sortOrder: number }) => {
+      const res = await fetch(`/api/workspace/categories/${vars.id}/move`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          parentCategoryId: vars.parentCategoryId,
+          projectId: null,
+          sortOrder: vars.sortOrder,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const msg = (body as { message?: string; error?: string }).message
+          ?? (body as { message?: string; error?: string }).error
+          ?? `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
+      return res.json();
+    },
+    onMutate: async (vars) => {
+      await qc.cancelQueries({ queryKey: QK_TIMELINE_ORG });
+      const previous = qc.getQueryData<PortfolioTimelineResponse>(QK_TIMELINE_ORG);
+      // Optimistic flat-array mutation: flip parentCategoryId on the source
+      // row. buildPortfolioTree rebuilds the nested tree from this flat
+      // array every render, so the outline re-renders immediately.
+      qc.setQueryData<PortfolioTimelineResponse>(QK_TIMELINE_ORG, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          categories: old.categories.map((c) =>
+            c.id === vars.id
+              ? { ...c, parentCategoryId: vars.parentCategoryId, projectId: null }
+              : c,
+          ),
+        };
+      });
+      return { previous };
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData(QK_TIMELINE_ORG, ctx.previous);
+      setMutationError(err instanceof Error ? err.message : "Couldn't move category");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: QK_TIMELINE_ORG });
+    },
+  });
+
+  function handleDragEnd(e: DragEndEvent) {
+    if (!e.over || !data) return;
+    const sourceKey = String(e.active.id);
+    const targetKey = String(e.over.id);
+    if (sourceKey === targetKey) return;
+    // Only category→category drops are wired in this slice.
+    if (!sourceKey.startsWith("dnd-cat:") || !targetKey.startsWith("dnd-cat:")) return;
+    const sourceId = sourceKey.slice("dnd-cat:".length);
+    const targetId = targetKey.slice("dnd-cat:".length);
+    if (sourceId === "uncat" || targetId === "uncat") return;  // synthetic bucket is not a valid drag/drop peer
+    // Cycle guard: the target cannot be a descendant of the source.
+    const targetAncestors = ancestorIds(data.categories, targetId);
+    if (targetAncestors.has(sourceId)) {
+      setMutationError("Can't move a category under its own descendant.");
+      return;
+    }
+    moveCategoryMutation.mutate({ id: sourceId, parentCategoryId: targetId, sortOrder: 0 });
+  }
 
   const categoryColorMap = useMemo(
     () => data ? buildCategoryColorMap(data.categories.map((c) => ({ id: c.id, colour: c.colour }))) : undefined,
@@ -381,6 +473,7 @@ export function PortfolioGanttClient() {
           onCreate={() => setAddCtx({ mode: "category" })}
         />
       ) : (
+        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
         <GanttContainer
           root={root}
           defaultZoom="month"
@@ -420,6 +513,7 @@ export function PortfolioGanttClient() {
             </button>
           }
         />
+        </DndContext>
       )}
 
       {managerOpen && (

--- a/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
@@ -1,5 +1,7 @@
 "use client";
+import { useMemo } from "react";
 import { ChevronRight } from "lucide-react";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
 import type { FlatRow } from "./gantt-utils";
 import { CategoryDot, type CategoryDotTier } from "./CategoryDot";
 
@@ -54,6 +56,13 @@ function labelFor(n: NodeRow["node"]): string {
   return n.task.title;
 }
 
+// v4 Slice 3C-3 — a category row is draggable if it's a real org-level
+// category (not the synthetic Uncategorised bucket, not a null id).
+// Project / task / subtask rows are not drag-enabled in this slice.
+function isDraggableCategory(n: NodeRow["node"]): n is Extract<NodeRow["node"], { kind: "category" }> {
+  return n.kind === "category" && n.id !== null && n.id !== "uncat" && n.id !== "__root__";
+}
+
 export function GanttOutlineRow({
   row, expanded, selected, hovered, onToggle, onSelect, onContextMenu, onHover,
 }: Props) {
@@ -64,19 +73,46 @@ export function GanttOutlineRow({
   const isCategory = n.kind === "category";
   const isUncategorised = isCategory && (n.id === null || n.id === "uncat");
 
-  const background = selected
-    ? "var(--surface-2)"
-    : hovered
+  // Stable unique id for @dnd-kit — always provide one even when disabled,
+  // otherwise dupe ids collide across rows.
+  const dndId = useMemo(() => {
+    if (n.kind === "category") return `dnd-cat:${n.id ?? "uncat"}`;
+    if (n.kind === "project")  return `dnd-proj:${n.id}`;
+    if (n.kind === "task")     return `dnd-task:${n.task.id}`;
+    return `dnd-sub:${n.task.id}`;
+  }, [n]);
+
+  const dndEnabled = isDraggableCategory(n);
+
+  const { attributes, listeners, setNodeRef: setDragRef, isDragging } =
+    useDraggable({ id: dndId, disabled: !dndEnabled });
+  const { isOver, setNodeRef: setDropRef } =
+    useDroppable({ id: dndId, disabled: !dndEnabled });
+
+  const setRef = (node: HTMLDivElement | null) => {
+    setDragRef(node);
+    setDropRef(node);
+  };
+
+  const background = isOver
+    ? "var(--brand-tint, rgba(108,68,246,0.10))"
+    : selected
       ? "var(--surface-2)"
-      : "transparent";
+      : hovered
+        ? "var(--surface-2)"
+        : "transparent";
+
+  const dndDomProps = dndEnabled ? { ...attributes, ...listeners } : {};
 
   return (
     <div
+      ref={dndEnabled ? setRef : undefined}
       role="row"
       onMouseEnter={() => onHover?.(true)}
       onMouseLeave={() => onHover?.(false)}
       onClick={onSelect}
       onContextMenu={onContextMenu}
+      {...dndDomProps}
       style={{
         height: row.height,
         display: "flex",
@@ -85,9 +121,12 @@ export function GanttOutlineRow({
         paddingLeft: indent,
         paddingRight: 14,
         borderLeft: selected ? "2px solid var(--brand)" : "2px solid transparent",
+        // Drop target outline when another category is hovering over this row.
+        outline: isOver && dndEnabled ? "2px dashed var(--brand)" : "none",
+        outlineOffset: "-2px",
         background,
-        cursor: onSelect ? "pointer" : "default",
-        opacity: row.dimmed ? 0.35 : 1,
+        cursor: dndEnabled ? (isDragging ? "grabbing" : "grab") : (onSelect ? "pointer" : "default"),
+        opacity: isDragging ? 0.4 : (row.dimmed ? 0.35 : 1),
         userSelect: "none",
         transition: "background-color 150ms ease-out",
       }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -790,6 +790,7 @@
       "name": "@larry/web",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.1.0",
         "@larry/shared": "file:../../packages/shared",
         "@tanstack/react-query": "^5.59.20",
         "framer-motion": "^12.35.0",
@@ -1255,6 +1256,45 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {


### PR DESCRIPTION
## Summary

Final slice for Fergus's original "drag tasks, categories, and projects around" ask. **Opened as draft** — DnD feel is visual; needs a browser preview before merge.

Scoped tight: category→category drop only. No project/task drag yet. No reorder-within-parent. Those are 3D work.

### What this ships

- Drag any org-level category row (the row's drag handle is the whole row — click-to-select still works because `PointerSensor` has `activationConstraint.distance=5`)
- Drop on another category row → becomes its subcategory
- Visual feedback: grab/grabbing cursor; drop target outlined in dashed lavender; dragged row at 40% opacity
- Client-side cycle check before POST — can't drop a category under its own descendant
- Server cycle guard remains as defence-in-depth (already shipped in #115)
- Optimistic tree update via `setQueryData` flipping `parentCategoryId` on the flat array; `buildPortfolioTree` rebuilds nested rendering on next tick, so the drop settles visually before the network round-trip
- Rollback on error: snapshot restored, banner message surfaced

### Architecture

- **Dep:** `@dnd-kit/core@^6.1.0` (~10kB gz)
- **`GanttOutlineRow`:** always calls `useDraggable` + `useDroppable` (rules-of-hooks), with `disabled: true` for non-category rows. DOM-side, `{...attributes, ...listeners}` are only spread when `dndEnabled`.
- **`PortfolioGanttClient`:** wraps `<GanttContainer>` in `<DndContext sensors onDragEnd>`. `handleDragEnd` parses keys, validates, and fires `moveCategoryMutation`.
- **`moveCategoryMutation`:** `useMutation` with `onMutate` (snapshot + optimistic `setQueryData`), `onError` (restore + banner), `onSettled` (invalidate).

### Deferred to a later PR

- Drag projects and tasks
- Reorder within the same parent (sortOrder refinement)
- Drop onto a "top of tree" zone to promote a subcategory (workaround: drag onto another top-level category then context-menu it out, or use Categories drawer)
- Drag ergonomics: ghost overlay, auto-scroll while dragging, keyboard-accessible drag
- Archived-project guards on future project-drag work

### Test plan

- [x] `apps/web` typecheck clean
- [x] 42 gantt unit tests pass
- [ ] **Vercel preview (requires Fergus's eye):**
  - Drag "Marketing" onto "Internal" → Marketing nests under Internal, bars re-render
  - Click (don't drag) a row → row selects, no drag starts
  - Drag category A onto a descendant of A → banner: "Can't move a category under its own descendant", no network call
  - Trigger a 5xx on /api/workspace/categories/:id/move → banner surfaces the error, tree reverts
  - Refresh page → tree matches last committed state

Spec: `docs/superpowers/specs/2026-04-18-gantt-v4-subcategories-sync-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)