### PR TITLE
fix(auth): CSRF bootstrap fixes + P2 polish (audit follow-up)

### DIFF
--- a/apps/api/src/lib/email-quota.ts
+++ b/apps/api/src/lib/email-quota.ts
@@ -8,6 +8,7 @@ export type EmailKind =
   | "email_change_confirm"
   | "email_change_notify"
   | "new_device_alert"
+  | "refresh_reuse_alert"
   | "member_invite"
   | "briefing_digest"
   | "generic";
@@ -51,6 +52,7 @@ const LIMITS: Record<EmailKind, { hour: number; day: number }> = {
   email_change_confirm: { hour: 3,  day: 10 },
   email_change_notify:  { hour: 5,  day: 15 },
   new_device_alert:     { hour: 10, day: 30 },
+  refresh_reuse_alert:  { hour: 3,  day: 6  },
   member_invite:        { hour: 0,  day: 0 },
   briefing_digest:      { hour: 5,  day: 10 },
   generic:              { hour: 10, day: 30 },

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -265,6 +265,56 @@ export async function sendNewDeviceAlert(
   }
 }
 
+export interface RefreshReuseInfo {
+  ip?: string;
+  userAgent?: string;
+}
+
+// P2-1. Sent when a previously-revoked refresh token is replayed — either
+// a racing legit client (rare) or a stolen-token replay. We've already
+// nuked the whole session family at the call site; this email tells the
+// human to rotate their password.
+export async function sendRefreshReuseAlert(
+  to: string,
+  info: RefreshReuseInfo,
+  ctx?: EmailSendContext,
+): Promise<void> {
+  if (!isResendConfigured()) {
+    console.log("[email] RESEND_API_KEY not configured. Skipping refresh-reuse alert for %s", to);
+    return;
+  }
+  if (!(await guard("refresh_reuse_alert", to, ctx))) return;
+  const resend = getResend();
+  const frontendUrl = getFrontendUrl();
+  const details = [
+    info.userAgent && `<li><strong>Browser:</strong> ${escapeHtml(info.userAgent).slice(0, 120)}</li>`,
+    info.ip && `<li><strong>IP:</strong> ${escapeHtml(info.ip)}</li>`,
+  ]
+    .filter(Boolean)
+    .join("");
+
+  const { error } = await resend.emails.send({
+    from: FROM_NOREPLY,
+    to,
+    subject: "Unusual sign-in activity on your Larry account",
+    html: wrapHtml(`
+      <h1 style="font-size: 22px; font-weight: 700; letter-spacing: -0.03em; margin: 0 0 12px;">We signed you out of every device</h1>
+      <p style="font-size: 15px; color: #555; line-height: 1.6; margin: 0 0 16px;">
+        A previously-expired Larry session token was presented again just now. That usually means either a device has a stale session, or someone else got hold of it. Either way, every active Larry session for your account has been signed out as a precaution.
+      </p>
+      ${details ? `<ul style="font-size: 14px; color: #555; line-height: 1.8; padding-left: 20px; margin: 0 0 28px;">${details}</ul>` : ""}
+      <p style="font-size: 15px; color: #555; line-height: 1.6; margin: 0 0 28px;">
+        If you don't recognise this, reset your password immediately.
+      </p>
+      ${ctaButton(`${frontendUrl}/forgot-password`, "Reset your password")}
+    `),
+  });
+  if (error) {
+    console.error("[email] sendRefreshReuseAlert failed:", error);
+    throw new Error(`Failed to send refresh-reuse alert: ${error.message}`);
+  }
+}
+
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }

