### PR TITLE
feat(gantt): slice 5 polish — 10 UX fixes from the 2026-04-18 QA review

### DIFF
--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -621,24 +621,23 @@ export function PortfolioGanttClient() {
               aria-label="New category"
               title="New category"
               style={{
+                // v4 Slice 5 — icon-only pill so this doesn't duplicate the
+                // toolbar "+ Category" button visually. The toolbar button is
+                // contextual (label changes with selection); this one is the
+                // always-creates-a-category shortcut for power users.
                 display: "inline-flex",
                 alignItems: "center",
-                gap: 4,
+                justifyContent: "center",
+                width: 24,
                 height: 24,
-                padding: "0 8px",
-                fontSize: 11,
-                fontWeight: 600,
-                letterSpacing: "0.04em",
-                textTransform: "uppercase",
-                background: "var(--brand)",
-                color: "#fff",
-                border: 0,
+                background: "var(--surface-2)",
+                color: "var(--brand)",
+                border: "1px solid var(--border)",
                 borderRadius: 6,
                 cursor: "pointer",
               }}
             >
-              <Plus size={12} strokeWidth={2.5} />
-              Category
+              <Plus size={14} strokeWidth={2.5} />
             </button>
           }
         />

--- a/apps/web/src/components/workspace/gantt/GanttBar.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttBar.tsx
@@ -24,16 +24,19 @@ interface Props {
   onMouseLeave?: () => void;
 }
 
+// v4 Slice 5 — roll-up rows (category / project) use a thinner, outlined
+// bar so they read as summaries of the child task bars below, instead of
+// looking identical to concrete task work. Task bars stay solid.
 const HEIGHT_BY_VARIANT: Record<GanttBarVariant, number> = {
-  category: 18,
-  project:  16,
+  category: 8,
+  project:  10,
   task:     14,
   subtask:  10,
 };
 
 const RADIUS_BY_VARIANT: Record<GanttBarVariant, number> = {
-  category: 3,
-  project:  3,
+  category: 2,
+  project:  2,
   task:     3,
   subtask:  2,
 };
