### PR TITLE
feat(gantt): right-click project → 'Add category in this project'

### DIFF
--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -25,6 +25,7 @@ const QK_TIMELINE_ORG = ["timeline", "org"] as const;
 type AddCtx =
   | { mode: "category" }
   | { mode: "subcategory"; parentCategoryId: string }
+  | { mode: "projectCategory"; projectId: string }    // v4 Slice 4.5 — project-scoped category
   | { mode: "project"; parentCategoryId?: string }
   | { mode: "task"; parentProjectId: string }
   | { mode: "subtask"; parentProjectId: string; parentTaskId: string };
@@ -517,6 +518,14 @@ export function PortfolioGanttClient() {
       return;
     }
 
+    if (action === "addCategory" && rowKind === "project") {
+      // v4 Slice 4.5 — project-scoped category. The AddNodeModal renders
+      // mode "category" with scopedProjectId set, so the server receives
+      // projectId and the DB CHECK constraint enforces single-parent.
+      setAddCtx({ mode: "projectCategory", projectId: rowKey.slice(5) });
+      return;
+    }
+
     if (action === "changeColour" && rowKind === "category") {
       const id = rowKey.slice(4);
       if (id === "uncat") return;
@@ -645,12 +654,19 @@ export function PortfolioGanttClient() {
 
       {addCtx && (
         <AddNodeModal
-          mode={addCtx.mode === "subcategory" ? "category" : addCtx.mode}
+          // subcategory + projectCategory both render as the "category" modal;
+          // parent* / scopedProjectId pick which single-parent the server receives.
+          mode={
+            addCtx.mode === "subcategory" || addCtx.mode === "projectCategory"
+              ? "category"
+              : addCtx.mode
+          }
           parentCategoryId={
             addCtx.mode === "project" ? addCtx.parentCategoryId :
             addCtx.mode === "subcategory" ? addCtx.parentCategoryId :
             undefined
           }
+          scopedProjectId={addCtx.mode === "projectCategory" ? addCtx.projectId : undefined}
           parentProjectId={addCtx.mode === "task" || addCtx.mode === "subtask" ? addCtx.parentProjectId : undefined}
           parentTaskId={addCtx.mode === "subtask" ? addCtx.parentTaskId : undefined}
           requireDates={addCtx.mode === "task" || addCtx.mode === "subtask"}

--- a/apps/web/src/components/workspace/gantt/gantt-types.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-types.ts
@@ -39,6 +39,7 @@ export type ContextMenuAction =
   | "removeFromTimeline"
   | "addChild"
   | "addSubcategory"   // v4 — only on category rows; creates category with parentCategoryId
+  | "addCategory"      // v4 Slice 4.5 — only on project rows; creates a project-scoped category
   | "rename"
   | "changeColour"
   | "delete";

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -353,10 +353,10 @@ describe("contextMenuItemsFor", () => {
     ]);
   });
 
-  it("project row gets Open, Move, Add task, Delete", () => {
+  it("project row gets Open, Move, Add task, Add category, Delete", () => {
     const items = contextMenuItemsFor({ rowKind: "project", isUncategorised: false });
     expect(items.map((i) => i.id)).toEqual([
-      "openDetail", "moveToCategory", "addChild", "delete",
+      "openDetail", "moveToCategory", "addChild", "addCategory", "delete",
     ]);
   });
 

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -537,6 +537,7 @@ export function contextMenuItemsFor(args: {
       { id: "openDetail",     label: "Open project" },
       { id: "moveToCategory", label: "Move to category…", hasSubmenu: true },
       { id: "addChild",       label: "Add task" },
+      { id: "addCategory",    label: "Add category in this project" },
       { id: "delete",         label: "Delete", destructive: true },
     ];
   }


### PR DESCRIPTION
## Summary

Adds the entry point Fergus flagged post-Slice 4: right-clicking a project row on the org timeline now offers **Add category in this project**, which opens the existing New-Category modal with `scopedProjectId` set.

## Why
Before: creating a project-scoped category required navigating into the project's own timeline and clicking the '+ Category' button. For portfolio-level planning (where you're already hovering over project rows) that's an unnecessary round trip.

## Changes
- `gantt-types.ts` — new `addCategory` entry in `ContextMenuAction`.
- `gantt-utils.ts` — `contextMenuItemsFor` emits the new item on `project` rows.
- `gantt-utils.test.ts` — test updated to assert the new menu shape.
- `PortfolioGanttClient.tsx` — new `AddCtx` variant `projectCategory`; handler wires into the existing `AddNodeModal` via `scopedProjectId`.

Server-side behaviour is unchanged: the category POST already accepts `projectId`, and the single-parent CHECK guarantees mutual exclusion with `parentCategoryId`.

## Test plan
- [x] `gantt-utils.test.ts` green (66 tests)
- [ ] Prod: right-click any project on /workspace/timeline → menu shows 'Add category in this project' → click → modal opens titled 'New category in project' → name it + pick colour + Create → category appears in the project's own timeline outline
- [ ] Prod: same flow on a project inside a category and on an Uncategorised project

🤖 Generated with [Claude Code](https://claude.com/claude-code)