--- a/apps/api/src/lib/validation.test.ts
+++ b/apps/api/src/lib/validation.test.ts
@@ -34,4 +34,13 @@ describe("emailSchema", () => {
   it("rejects invalid emails", () => {
     expect(() => emailSchema.parse("not-an-email")).toThrow();
   });
+
+  it("trims leading/trailing whitespace before the email check", () => {
+    expect(emailSchema.parse("  hello@example.com  ")).toBe("hello@example.com");
+    expect(emailSchema.parse("\thello@example.com\n")).toBe("hello@example.com");
+  });
+
+  it("still rejects junk after trim", () => {
+    expect(() => emailSchema.parse("  not-an-email  ")).toThrow();
+  });
 });

--- a/apps/api/src/lib/validation.ts
+++ b/apps/api/src/lib/validation.ts
@@ -12,7 +12,11 @@ export const passwordSchema = z
   .regex(/[0-9]/, "Password must contain at least one number")
   .regex(/[^a-zA-Z0-9]/, "Password must contain at least one special character");
 
+// Trim + lowercase BEFORE running the RFC-ish email check. Reversing
+// the order means pasted addresses with stray whitespace ("  x@y.com ",
+// the iOS clipboard-with-trailing-newline bite) fail validation instead
+// of silently succeeding after normalisation.
 export const emailSchema = z
   .string()
-  .email("Invalid email address")
-  .transform((v) => v.trim().toLowerCase());
+  .transform((v) => v.trim().toLowerCase())
+  .pipe(z.string().email("Invalid email address"));

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -344,6 +344,18 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
       email: user.email,
     });
 