@@ -63,11 +66,17 @@ export function GanttBar({
   const height = HEIGHT_BY_VARIANT[variant];
   const radius = RADIUS_BY_VARIANT[variant];
   const isLeaf = variant === "task" || variant === "subtask";
+  const isRollup = variant === "category" || variant === "project";
   const progressClamped = Math.min(100, Math.max(0, progressPercent));
 
   const rgbRing = (highlighted || selected)
     ? `0 0 0 2px ${rgbaFromHex(categoryColor, 0.25)}`
     : undefined;
+
+  // v4 Slice 5 — roll-ups: 35% translucent fill with a 1.5px full-opacity
+  // outline so the bar reads as "summary" vs a solid task bar.
+  const bg = isRollup ? rgbaFromHex(categoryColor, 0.35) : categoryColor;
+  const outline = isRollup ? `1.5px solid ${categoryColor}` : "none";
 
   return (
     <div
@@ -89,21 +98,25 @@ export function GanttBar({
         pointerEvents: "auto",
       }}
     >
-      {/* Solid category-colour bar */}
+      {/* Category-coloured bar — solid on tasks, translucent+outlined on roll-ups */}
       <div
         style={{
           position: "relative",
           width: "100%",
           height,
-          background: categoryColor,
+          background: bg,
+          border: outline,
           borderRadius: radius,
-          boxShadow: rgbRing ?? "0 1px 2px rgba(0,0,0,0.04)",
+          boxShadow: rgbRing ?? (isRollup ? "none" : "0 1px 2px rgba(0,0,0,0.04)"),
           transition: "box-shadow 150ms ease-out",
           overflow: "hidden",
+          boxSizing: "border-box",
         }}
       >
-        {/* Progress overlay — darker inner fill up to progress% */}
-        {progressClamped > 0 && (
+        {/* Progress overlay — leaf bars only. Roll-ups intentionally skip
+            progress because the aggregate would be misleading (a category
+            rolling up 3 projects at different % can't be a single bar). */}
+        {!isRollup && progressClamped > 0 && (
           <div
             style={{
               position: "absolute",

--- a/apps/web/src/components/workspace/gantt/GanttContainer.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { CategoryColorMap, ContextMenuAction, ContextMenuState, GanttNode, GanttTask, ZoomLevel } from "./gantt-types";
-import { computeRange, flattenVisible, dateToPct, contextMenuItemsFor } from "./gantt-utils";
+import { computeRange, flattenVisible, dateToPct, contextMenuItemsFor, searchUnDimmedKeys } from "./gantt-utils";
 import { GanttOutline } from "./GanttOutline";
 import { GanttGrid } from "./GanttGrid";
 import { GanttToolbar } from "./GanttToolbar";
@@ -50,8 +50,11 @@ export function GanttContainer({
   const rows = useMemo(() => {
     const base = flattenVisible(root, expanded, { categoryColorMap, rootCategoryColor });
     if (!search.trim()) return base;
-    const q = search.toLowerCase();
-    return base.map((r) => ({ ...r, dimmed: !nodeLabel(r.node).toLowerCase().includes(q) }));
+    // v4 Slice 5 — ancestor-aware dimming: a row stays un-dimmed if itself,
+    // any ancestor, or any descendant matches. Keeps the match's context
+    // chain legible instead of fading it out.
+    const unDimmed = searchUnDimmedKeys(root, search);
+    return base.map((r) => ({ ...r, dimmed: !unDimmed.has(r.key) }));
   }, [root, expanded, search, categoryColorMap, rootCategoryColor]);
 
   const toggle = useCallback((key: string) => {

--- a/apps/web/src/components/workspace/gantt/GanttContainer.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttContainer.tsx
@@ -90,12 +90,16 @@ export function GanttContainer({
 
   const handleContextMenu = useCallback(
     (rowKey: string, rowKind: GanttNode["kind"], e: React.MouseEvent) => {
+      // v4 Slice 5 — no context menu on the synthetic Uncategorised bucket.
+      // Previously it opened with a single disabled-sentinel item which read
+      // like an error; the row's italic typography already tells users it's
+      // not editable.
+      if (rowKey === "cat:uncat") return;
       if (rowKind === "subtask" || rowKind === "task" || rowKind === "project" || rowKind === "category") {
-        const isUncategorised = rowKey === "cat:uncat";
         setContextMenu({
           rowKey,
           rowKind,
-          isUncategorised,
+          isUncategorised: false,
           x: e.clientX,
           y: e.clientY,
         });

--- a/apps/web/src/components/workspace/gantt/GanttDateHeader.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttDateHeader.tsx
@@ -15,12 +15,12 @@ const TODAY_LABEL_BAND = 16;
 
 // Horizontal scale: px-per-day per zoom. Drives the grid minWidth so day-
 // number labels and month labels never overlap. Tuned so adjacent ticks are
-// spaced comfortably wider than their labels (~16px for "23" at 11px tabular):
-//   - week:    daily ticks × 36px = 36px between labels (20px gap)
+// spaced comfortably wider than their labels:
+//   - week:    daily ticks × 48px (room for "Mon 16" / "Tue 17" weekday+num)
 //   - month:   weekly ticks × 14px per day = 98px between labels
 //   - quarter: biweekly ticks × 8px per day = 112px between labels
 export const PX_PER_DAY_BY_ZOOM: Record<ZoomLevel, number> = {
-  week:    36,
+  week:    48,
   month:   14,
   quarter:  8,
 };
@@ -40,7 +40,9 @@ export function GanttDateHeader({ range, zoom }: Props) {
         zIndex: 3,
       }}
     >
-      {/* Today label band (top 16px) */}
+      {/* Today pill (top 16px). v4 Slice 5 — upgraded from a bare 10px text
+          to a proper pill that reads as a persistent now-marker; easier to
+          spot when scrolled and matches the industry norm (Asana/Monday). */}
       <div style={{ position: "relative", height: TODAY_LABEL_BAND }}>
         {todayInRange && (
           <span
@@ -48,15 +50,21 @@ export function GanttDateHeader({ range, zoom }: Props) {
               position: "absolute",
               left: `${todayPct}%`,
               transform: "translateX(-50%)",
-              top: 2,
+              top: 0,
+              padding: "1px 6px",
               fontSize: 10,
-              fontWeight: 600,
-              color: "var(--brand)",
+              fontWeight: 700,
+              letterSpacing: "0.04em",
+              textTransform: "uppercase",
+              color: "#fff",
+              background: "var(--brand)",
+              borderRadius: 3,
               whiteSpace: "nowrap",
               pointerEvents: "none",
+              boxShadow: "0 1px 3px rgba(108, 68, 246, 0.35)",
             }}
           >
-            Today
+            Today {new Date().toLocaleDateString("en-GB", { day: "numeric", month: "short" })}
           </span>
         )}
       </div>
@@ -132,7 +140,10 @@ export function GanttDateHeader({ range, zoom }: Props) {
                   whiteSpace: "nowrap",
                 }}
               >
-                {d.label.replace(/^[A-Za-z]+\s/, "")}
+                {/* v4 Slice 5 — keep the weekday prefix at week zoom so
+                    "Mon 16" stays visible. Month / quarter zoom already emit
+                    number-only labels so no strip needed. */}
+                {d.label}
               </span>
             </div>
           ))}

--- a/apps/web/src/components/workspace/gantt/GanttOutline.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttOutline.tsx
@@ -156,9 +156,13 @@ export function GanttOutline({
       </div>
       {footer}
       {overlay}
+      {/* v4 Slice 5 — wider (12 px) hit area so the outline resize handle is
+          actually discoverable. The visible affordance stays 1 px wide via
+          the outline's right border; this invisible overlay catches clicks. */}
       <div
         onMouseDown={onMouseDown}
-        style={{ position: "absolute", right: -3, top: 0, bottom: 0, width: 6, cursor: "col-resize" }}
+        aria-hidden="true"
+        style={{ position: "absolute", right: -6, top: 0, bottom: 0, width: 12, cursor: "col-resize" }}
       />
     </div>
   );

--- a/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
@@ -180,7 +180,7 @@ export function GanttOutlineRow({
       />
 
       <span
-        title={label}
+        title={row.emptyNote ? `${label} — ${row.emptyNote}` : label}
         style={{
           ...TYPOGRAPHY_BY_TIER[tier],
           fontStyle: isUncategorised ? "italic" : "normal",
@@ -192,6 +192,19 @@ export function GanttOutlineRow({
         }}
       >
         {label}
+        {row.emptyNote && (
+          <span style={{
+            marginLeft: 8,
+            fontSize: 11,
+            fontWeight: 400,
+            letterSpacing: 0,
+            textTransform: "none",
+            color: "var(--text-muted)",
+            fontStyle: "italic",
+          }}>
+            · {row.emptyNote}
+          </span>
+        )}
       </span>
     </div>
   );

--- a/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttOutlineRow.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { ChevronRight } from "lucide-react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import type { FlatRow } from "./gantt-utils";
@@ -107,17 +107,35 @@ export function GanttOutlineRow({
         ? "var(--surface-2)"
         : "transparent";
 
-  const dndDomProps = dndEnabled ? { ...attributes, ...listeners } : {};
+  // v4 Slice 5 — drop the `role=button` that dnd-kit spreads onto the element
+  // (it overrides our `role=row` otherwise). Screen readers now announce each
+  // row as part of the Gantt grid again instead of as a button.
+  const dndDomProps = dndEnabled ? { ...attributes, ...listeners, role: undefined } : {};
+
+  // v4 Slice 5 — suppress the click-select that fires on pointerup at the
+  // end of a drag. dnd-kit activates on pointer distance > 5px, but the
+  // browser still fires a synthetic click event when pointerdown + pointerup
+  // land on the same element; without this guard a drop would also leave the
+  // drop target highlighted in the "selected" state.
+  const lastDragEnd = useRef(0);
+  const prevIsDragging = useRef(isDragging);
+  if (prevIsDragging.current && !isDragging) lastDragEnd.current = performance.now();
+  prevIsDragging.current = isDragging;
+
+  const handleSelectGated = () => {
+    if (performance.now() - lastDragEnd.current < 200) return;
+    onSelect?.();
+  };
 
   return (
     <div
       ref={dndEnabled ? setRef : undefined}
-      role="row"
       onMouseEnter={() => onHover?.(true)}
       onMouseLeave={() => onHover?.(false)}
-      onClick={onSelect}
+      onClick={handleSelectGated}
       onContextMenu={onContextMenu}
       {...dndDomProps}
+      role="row"
       style={{
         height: row.height,
         display: "flex",

--- a/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+++ b/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
@@ -445,24 +445,22 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
               aria-label="New category in this project"
               title="New category in this project"
               style={{
+                // v4 Slice 5 — icon-only, matches the org timeline outline
+                // button. The big pill label lived in the same visual band
+                // as the toolbar "+ Task" button and read as a duplicate.
                 display: "inline-flex",
                 alignItems: "center",
-                gap: 4,
+                justifyContent: "center",
+                width: 24,
                 height: 24,
-                padding: "0 8px",
-                fontSize: 11,
-                fontWeight: 600,
-                letterSpacing: "0.04em",
-                textTransform: "uppercase",
-                background: "var(--brand)",
-                color: "#fff",
-                border: 0,
+                background: "var(--surface-2)",
+                color: "var(--brand)",
+                border: "1px solid var(--border)",
                 borderRadius: 6,
                 cursor: "pointer",
               }}
             >
-              <Plus size={12} strokeWidth={2.5} />
-              Category
+              <Plus size={14} strokeWidth={2.5} />
             </button>
           }
         />

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -427,6 +427,56 @@ describe("statusChipFor", () => {
   });
 });
 
+/* ─── v4 Slice 5 — search dimming ─────────────────────────────────── */
+
+import { searchUnDimmedKeys } from "./gantt-utils";
+
+describe("searchUnDimmedKeys", () => {
+  const mkTree = (): GanttNode => {
+    const task: GanttNode = { kind: "task", id: "t1", task: baseTask({ id: "t1", title: "Verify migrations" }), children: [] };
+    const sibTask: GanttNode = { kind: "task", id: "t2", task: baseTask({ id: "t2", title: "Design landing page" }), children: [] };
+    const project: GanttNode = { kind: "project", id: "p1", name: "Onboarding", status: "active", children: [task, sibTask] };
+    const category: GanttNode = { kind: "category", id: "c1", name: "Marketing", colour: null, children: [project] };
+    const peerCat: GanttNode = { kind: "category", id: "c2", name: "Legal", colour: null, children: [] };
+    return { kind: "category", id: "__root__", name: "", colour: null, children: [category, peerCat] };
+  };
+
+  it("returns an empty set for an empty query", () => {
+    const set = searchUnDimmedKeys(mkTree(), "");
+    expect(set.size).toBe(0);
+  });
+
+  it("includes the matching task AND its ancestors", () => {
+    const set = searchUnDimmedKeys(mkTree(), "verify");
+    expect(set).toContain("task:t1");
+    expect(set).toContain("proj:p1");
+    expect(set).toContain("cat:c1");
+    // Sibling task that doesn't match is NOT un-dimmed
+    expect(set.has("task:t2")).toBe(false);
+    // Peer category that doesn't match is NOT un-dimmed
+    expect(set.has("cat:c2")).toBe(false);
+  });
+
+  it("when a category matches, its whole subtree stays un-dimmed", () => {
+    const set = searchUnDimmedKeys(mkTree(), "marketing");
+    expect(set).toContain("cat:c1");
+    expect(set).toContain("proj:p1");
+    expect(set).toContain("task:t1");
+    expect(set).toContain("task:t2");
+    expect(set.has("cat:c2")).toBe(false);
+  });
+
+  it("never emits the synthetic __root__ key", () => {
+    const set = searchUnDimmedKeys(mkTree(), "verify");
+    expect(set.has("cat:__root__")).toBe(false);
+  });
+
+  it("query is case-insensitive and trims whitespace", () => {
+    const set = searchUnDimmedKeys(mkTree(), "  MIGR  ");
+    expect(set).toContain("task:t1");
+  });
+});
+
 /* ─── v4 Slice 4 — validateDrop ────────────────────────────────────── */
 
 import { validateDrop, parseDndKey, type DropContext } from "./gantt-utils";

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -218,6 +218,11 @@ export type FlatRow = {
   categoryColor: string; // resolved category colour; fallback to Larry purple
   dimmed?: boolean;
   height: number;      // per-level (ROW_HEIGHT for cat/proj, ROW_HEIGHT_TASK for task/sub)
+  // v4 Slice 5 — a human-readable suffix ("no scheduled tasks") rendered
+  // after the row label when the row is a structural container with no
+  // scheduled content. Set only on project / category rows whose subtree
+  // collapsed to zero Gantt-visible descendants.
+  emptyNote?: string;
 };
 
 export interface FlattenOptions {
@@ -256,9 +261,26 @@ export function flattenVisible(
     const key = keyOf(node);
     const categoryColor = colourFor(node, inherited);
 
+    // v4 Slice 5 — annotate structural container rows that have no Gantt
+    // content so the outline can render a "(no scheduled tasks)" suffix.
+    // Project rows: empty = zero children (server already filtered null-date
+    // tasks out). Category rows: only when id is a real category (not the
+    // Uncategorised bucket — that's already italic + always empty-by-design).
+    let emptyNote: string | undefined;
+    if (!isSyntheticRoot && !hasChildren) {
+      if (node.kind === "project") {
+        emptyNote = "no scheduled tasks";
+      } else if (node.kind === "category"
+                 && node.id !== null
+                 && node.id !== "uncat"
+                 && node.id !== "__root__") {
+        emptyNote = "no projects yet";
+      }
+    }
+
     if (!isSyntheticRoot) {
       const height = (node.kind === "task" || node.kind === "subtask") ? ROW_HEIGHT_TASK : ROW_HEIGHT;
-      rows.push({ kind: "node", key, depth, node, hasChildren, categoryColor, height });
+      rows.push({ kind: "node", key, depth, node, hasChildren, categoryColor, height, emptyNote });
     }
 
     if (!isSyntheticRoot && !expanded.has(key)) return;
@@ -542,10 +564,13 @@ export function contextMenuItemsFor(args: {
       { id: "delete",         label: "Delete", destructive: true },
     ];
   }
-  // task or subtask
+  // task or subtask — tasks inherit their category from the parent project,
+  // so "moveToCategory" here rewrites the project's categoryId rather than
+  // the task's. Until tasks.category_id exists as a real column, be honest
+  // in the label about the scope of the action.
   return [
     { id: "openDetail",          label: "Open task" },
-    { id: "moveToCategory",      label: "Move project to category…", hasSubmenu: true },
+    { id: "moveToCategory",      label: "Change project's category…", hasSubmenu: true },
     { id: "removeFromTimeline",  label: "Remove from timeline" },
     { id: "delete",              label: "Delete", destructive: true },
   ];

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -571,6 +571,73 @@ export function statusChipFor(status: GanttTaskStatus): StatusChipData | null {
   }
 }
 
+/* ─── v4 Slice 5 — search dimming (ancestor-aware) ──────────────────── */
+
+// Build the set of node keys that should stay un-dimmed for a given search
+// query. A row stays un-dimmed if:
+//   • Its own label matches the query (case-insensitive substring), OR
+//   • Any descendant's label matches (so the parent stays legible as
+//     context for the match below it), OR
+//   • Any ancestor's label matches (so a matched parent keeps its children
+//     visible rather than fading them out).
+// Returns an empty set when the query is blank; the caller should skip
+// dimming entirely in that case.
+export function searchUnDimmedKeys(root: GanttNode, rawQuery: string): Set<string> {
+  const query = rawQuery.trim().toLowerCase();
+  const out = new Set<string>();
+  if (!query) return out;
+
+  function keyOf(node: GanttNode): string {
+    if (node.kind === "category") return `cat:${node.id ?? "uncat"}`;
+    if (node.kind === "project") return `proj:${node.id}`;
+    if (node.kind === "task") return `task:${node.id}`;
+    return `sub:${node.id}`;
+  }
+
+  function labelOf(node: GanttNode): string {
+    if (node.kind === "category" || node.kind === "project") return node.name;
+    return node.task.title;
+  }
+
+  // Mark every node in the given subtree as un-dimmed.
+  function addSubtree(node: GanttNode): void {
+    const isSyntheticRoot = node.kind === "category" && node.id === "__root__";
+    if (!isSyntheticRoot) out.add(keyOf(node));
+    if (node.kind === "subtask") return;
+    for (const child of node.children) addSubtree(child);
+  }
+
+  // walk returns true if `node` or any descendant matched. When a match sits
+  // on this node, every queued ancestor key is added to `out`, and the
+  // node's whole subtree is kept un-dimmed too.
+  function walk(node: GanttNode, ancestors: string[]): boolean {
+    const isSyntheticRoot = node.kind === "category" && node.id === "__root__";
+    const k = keyOf(node);
+    const selfMatch = !isSyntheticRoot && labelOf(node).toLowerCase().includes(query);
+    let descendantMatch = false;
+    if (node.kind !== "subtask") {
+      const nextAncestors = isSyntheticRoot ? ancestors : [...ancestors, k];
+      for (const child of node.children) {
+        if (walk(child, nextAncestors)) descendantMatch = true;
+      }
+    }
+    if (selfMatch) {
+      // Propagate up + keep the whole subtree in context.
+      for (const a of ancestors) out.add(a);
+      addSubtree(node);
+      return true;
+    }
+    if (descendantMatch) {
+      // Some child matched — this node stays visible as context.
+      if (!isSyntheticRoot) out.add(k);
+      return true;
+    }
+    return false;
+  }
+  walk(root, []);
+  return out;
+}
+
 /* ─── v4 Slice 4 — drag-and-drop validation ─────────────────────────── */
 
 // dnd-kit sortable ids issued by GanttOutlineRow:

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts", "src/**/*.spec.ts"],
     passWithNoTests: true,


### PR DESCRIPTION
## Summary

Single-branch cleanup covering every P1/P2/P3 UX gap the 2026-04-18 QA review identified, plus the pre-existing vitest alias breakage that landed with the `@/lib/timezone-context` import. No new features — all polish and semantics.

### Commits (each targets one finding)

| Fix | Commit | What it does |
|-----|--------|--------------|
| #3 + #4 + vitest | `0987d4b` | role=row preserved on draggable rows; click-select suppressed within 200 ms of a drag end; `@/` alias added to vitest.config so the web suite runs again |
| #6 | `646f6bb` | Search no longer dims ancestors of matches; category-name matches keep the whole subtree visible. New `searchUnDimmedKeys()` helper + 5 unit tests |
| #1 + #2 + #7 | `590568e` | Empty projects show "· no scheduled tasks" suffix; empty categories show "· no projects yet"; task `moveToCategory` relabeled to "Change project's category…"; right-click on Uncategorised no longer opens a one-item disabled menu |
| #5 + #8 + #9 | `c09ca29` | Roll-up bars (category/project) now render translucent + outlined so they read as summaries vs task bars; today marker upgraded to a branded pill "Today 19 Apr"; week-zoom day labels keep their weekday prefix (Mon 16 / Tue 17) and px-per-day widened 36 → 48 to fit |
| #13 | `e19cb47` | Outline's "+ Category" button is now an icon-only 24×24 pill instead of a full purple label that duplicated the toolbar's contextual `+ …` button |
| #14 | `764df11` | Outline resize handle hit area widened 6 → 12 px; aria-hidden |

### Test plan
- [x] Web unit tests green (72 tests, 5 new)
- [x] TypeScript clean on every file I touched
- [ ] Prod: right-click a task row → menu item reads "Change project's category…" ✓
- [ ] Prod: right-click Uncategorised → no menu appears ✓
- [ ] Prod: search "verify" → `Uncategorised` parent stays legible, matches stay crisp, siblings dim ✓
- [ ] Prod: empty project rows show the "· no scheduled tasks" suffix ✓
- [ ] Prod: today marker is a branded pill; week zoom shows "Mon 16" ✓
- [ ] Prod: category / project Gantt bars are translucent + outlined, task bars solid ✓
- [ ] Prod: outline "+ Category" is icon-only ✓
- [ ] Prod: resizing the outline is easier to grab ✓

### Deferred to a later slice

- **#11** — status chip clipping at low zoom. Needs a right-edge buffer in the grid; left for a structural fix.
- **#12** — custom drag ghost via `DragOverlay`. Purely polish; doesn't affect function.
- **Task.category_id** — for real "Move task to category" semantics instead of the relabel in #2. Needs schema migration, belongs in its own slice.

QA report: `docs/reports/2026-04-18-gantt-v4-qa-review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)