### PR TITLE
fix(auth): login audit polish — accept UX + case-insensitive email + 12-char password

### DIFF
--- a/apps/api/src/lib/validation.test.ts
+++ b/apps/api/src/lib/validation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { emailSchema, passwordSchema } from "./validation.js";
+
+describe("passwordSchema", () => {
+  it("accepts a 12-char password with upper, digit, symbol", () => {
+    expect(() => passwordSchema.parse("StrongPass1!")).not.toThrow();
+  });
+
+  it("rejects passwords under 12 characters", () => {
+    // 11 chars — used to pass the old min-8 policy.
+    expect(() => passwordSchema.parse("StrongPas1!")).toThrow(
+      /12 characters/,
+    );
+  });
+
+  it("rejects passwords missing an uppercase letter", () => {
+    expect(() => passwordSchema.parse("lowercase123!")).toThrow(/uppercase/);
+  });
+
+  it("rejects passwords missing a digit", () => {
+    expect(() => passwordSchema.parse("NoDigitsHere!")).toThrow(/number/);
+  });
+
+  it("rejects passwords missing a symbol", () => {
+    expect(() => passwordSchema.parse("NoSymbols1234")).toThrow(/special/);
+  });
+});
+
+describe("emailSchema", () => {
+  it("lowercases the input", () => {
+    expect(emailSchema.parse("Hello@Example.COM")).toBe("hello@example.com");
+  });
+
+  it("rejects invalid emails", () => {
+    expect(() => emailSchema.parse("not-an-email")).toThrow();
+  });
+});

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
 
+// Password policy: 12 chars + uppercase + digit + symbol. Matches the
+// minLength=12 constraint the signup/accept/redeem UIs already enforce;
+// previously the server allowed 8 which would have let a future API-only
+// client create accounts the UI could never log back into without a
+// "password is too short for our rules" surprise.
 export const passwordSchema = z
   .string()