+    // P2-5: rotate sessions on re-login. Revoke any other currently-active
+    // refresh tokens for this (user, tenant) BEFORE issuing the new one.
+    // /refresh already rotates on each cycle, but a stale token sitting
+    // on an abandoned device extends the blast radius of a later theft —
+    // logging in should invalidate every prior browser/device session.
+    await fastify.db.query(
+      `UPDATE refresh_tokens
+          SET revoked_at = NOW()
+        WHERE user_id = $1 AND tenant_id = $2 AND revoked_at IS NULL`,
+      [user.id, user.tenant_id],
+    );
+
     const refreshToken = await issueRefreshToken(fastify, {
       userId: user.id,
       tenantId: user.tenant_id,
@@ -416,7 +428,44 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
     );
 
     const tokenRow = rows[0];
-    if (!tokenRow || tokenRow.revoked_at || new Date(tokenRow.expires_at) < new Date()) {
+    if (!tokenRow) {
+      return reply.unauthorized("Invalid refresh token.");
+    }
+    if (new Date(tokenRow.expires_at) < new Date()) {
+      return reply.unauthorized("Invalid refresh token.");
+    }
+    // P2-1: refresh-token reuse detection. A revoked token presented
+    // again means either the legitimate owner is racing a rotation (rare
+    // under our single-rotate-per-call design) or an attacker replayed a
+    // stolen token after we already rotated. Either way, burn the whole
+    // family for that (user, tenant): any currently-active token could
+    // be the attacker's branch. Audit + notify the user so they can reset
+    // credentials.
+    if (tokenRow.revoked_at) {
+      try {
+        await fastify.db.query(
+          `UPDATE refresh_tokens
+              SET revoked_at = NOW()
+            WHERE user_id = $1 AND tenant_id = $2 AND revoked_at IS NULL`,
+          [tokenRow.user_id, tokenRow.tenant_id],
+        );
+        await writeAuditLog(fastify.db, {
+          tenantId: tokenRow.tenant_id,
+          actorUserId: tokenRow.user_id,
+          actionType: "auth.refresh_reuse_detected",
+          objectType: "refresh_token",
+          objectId: tokenRow.id,
+          details: { reusedTokenId: tokenRow.id },
+        });
+        const { sendRefreshReuseAlert } = await import("../../lib/email.js");
+        await sendRefreshReuseAlert(
+          tokenRow.email,
+          { ip: request.ip, userAgent: request.headers["user-agent"] ?? "unknown" },
+          { userId: tokenRow.user_id, tenantId: tokenRow.tenant_id },
+        ).catch(() => {});
+      } catch {
+        /* non-fatal — still 401 below */
+      }
       return reply.unauthorized("Invalid refresh token.");
     }
 

--- a/apps/api/tests/auth-refresh-reuse.test.ts
+++ b/apps/api/tests/auth-refresh-reuse.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Fastify from "fastify";
+import sensible from "@fastify/sensible";
+import jwt from "@fastify/jwt";
+import { ZodError } from "zod";
+import type { Db } from "@larry/db";
+import { authRoutes } from "../src/routes/v1/auth.js";
+
+// P2-1 regression test. When a revoked refresh token is replayed, the
+// handler must:
+//   1. return 401
+//   2. nuke every active refresh token for the (user, tenant) pair
+//   3. write an `auth.refresh_reuse_detected` audit log
+//
+// We mock the email sender so the test doesn't hit Resend.
+vi.mock("../src/lib/email.js", () => ({
+  sendRefreshReuseAlert: vi.fn(async () => undefined),
+  sendNewDeviceAlert: vi.fn(async () => undefined),
+  sendPasswordResetEmail: vi.fn(async () => undefined),
+  sendVerificationEmail: vi.fn(async () => undefined),
+  sendEmailChangeConfirmation: vi.fn(async () => undefined),
+  sendEmailChangeNotification: vi.fn(async () => undefined),
+  sendMemberInviteEmail: vi.fn(async () => undefined),
+  sendBriefingDigestEmail: vi.fn(async () => undefined),
+}));
+
+const TENANT = "11111111-1111-4111-8111-111111111111";
+const USER = "33333333-3333-4333-8333-333333333333";
+
+interface AuditCall {
+  sql: string;
+  args: unknown[];
+}
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  const calls: AuditCall[] = [];
+  const auditCalls: Array<Record<string, unknown>> = [];
+
+  // Refresh-token lookup row — revoked_at is populated so the handler
+  // treats this as a REUSE attempt.
+  const revokedTokenRow = {
+    id: "tok-1",
+    tenant_id: TENANT,
+    user_id: USER,
+    role: "member" as const,
+    email: "victim@example.com",
+    expires_at: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+    revoked_at: new Date().toISOString(),
+  };
+
+  const dbQuery = vi.fn(async (sql: string, args: unknown[] = []) => {
+    calls.push({ sql, args });
+    if (/FROM refresh_tokens rt/i.test(sql)) return [revokedTokenRow];
+    if (/FROM audit_log/i.test(sql)) return [];
+    return [];
+  });
+  const dbQueryTenant = vi.fn(async (_tenant: string, sql: string, args: unknown[] = []) => {
+    calls.push({ sql, args });
+    if (/FROM audit_log/i.test(sql)) return [];
+    return [];
+  });
+
+  app.decorate("db", {
+    query: dbQuery,
+    queryTenant: dbQueryTenant,
+    tx: vi.fn(async (fn: (c: unknown) => unknown) =>
+      fn({ query: vi.fn(async () => ({ rows: [], rowCount: 1 })) }),
+    ),
+  } as unknown as Db);
+  app.decorate("config", { ACCESS_TOKEN_TTL: "15m", REFRESH_TOKEN_TTL: "30d" } as never);
+  await app.register(jwt, { secret: "test-secret-minimum-length-for-jwt-xxxx" });
+  app.decorate("authenticate", async () => undefined);
+  app.decorate("requireRole", () => async () => undefined);
+  app.setErrorHandler((error, _req, reply) => {
+    if (error instanceof ZodError) {
+      return reply.status(400).send({ statusCode: 400, message: error.issues.map((i) => i.message).join(". ") + "." });
+    }
+    const status = (error as Error & { statusCode?: number }).statusCode ?? 500;
+    return reply.status(status).send({ statusCode: status, message: error.message });
+  });
+  await app.register(sensible);
+  await app.register(authRoutes, { prefix: "/auth" });
+  await app.ready();
+  return { app, dbQuery, calls, auditCalls };
+}
+
+const apps: Array<Awaited<ReturnType<typeof buildApp>>["app"]> = [];
+afterEach(async () => {
+  while (apps.length) await apps.pop()!.close();
+  vi.clearAllMocks();
+});
+
+describe("POST /auth/refresh — revoked token reuse", () => {
+  it("returns 401 and revokes every active refresh token for the user+tenant", async () => {
+    const { app, calls } = await buildApp();
+    apps.push(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/auth/refresh",
+      payload: { refreshToken: "stolen-or-replayed", tenantId: TENANT },
+    });
+
+    expect(res.statusCode).toBe(401);
+
+    // Should have issued the family-nuke UPDATE
+    const nukeCalls = calls.filter(
+      (c) =>
+        /UPDATE refresh_tokens/i.test(c.sql) &&
+        /revoked_at = NOW\(\)/i.test(c.sql) &&
+        /WHERE user_id = \$1 AND tenant_id = \$2 AND revoked_at IS NULL/i.test(c.sql),
+    );
+    expect(nukeCalls.length).toBeGreaterThanOrEqual(1);
+    expect(nukeCalls[0].args).toEqual([USER, TENANT]);
+
+    // Should have written an audit log entry for refresh_reuse_detected
+    const auditInserts = calls.filter(
+      (c) => /INSERT INTO audit_log/i.test(c.sql) && c.args.includes("auth.refresh_reuse_detected"),
+    );
+    expect(auditInserts.length).toBe(1);
+  });
+});

--- a/apps/web/src/app/api/auth/dev-login/route.ts
+++ b/apps/web/src/app/api/auth/dev-login/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
-import { createSessionToken, sessionCookieOptions, AppSession } from "@/lib/auth";
+import {
+  createSessionToken,
+  csrfCookieOptions,
+  sessionCookieOptions,
+  AppSession,
+} from "@/lib/auth";
 
 const allowed = process.env.ALLOW_DEV_AUTH_BYPASS === "true";
 
@@ -65,8 +70,9 @@ export async function POST() {
     authMode: "dev",
   };
 
-  const token = await createSessionToken(session);
+  const { token, csrfToken } = await createSessionToken(session);
   const response = NextResponse.json({ success: true, userId: session.userId });
   response.cookies.set(sessionCookieOptions(token));
+  response.cookies.set(csrfCookieOptions(csrfToken));
   return response;
 }

--- a/apps/web/src/app/api/auth/google/complete/route.ts
+++ b/apps/web/src/app/api/auth/google/complete/route.ts
@@ -1,6 +1,10 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { createSessionToken, sessionCookieOptions } from "@/lib/auth";
+import {
+  createSessionToken,
+  csrfCookieOptions,
+  sessionCookieOptions,
+} from "@/lib/auth";
 
 /**
  * Verify the HMAC-signed one-time code from the API's Google OAuth callback.
@@ -77,7 +81,7 @@ export async function GET(req: NextRequest) {
     const refreshToken = typeof payload.refreshToken === "string" ? payload.refreshToken : undefined;
     const isNewUser = payload.isNewUser === true;
 
-    const sessionToken = await createSessionToken({
+    const { token: sessionToken, csrfToken } = await createSessionToken({
       userId,
       email,
       tenantId,
@@ -90,6 +94,7 @@ export async function GET(req: NextRequest) {
     const destination = isNewUser ? "/signup?step=role" : "/workspace";
     const res = NextResponse.redirect(new URL(destination, req.url));
     res.cookies.set(sessionCookieOptions(sessionToken));
+    res.cookies.set(csrfCookieOptions(csrfToken));
     return res;
   } catch (err) {
     console.error("[google/complete]", err);

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
   createSessionToken,
+  csrfCookieOptions,
   normalizeEmail,
   sessionCookieOptions,
 } from "@/lib/auth";
@@ -101,7 +102,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: GENERIC_ERROR }, { status: 401 });
     }
 
-    const token = await createSessionToken({
+    const { token, csrfToken } = await createSessionToken({
       userId: payload.user.id,
       email: payload.user.email,
       tenantId: payload.user.tenantId,
@@ -113,6 +114,7 @@ export async function POST(req: NextRequest) {
     });
     const res = NextResponse.json({ success: true });
     res.cookies.set(sessionCookieOptions(token));
+    res.cookies.set(csrfCookieOptions(csrfToken));
     return res;
   } catch (err) {
     console.error("[login]", err);

--- a/apps/web/src/app/api/auth/signup/route.ts
+++ b/apps/web/src/app/api/auth/signup/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
   createSessionToken,
+  csrfCookieOptions,
   normalizeEmail,
   sessionCookieOptions,
 } from "@/lib/auth";
@@ -113,7 +114,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const token = await createSessionToken({
+    const { token, csrfToken } = await createSessionToken({
       userId: payload.user.id,
       email: payload.user.email,
       tenantId: payload.user.tenantId,
@@ -125,6 +126,10 @@ export async function POST(req: NextRequest) {
     });
     const res = NextResponse.json({ success: true }, { status: 201 });
     res.cookies.set(sessionCookieOptions(token));
+    // Mirror the session's csrfToken into a readable cookie so the
+    // signup wizard's subsequent mutating /api/** calls (invitations,
+    // project create) pass middleware CSRF validation.
+    res.cookies.set(csrfCookieOptions(csrfToken));
     return res;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/apps/web/src/app/api/auth/switch-tenant/route.ts
+++ b/apps/web/src/app/api/auth/switch-tenant/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import {
   createSessionToken,
+  csrfCookieOptions,
   getSession,
   sessionCookieOptions,
 } from "@/lib/auth";
@@ -51,7 +52,7 @@ export async function POST(request: NextRequest) {
 
   // Re-mint the iron-session cookie so the next request proxies against the
   // new tenant. Mirrors /api/auth/login.
-  const token = await createSessionToken({
+  const { token, csrfToken } = await createSessionToken({
     userId: data.user.id,
     email: data.user.email,
     tenantId: data.user.tenantId,
@@ -67,5 +68,6 @@ export async function POST(request: NextRequest) {
     role: data.user.role,
   });
   res.cookies.set(sessionCookieOptions(token));
+  res.cookies.set(csrfCookieOptions(csrfToken));
   return res;
 }

--- a/apps/web/src/app/api/invitations/[token]/accept/route.ts
+++ b/apps/web/src/app/api/invitations/[token]/accept/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createSessionToken, sessionCookieOptions } from "@/lib/auth";
+import {
+  createSessionToken,
+  csrfCookieOptions,
+  sessionCookieOptions,
+} from "@/lib/auth";
 
 const API_BASE = process.env.LARRY_API_BASE_URL ?? "http://localhost:8080";
 
@@ -52,7 +56,7 @@ export async function POST(
 
   // Mint the iron-session cookie so the invitee lands logged in on /workspace.
   // Mirrors apps/web/src/app/api/auth/login/route.ts:104-115.
-  const sessionToken = await createSessionToken({
+  const { token: sessionToken, csrfToken } = await createSessionToken({
     userId: payload.userId,
     email: payload.email,
     tenantId: payload.tenantId,
@@ -69,5 +73,6 @@ export async function POST(
     tenantId: payload.tenantId,
   });
   res.cookies.set(sessionCookieOptions(sessionToken));
+  res.cookies.set(csrfCookieOptions(csrfToken));
   return res;
 }

--- a/apps/web/src/app/api/invite-links/[token]/redeem/route.ts
+++ b/apps/web/src/app/api/invite-links/[token]/redeem/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createSessionToken, sessionCookieOptions } from "@/lib/auth";
+import {
+  createSessionToken,
+  csrfCookieOptions,
+  sessionCookieOptions,
+} from "@/lib/auth";
 
 const API_BASE = process.env.LARRY_API_BASE_URL ?? "http://localhost:8080";
 
@@ -57,7 +61,7 @@ export async function POST(
     email = undefined;
   }
 
-  const sessionToken = await createSessionToken({
+  const { token: sessionToken, csrfToken } = await createSessionToken({
     userId: payload.userId,
     email,
     tenantId: payload.tenantId,
@@ -72,5 +76,6 @@ export async function POST(
     tenantId: payload.tenantId,
   });
   res.cookies.set(sessionCookieOptions(sessionToken));
+  res.cookies.set(csrfCookieOptions(csrfToken));
   return res;
 }

--- a/apps/web/src/lib/api-session.ts
+++ b/apps/web/src/lib/api-session.ts
@@ -5,7 +5,11 @@
  */
 
 import type { AppSession } from "@/lib/auth";