-  .min(8, "Password must be at least 8 characters")
+  .min(12, "Password must be at least 12 characters")
   .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
   .regex(/[0-9]/, "Password must contain at least one number")
   .regex(/[^a-zA-Z0-9]/, "Password must contain at least one special character");

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -59,9 +59,11 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
   }, async (request, reply) => {
     const body = SignupSchema.parse(request.body);
 
-    // Check for existing user with same email
+    // Check for existing user with same email. emailSchema normalises to
+    // lowercase, but legacy rows may have mixed-case values — always
+    // compare with lower() so duplicate-detection is airtight.
     const existing = await fastify.db.query<{ id: string }>(
-      `SELECT id FROM users WHERE email = $1 LIMIT 1`,
+      `SELECT id FROM users WHERE lower(email) = lower($1) LIMIT 1`,
       [body.email],
     );
 
@@ -217,6 +219,8 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
     // Resolve membership by email. If a tenantId is supplied, scope to it;
     // otherwise pick the user's oldest membership (deterministic default for
     // users who belong to exactly one tenant, which is the signup case).
+    // Case-insensitive email lookup so legacy mixed-case rows still log in
+    // (the schema normalises new inputs, but old data is unchanged).
     const rows = tenantId
       ? await fastify.db.query<{
           id: string;
@@ -229,7 +233,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
           `SELECT u.id, u.email, u.password_hash, u.display_name, m.role, m.tenant_id
            FROM users u
            JOIN memberships m ON m.user_id = u.id
-           WHERE u.email = $1 AND m.tenant_id = $2
+           WHERE lower(u.email) = lower($1) AND m.tenant_id = $2
            LIMIT 1`,
           [body.email, tenantId]
         )
@@ -244,7 +248,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
           `SELECT u.id, u.email, u.password_hash, u.display_name, m.role, m.tenant_id
            FROM users u
            JOIN memberships m ON m.user_id = u.id
-           WHERE u.email = $1
+           WHERE lower(u.email) = lower($1)
            ORDER BY m.created_at ASC
            LIMIT 1`,
           [body.email]

--- a/apps/api/src/routes/v1/invitations.ts
+++ b/apps/api/src/routes/v1/invitations.ts
@@ -262,6 +262,7 @@ export const invitationsRoutes: FastifyPluginAsync = async (fastify) => {
       email: inv.email,
       role: inv.role,
       expiresAt: inv.expiresAt,
+      tenantId: inv.tenantId,
       tenantName: tenant[0]?.name ?? null,
       tenantSlug: tenant[0]?.slug ?? null,
       projectId: inv.projectId,

--- a/apps/api/tests/invite-links-routes.test.ts
+++ b/apps/api/tests/invite-links-routes.test.ts
@@ -283,7 +283,7 @@ describe("POST /orgs/invite-links/by-token/:token/redeem", () => {
     const res = await app.inject({
       method: "POST",
       url: "/orgs/invite-links/by-token/long-enough-token/redeem",
-      payload: { email: "new@example.com", password: "LongPass1!" },
+      payload: { email: "new@example.com", password: "LongPassword12!" },
     });
     expect(res.statusCode).toBe(410);
   });

--- a/apps/web/src/app/invite/accept/AcceptForm.tsx
+++ b/apps/web/src/app/invite/accept/AcceptForm.tsx
@@ -7,18 +7,30 @@ interface AcceptFormProps {
   token: string;
   email: string;
   currentUserEmail: string | null;
+  /** True when the signed-in email matches the invite but the active tenant differs. */
+  willSwitchTenant?: boolean;
+  targetTenantName?: string | null;
 }
 
-export function AcceptForm({ token, email, currentUserEmail }: AcceptFormProps) {
+export function AcceptForm({
+  token,
+  email,
+  currentUserEmail,
+  willSwitchTenant = false,
+  targetTenantName = null,
+}: AcceptFormProps) {
   const router = useRouter();
   const [password, setPassword] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  const [confirmedSwitch, setConfirmedSwitch] = useState(false);
 
   const mismatch =
     currentUserEmail !== null &&
     currentUserEmail.toLowerCase() !== email.toLowerCase();
+
+  const needsSwitchConfirm = willSwitchTenant && !confirmedSwitch;
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -65,6 +77,34 @@ export function AcceptForm({ token, email, currentUserEmail }: AcceptFormProps) 
         >
           Sign out and accept as {email}
         </a>
+      </div>
+    );
+  }
+
+  if (needsSwitchConfirm) {
+    return (
+      <div className="space-y-3">
+        <p className="text-[13px]" style={{ color: "var(--text-2)" }}>
+          Accepting will switch your active session to
+          {" "}<strong>{targetTenantName ?? "the new workspace"}</strong>. Confirm to continue.
+        </p>
+        <div className="flex gap-2">
+          <a
+            href="/workspace"
+            className="flex-1 h-10 inline-flex items-center justify-center rounded-full border text-[13px] font-semibold"
+            style={{ borderColor: "var(--border)", color: "var(--text-1)" }}
+          >
+            Cancel
+          </a>
+          <button
+            type="button"
+            onClick={() => setConfirmedSwitch(true)}
+            className="flex-1 h-10 rounded-full text-[13px] font-semibold text-white"
+            style={{ background: "#6c44f6" }}
+          >
+            Switch and accept
+          </button>
+        </div>
       </div>
     );
   }
@@ -149,7 +189,9 @@ export function AcceptForm({ token, email, currentUserEmail }: AcceptFormProps) 
         {busy
           ? "Accepting…"
           : currentUserEmail
-            ? `Continue as ${currentUserEmail}`
+            ? willSwitchTenant
+              ? `Switch to ${targetTenantName ?? "this workspace"} as ${currentUserEmail}`
+              : `Continue as ${currentUserEmail}`
             : "Create account and join"}
       </button>
     </form>

--- a/apps/web/src/app/invite/accept/page.tsx
+++ b/apps/web/src/app/invite/accept/page.tsx
@@ -8,6 +8,7 @@ interface Preview {
   email: string;
   role: string;
   expiresAt: string;
+  tenantId: string;
   tenantName: string | null;
   tenantSlug: string | null;
   projectId: string | null;
@@ -88,6 +89,25 @@ function StateCard({
   );
 }
 
+async function fetchCurrentTenantName(
+  accessToken: string,
+): Promise<string | null> {
+  const base = process.env.LARRY_API_BASE_URL ?? "http://localhost:8080";
+  try {
+    const res = await fetch(`${base}/v1/auth/tenants`, {
+      cache: "no-store",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      tenants?: Array<{ name: string; current: boolean }>;
+    };
+    return data.tenants?.find((t) => t.current)?.name ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export default async function AcceptInvitationPage({
   searchParams,
 }: {
@@ -96,6 +116,11 @@ export default async function AcceptInvitationPage({
   const { token } = await searchParams;
   const session = await getSession();
   const currentUserEmail = session?.email ?? null;
+  const currentTenantId = session?.tenantId ?? null;
+  const currentTenantName =
+    session?.apiAccessToken
+      ? await fetchCurrentTenantName(session.apiAccessToken)
+      : null;
 
   if (!token) {
     return (
@@ -166,7 +191,16 @@ export default async function AcceptInvitationPage({
     );
   }
 
-  const { email, role, tenantName, expiresAt, projectName, projectRole } = result.data;
+  const { email, role, tenantId, tenantName, expiresAt, projectName, projectRole } = result.data;
+
+  // Signed-in as the same email but in a different tenant: accepting replaces
+  // the session. We don't *lose* the current membership — the row stays — but
+  // the user will need the workspace switcher to get back. Surface that.
+  const willSwitchTenant =
+    currentUserEmail !== null &&
+    currentUserEmail.toLowerCase() === email.toLowerCase() &&
+    currentTenantId !== null &&
+    currentTenantId !== tenantId;
 
   return (
     <Shell>
@@ -206,10 +240,26 @@ export default async function AcceptInvitationPage({
           </p>
         </div>
 
+        {willSwitchTenant && (
+          <div
+            className="rounded-lg border px-3 py-2 text-[12px]"
+            style={{
+              borderColor: "#fde68a",
+              background: "#fffbeb",
+              color: "#92400e",
+            }}
+          >
+            You'll keep your {currentTenantName ? <strong>{currentTenantName}</strong> : "current workspace"} membership.
+            Accepting adds <strong>{tenantName ?? "this workspace"}</strong> as a second one — your active session will switch to it, and you can flip back anytime from the topbar.
+          </div>
+        )}
+
         <AcceptForm
           token={token}
           email={email}
           currentUserEmail={currentUserEmail}
+          willSwitchTenant={willSwitchTenant}
+          targetTenantName={tenantName}
         />
       </div>
     </Shell>

--- a/docs/security/login-audit-2026-04-19.md
+++ b/docs/security/login-audit-2026-04-19.md
@@ -1,0 +1,114 @@
+# Login / auth audit — 2026-04-19
+
+Scope: the login stack as it stands on the day before public launch. Paired
+with PR `fix/login-audit-polish` which ships the three highest-impact fixes
+(accept UX, case-insensitive email, password policy).
+
+## Executive summary
+Login design is materially aligned with industry standard (OWASP ASVS Level 2,
+NIST SP 800-63B). The biggest missing piece is CSRF enforcement; the other
+gaps are hardening rather than critical holes. No exploitable auth bypass
+found during this pass.
+
+## What already meets the bar
+
+| Control | Where it lives | Notes |
+|---|---|---|
+| Password hashing | `apps/api/src/lib/auth.ts:7` | Bcrypt, 12 rounds. |
+| Password policy | `apps/api/src/lib/validation.ts` | Min 12 chars + upper + digit + symbol (post-#PR). |
+| Rate limiting | `routes/v1/auth.ts` `config.rateLimit` per-endpoint | signup 5/h, login 10/15m, refresh 30/h, per-IP. |
+| Account lockout | `routes/v1/auth.ts:286-290` | 10 fails → 30 min lock, INSERT…ON CONFLICT atomically. |
+| Generic error messages | `routes/v1/auth.ts:254-260, 306` | No email-enumeration signal. |
+| Refresh token rotation | `routes/v1/auth.ts:426-438` | Old revoked, new issued, inside a tx. |
+| Refresh token at rest | `apps/api/src/lib/auth.ts:17-24` | SHA-256 hashed; raw never persisted. |
+| Refresh revocation on logout | `routes/v1/auth.ts:856` | UPDATE SET revoked_at = NOW() for all active tokens per (user, tenant). |
+| Session cookie flags | `apps/web/src/lib/auth.ts:102-112` | httpOnly, secure (prod), sameSite=lax, path=/. |
+| Session cookie JWT | `apps/web/src/lib/auth.ts:45-62` | HS256, 24h TTL, `csrfToken` bound inside payload. |
+| New-device email alerts | `routes/v1/auth.ts:315-334` | Best-effort, does not block login. |
+| Email verification | `routes/v1/auth.ts:152-170`, `auth-verification.ts` | Single-use hashed token, 24h expiry, 7-day grace period. |
+| Password reset | `auth-password-reset.ts` | Signed token, single-use (marked consumed on reset). |
+| Audit logging | `auth.ts:175-183, 353-360, 860-866` | signup, login, logout, lockout, tenant switch. |
+| Last-admin guard | `apps/api/src/lib/last-admin-guard.ts` | Prevents locking yourself out of a tenant. |
+| Seat cap enforcement | `apps/api/src/lib/seat-cap.ts` | Memberships + pending invites. |
+| Tenant switcher | `auth.ts` `/tenants`, `/switch-tenant`; `apps/web/src/components/workspace/WorkspaceSwitcher.tsx` | Shipped PR #124. |
+
+## Fixes shipping in this PR
+
+1. **Accept flow UX** (`apps/web/src/app/invite/accept/*`). When a signed-in
+   user with the same email accepts an invite for a **different** tenant, the
+   page now shows a warning block explaining their current-workspace
+   membership is preserved, and a confirm step is required before switching.
+   The button label changes to "Switch to <X> as <email>".
+2. **Case-insensitive email lookup** (`routes/v1/auth.ts` signup + login).
+   Old mixed-case `users.email` rows would silently fail login even though
+   `emailSchema` normalises new inputs. Now `WHERE lower(u.email) = lower($1)`.
+3. **Password policy bump** (`lib/validation.ts`). `passwordSchema` was min 8;
+   the UI (accept/redeem forms) already required 12. Raised server to 12 so
+   the policy matches across surfaces.
+
+## Recommended follow-ups, ranked
+
+### P1 — ship this sprint
+
+**CSRF enforcement on mutating endpoints.** A `csrfToken` is generated and
+embedded in the session JWT (`apps/web/src/lib/auth.ts:55`) but no middleware
+checks an `X-CSRF-Token` header against it. `sameSite=lax` blocks most
+classical CSRF vectors, but the industry standard is defence in depth —
+double-submit pattern or header echo. Effort: ~2 hours, single middleware in
+the Next.js proxy layer.
+
+**MFA on `/login`.** `assertMfaIfRequired` exists but is only called from
+invite creation (`routes/v1/invitations.ts`). The Tenants table has a
+`mfa_required_for_admins` flag (`schema.sql:1593-1594`) that today does
+nothing at login. Should gate successful password verification on MFA enrol
+status for admins in mfa-required tenants. Effort: 1 day including TOTP
+enrolment UI.
+
+### P2 — backlog
+
+**Device fingerprint.** `auth.ts:321-322` does exact `(ip, user_agent)` match
+for known-device detection. Mobile clients rotate UA on each OS update and
+change IP on every Wi-Fi handoff, producing constant "new device" emails.
+Replace with a persistent `device_id` cookie + loose fingerprint.
+
+**Password breach check.** NIST SP 800-63B recommends comparing new passwords
+against HaveIBeenPwned's k-anonymous breach API. Currently any policy-passing
+password is accepted even if it's in the top-10k breached list.
+
+**Email trim pre-validation.** `emailSchema` runs `.email()` before
+`.transform()` so leading/trailing whitespace in pasted addresses fails
+validation. Reorder with a pre-transform pass (`.string().transform(trim).pipe(z.string().email())`).
+
+**Refresh token reuse detection.** If an already-revoked refresh token is
+presented, we return 401 but don't revoke the whole session family. An
+attacker who steals a refresh token and races the legitimate owner can keep
+one branch alive. Industry standard: revoke all sibling tokens when a
+revoked one is reused.
+
+**Session rotation on login.** Existing active sessions aren't invalidated
+when the user logs in again. Low impact since refresh rotation covers this
+on every /refresh cycle, but best practice is to kill the prior family.
+
+### P3 — nice to have
+
+- `HSTS` / `Strict-Transport-Security` header from the web layer (Vercel
+  already sets it, confirm for completeness).
+- `X-Frame-Options: DENY` on the auth pages to block clickjacking.
+- Move `SESSION_COOKIE` name to `__Host-larry_session` once `path=/` +
+  `secure` are guaranteed — unlocks extra browser-level isolation.
+- Add `/v1/auth/sessions` endpoint for users to view + revoke active devices.
+- Rotate JWT signing secret on a schedule, not just on compromise.
+
+## Out of scope for this pass
+- OAuth / Google SSO flow (`auth-google.ts`) — reviewed surface-level, no red
+  flags but deserves its own audit.
+- Workspace-level SSO (SAML/OIDC) — not yet implemented.
+- Session storage backend (currently stateless JWT cookie) — consider
+  moving refresh-token-id into the cookie for instant revocation.
+
+## Testing posture
+
+553/553 API tests green after the shipped fixes. `src/lib/validation.test.ts`
+added to lock in the tightened password policy so a future relaxation requires
+an explicit decision. Recommend extending `tests/auth-tenants-switch.test.ts`
+with a login-path test for case-insensitive email lookup when #PR merges.


### PR DESCRIPTION
## Context
End-to-end pass over the login stack the day before launch, measured
against OWASP ASVS L2 / NIST SP 800-63B. Full findings:
`docs/security/login-audit-2026-04-19.md`.

Takeaway: design is largely on-bar (bcrypt/rate-limit/lockout/rotation
all present). The biggest missing control is CSRF enforcement — noted
as P1 follow-up. This PR closes three concrete issues that matter for
launch.

## Three fixes
1. **Accept flow no longer silently takes over an active session.** When
   a signed-in user with the same email accepts an invite for a
   *different* tenant, they now see a yellow "you'll keep <current>"
   banner and must click a dedicated "Switch and accept" button. Prevents
   the confusing "I was just using Workspace A and now I'm stuck in B"
   moment. The public invitation preview (`GET /v1/orgs/invitations/:token`)
   now also returns `tenantId` so the web can detect the cross-tenant case.
2. **Email lookups are case-insensitive.** `routes/v1/auth.ts` login
   query + signup duplicate-check now use `lower(u.email) = lower($1)`.
   `emailSchema` already normalises new inputs, but any legacy mixed-case
   `users.email` row would have silently 401'd on login. Landmine closed.
3. **Password policy bumped to 12 chars.** `passwordSchema` was min 8,
   but the signup/accept/redeem UIs already enforced 12. Now the API is
   as strict as the UI. New unit tests in `src/lib/validation.test.ts`
   lock the policy in.

## Risk
Low. All three are strict tightenings or UX additions; no control
weakened. One invite-links test password bumped from 10 → 15 chars to
satisfy the stricter schema.

## Tests
- 553/553 API suite green.
- API typecheck clean.
- New: `src/lib/validation.test.ts` (7 assertions).

## Follow-ups (not in this PR)
- P1: CSRF middleware on the Next.js proxy.
- P1: MFA enforcement on `/login` for admins in mfa-required tenants.
- P2: device fingerprint, password breach check, email trim pre-validation,
  refresh-token reuse detection, session rotation on login.

See `docs/security/login-audit-2026-04-19.md` for ranked list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)