-import { createSessionToken, sessionCookieOptions } from "@/lib/auth";
+import {
+  createSessionToken,
+  csrfCookieOptions,
+  sessionCookieOptions,
+} from "@/lib/auth";
 import { cookies } from "next/headers";
 
 interface ApiRefreshResponse {
@@ -95,7 +99,8 @@ export async function refreshApiSession(
 // ── Persist updated session cookie ──────────────────────────────────────────
 
 export async function persistRefreshedSession(session: AppSession): Promise<void> {
-  const token = await createSessionToken(session);
+  const { token, csrfToken } = await createSessionToken(session);
   const store = await cookies();
   store.set(sessionCookieOptions(token));
+  store.set(csrfCookieOptions(csrfToken));
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -42,7 +42,12 @@ export function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
 }
 
-export async function createSessionToken(session: AppSession): Promise<string> {
+export const CSRF_COOKIE = "larry_csrf";
+
+export async function createSessionToken(
+  session: AppSession,
+): Promise<{ token: string; csrfToken: string }> {
+  const csrfToken = session.csrfToken ?? randomUUID();
   const payload: SessionJwtPayload = {
     sub: session.userId,
     email: session.email,
@@ -52,14 +57,16 @@ export async function createSessionToken(session: AppSession): Promise<string> {
     apiAccessToken: session.apiAccessToken,
     apiRefreshToken: session.apiRefreshToken,
     authMode: session.authMode,
-    csrfToken: session.csrfToken ?? randomUUID(),
+    csrfToken,
   };
 
-  return new SignJWT(payload)
+  const token = await new SignJWT(payload)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime(`${SESSION_DURATION_SECS}s`)
     .sign(getSecret());
+
+  return { token, csrfToken };
 }
 
 export async function verifySessionToken(
@@ -119,6 +126,22 @@ export function clearSessionCookieOptions() {
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax" as const,
     maxAge: 0,
+    path: "/",
+  };
+}
+
+// Readable (non-httpOnly) CSRF double-submit cookie. Paired with the
+// session cookie wherever a session is minted/rotated so the client
+// window.fetch patch can echo it back as X-CSRF-Token on mutating
+// /api/** requests (validated by middleware apiMiddleware).
+export function csrfCookieOptions(csrfToken: string) {
+  return {
+    name: CSRF_COOKIE,
+    value: csrfToken,
+    httpOnly: false,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    maxAge: SESSION_DURATION_SECS,
     path: "/",
   };
 }

--- a/apps/web/src/lib/workspace-proxy.ts
+++ b/apps/web/src/lib/workspace-proxy.ts
@@ -1,5 +1,9 @@
 import type { AppSession } from "@/lib/auth";
-import { createSessionToken, sessionCookieOptions } from "@/lib/auth";
+import {
+  createSessionToken,
+  csrfCookieOptions,
+  sessionCookieOptions,
+} from "@/lib/auth";
 import { cookies } from "next/headers";
 import {
   getApiBaseUrl,
@@ -52,9 +56,12 @@ export async function persistSession(session: AppSession): Promise<void> {
   // update paths should all mint a fresh token. createSessionToken
   // defaults to a new randomUUID when csrfToken is undefined.
   const { csrfToken: _oldCsrf, ...rest } = session;
-  const token = await createSessionToken(rest);
+  const { token, csrfToken } = await createSessionToken(rest);
   const store = await cookies();
   store.set(sessionCookieOptions(token));
+  // Keep larry_csrf in sync with the rotated session csrfToken, else
+  // the client's next mutating /api/** call will 403.
+  store.set(csrfCookieOptions(csrfToken));
 }
 
 // ── Main proxy function ─────────────────────────────────────────────────────

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -7,6 +7,21 @@ const SESSION_COOKIE = "larry_session";
 const SESSION_DURATION_SECS = 24 * 60 * 60; // 24 hours
 const SLIDING_REFRESH_THRESHOLD_SECS = 12 * 60 * 60; // reissue if < 12h remaining
 
+// Pages that must be reachable without a session. Still run through
+// pageMiddleware so that when a session DOES exist (e.g. right after
+// /api/auth/signup or /api/auth/google/complete minted one), we mirror
+// the session's csrfToken into the readable larry_csrf cookie before
+// the signup wizard fires its first mutating /api/** call.
+const PUBLIC_AUTH_PAGES: ReadonlySet<string> = new Set([
+  "/signup",
+  "/login",
+  "/forgot-password",
+  "/reset-password",
+  "/verify-email",
+  "/verify-email-required",
+  "/confirm-email-change",
+]);
+
 export async function middleware(req: NextRequest) {
   if (req.nextUrl.pathname.startsWith("/api/")) {
     return apiMiddleware(req);
@@ -62,8 +77,12 @@ async function apiMiddleware(req: NextRequest) {
 // ── Page-level session gate (existing behaviour) ────────────────────────────
 async function pageMiddleware(req: NextRequest) {
   const token = req.cookies.get(SESSION_COOKIE)?.value;
+  const isPublicAuth = PUBLIC_AUTH_PAGES.has(req.nextUrl.pathname);
 
   if (!token) {
+    // Unauth'd visit to a public auth page (signup, login, etc.) — just
+    // render. No CSRF cookie to mirror yet.
+    if (isPublicAuth) return NextResponse.next();
     return NextResponse.redirect(new URL("/login", req.url));
   }
 
@@ -72,7 +91,9 @@ async function pageMiddleware(req: NextRequest) {
     secret = getSessionSecret();
   } catch {
     // SESSION_SECRET misconfigured in production — fail closed
-    const res = NextResponse.redirect(new URL("/login", req.url));
+    const res = isPublicAuth
+      ? NextResponse.next()
+      : NextResponse.redirect(new URL("/login", req.url));
     res.cookies.set({ name: SESSION_COOKIE, value: "", maxAge: 0, path: "/" });
     return res;
   }
@@ -118,8 +139,12 @@ async function pageMiddleware(req: NextRequest) {
 
     return res;
   } catch {
-    // Token expired or tampered — clear and redirect
-    const res = NextResponse.redirect(new URL("/login", req.url));
+    // Token expired or tampered — clear cookie. On public auth pages
+    // just render (no redirect-loop on /login itself); elsewhere send
+    // the user to /login.
+    const res = isPublicAuth
+      ? NextResponse.next()
+      : NextResponse.redirect(new URL("/login", req.url));
     res.cookies.set({ name: SESSION_COOKIE, value: "", maxAge: 0, path: "/" });
     return res;
   }
@@ -131,5 +156,12 @@ export const config = {
     "/workspace/:path*",
     "/admin/:path*",
     "/api/:path*",
+    "/signup",
+    "/login",
+    "/forgot-password",
+    "/reset-password",
+    "/verify-email",
+    "/verify-email-required",
+    "/confirm-email-change",
   ],
 };

--- a/docs/security/login-audit-2026-04-19.md
+++ b/docs/security/login-audit-2026-04-19.md
@@ -68,6 +68,11 @@ enrolment UI.
 
 ### P2 — backlog
 
+**✅ Shipped in `fix/auth-p2-polish`:**
+- Email trim+normalise ordering: `emailSchema` now `.transform(trim+lower).pipe(.email())` so pasted addresses with stray whitespace validate correctly instead of silently failing.
+- Refresh-token reuse detection: `/v1/auth/refresh` now, when a revoked token is replayed, revokes every active refresh token for `(user_id, tenant_id)`, writes an `auth.refresh_reuse_detected` audit log, and emails the user. Stolen-token replay can no longer keep a quiet parallel branch alive.
+- Session rotation on re-login: `/v1/auth/login` now revokes every prior active refresh token for `(user_id, tenant_id)` before issuing the new one. Stale sessions on forgotten devices no longer linger.
+
 **Device fingerprint.** `auth.ts:321-322` does exact `(ip, user_agent)` match
 for known-device detection. Mobile clients rotate UA on each OS update and
 change IP on every Wi-Fi handoff, producing constant "new device" emails.


### PR DESCRIPTION
Launch-day auth hardening. Bundles four commits — all small, all audit-doc annotated, all on the same auth surface.

## CSRF bootstrap fixes (post-#128 follow-ups)

**df44580** — set `larry_csrf` cookie on /signup so the wizard can pass CSRF.
The signup wizard fires mutating `/api/**` calls (step-1 invites, step-2 project create) from `/signup` itself, before the user ever navigates to `/workspace`. Middleware's matcher didn't include public auth pages, so the cookie was never written and subsequent mutating calls 403'd.

**a2795bc** — set `larry_csrf` cookie whenever a session is minted/rotated.
Complementary: co-mint the CSRF cookie in the same response that sets the session cookie, at every mint/rotate point, so state-only client transitions (step 0→1, step 1→2, Google signup landing on `/signup?step=role`) never see a missing cookie.

## P2 backlog items from `docs/security/login-audit-2026-04-19.md`

**010c4af** — three P2 login hardening wins.

- **P2-1 Refresh-token reuse detection** — `/v1/auth/refresh` now, when a revoked token is replayed, revokes every active refresh token for `(user_id, tenant_id)`, writes an `auth.refresh_reuse_detected` audit log, and emails the user. Closes the race where a stolen-token replay keeps a parallel session alive after rotation.
- **P2-5 Session rotation on re-login** — `/v1/auth/login` now revokes every prior active refresh token for `(user_id, tenant_id)` before issuing new ones. Logging in now means "every other session is gone."
- **P2-4 Email trim + normalisation order** — `emailSchema` was `.string().email().transform(trim+lower)`, so pasted addresses with stray whitespace failed validation silently. Reordered to `.transform(trim+lower).pipe(.email())`.
- New `sendRefreshReuseAlert` email + `refresh_reuse_alert` EmailKind with per-user caps 3/h + 6/d.
- New regression test `apps/api/tests/auth-refresh-reuse.test.ts` verifying 401 + family-nuke UPDATE + audit log insert.

## Verification
- 556/556 API tests green, typecheck clean
- Audit doc `docs/security/login-audit-2026-04-19.md` P2 section now leads with a "shipped" block.

## Test plan
- [ ] CI green
- [ ] Post-deploy: complete a fresh email signup → click through step 1 (invites) and step 2 (project create) without seeing "Invalid CSRF token" anywhere.
- [ ] Complete a Google signup → same check on the `/signup?step=role` landing.
- [ ] Log in as launch-test, then immediately log in again in a second tab → first tab's refresh-token rotation should 401 (family nuked by re-login).
- [ ] `curl -X POST /api/auth/forgot-password` with body `{"email":"  test@example.com  "}` → 200 (trim path).

Remaining P2 backlog: device fingerprint cookie, HIBP breach check, auth-page header tightening. P1-2 MFA deferred to a dedicated session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)