### PR TITLE
fix(auth): HIBP password breach check on all password-setting paths (P2-2)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import { createQueuePublisher } from "./services/queue.js";
 import { getRedis, closeRedis } from "./lib/redis.js";
 import { LLMQuotaError } from "./lib/llm-budget.js";
 import { EmailQuotaError } from "./lib/email-quota.js";
+import { PasswordBreachedError } from "./lib/password-breach.js";
 
 export async function createApp() {
   const env = getApiEnv();
@@ -92,6 +93,13 @@ export async function createApp() {
         statusCode: 429,
         error: "Too Many Requests",
         message: "Email send limit reached. Please try again later.",
+      });
+    }
+    if (error instanceof PasswordBreachedError) {
+      return reply.status(400).send({
+        statusCode: 400,
+        error: "Password Compromised",
+        message: error.message,
       });
     }
     // Let Fastify handle everything else (including @fastify/sensible errors)

--- a/apps/api/src/lib/password-breach.test.ts
+++ b/apps/api/src/lib/password-breach.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  assertPasswordNotBreached,
+  getBreachCount,
+  PasswordBreachedError,
+  __resetBreachCacheForTests,
+} from "./password-breach.js";
+
+// SHA1("password") = 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8
+// Prefix "5BAA6", suffix "1E4C9B93F3F0682250B6CF8331B7EE68FD8"
+const PASSWORD_HASH_PREFIX = "5BAA6";
+const PASSWORD_HASH_SUFFIX = "1E4C9B93F3F0682250B6CF8331B7EE68FD8";
+
+// SHA1("zX9#qW7!LpB3nM2F") — a reasonably unique passphrase, should
+// return 0 in our mocked "prefix not found" response.
+const UNIQUE_SUFFIX = "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEAD";
+
+function makeFetcher(body: string, status = 200): typeof fetch {
+  return vi.fn(async () => new Response(body, { status })) as unknown as typeof fetch;
+}
+
+describe("getBreachCount", () => {
+  beforeEach(() => {
+    __resetBreachCacheForTests();
+  });
+
+  it("returns the breach count for a matching suffix", async () => {
+    const body = [
+      `${PASSWORD_HASH_SUFFIX}:9876543`,
+      "OTHER_SUFFIX_000000000000000000000000000:42",
+    ].join("\r\n");
+    const count = await getBreachCount("password", { fetcher: makeFetcher(body) });
+    expect(count).toBe(9876543);
+  });
+
+  it("returns 0 when no row matches the suffix", async () => {
+    const body = "OTHER_SUFFIX_000000000000000000000000000:42";
+    const count = await getBreachCount("password", { fetcher: makeFetcher(body) });
+    expect(count).toBe(0);
+  });
+
+  it("caches responses by prefix", async () => {
+    const body = `${PASSWORD_HASH_SUFFIX}:1`;
+    const fetcher = makeFetcher(body);
+    await getBreachCount("password", { fetcher });
+    await getBreachCount("password", { fetcher });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after cache TTL expires", async () => {
+    const body = `${PASSWORD_HASH_SUFFIX}:1`;
+    const fetcher = makeFetcher(body);
+    let now = 1_000_000;
+    await getBreachCount("password", { fetcher, now: () => now });
+    now += 61 * 60 * 1000; // > 1h
+    await getBreachCount("password", { fetcher, now: () => now });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends only the first 5 hex chars to HIBP", async () => {
+    const fetcher = vi.fn(async (url: string | URL) => {
+      expect(String(url)).toBe(`https://api.pwnedpasswords.com/range/${PASSWORD_HASH_PREFIX}`);
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+    await getBreachCount("password", { fetcher });
+  });
+});
+
+describe("assertPasswordNotBreached", () => {
+  beforeEach(() => {
+    __resetBreachCacheForTests();
+  });
+
+  it("throws PasswordBreachedError when password is in HIBP", async () => {
+    const body = `${PASSWORD_HASH_SUFFIX}:9876543`;
+    await expect(
+      assertPasswordNotBreached("password", { fetcher: makeFetcher(body) }),
+    ).rejects.toBeInstanceOf(PasswordBreachedError);
+  });
+
+  it("passes when password suffix not in range response", async () => {
+    const body = `${UNIQUE_SUFFIX}:1`;
+    await expect(
+      assertPasswordNotBreached("password", { fetcher: makeFetcher(body) }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows transport errors (fails open)", async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+    await expect(
+      assertPasswordNotBreached("anything", { fetcher }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows non-2xx responses (fails open)", async () => {
+    const fetcher = makeFetcher("Bad Gateway", 502);
+    await expect(
+      assertPasswordNotBreached("anything", { fetcher }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("respects minCount to allow low-occurrence passwords through", async () => {
+    const body = `${PASSWORD_HASH_SUFFIX}:3`;
+    await expect(
+      assertPasswordNotBreached("password", {
+        fetcher: makeFetcher(body),
+        minCount: 10,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      assertPasswordNotBreached("password", {
+        fetcher: makeFetcher(body),
+        minCount: 1,
+      }),
+    ).rejects.toBeInstanceOf(PasswordBreachedError);
+  });
+});

--- a/apps/api/src/lib/password-breach.ts
+++ b/apps/api/src/lib/password-breach.ts
@@ -1,0 +1,134 @@
+import { createHash } from "node:crypto";
+
+// NIST SP 800-63B recommends rejecting passwords that appear in breach
+// corpora. HaveIBeenPwned's Pwned Passwords range API exposes this
+// privacy-preservingly: SHA-1 the password, send only the first 5 hex
+// chars, get back the list of full hashes matching that prefix. The
+// full password (or full hash) never leaves our process.
+//
+// Docs: https://haveibeenpwned.com/API/v3#PwnedPasswords
+//
+// P2-2, login audit 2026-04-19.
+
+const HIBP_RANGE_URL = "https://api.pwnedpasswords.com/range/";
+const REQUEST_TIMEOUT_MS = 2500;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1h
+
+// In-memory prefix cache (per-instance). HIBP already serves Cache-Control,
+// but reaching it adds ~100ms and the prefix space (16^5 ≈ 1M buckets)
+// means the realistic working set for one Fastify instance is tiny.
+const cache = new Map<string, { body: string; expiresAt: number }>();
+
+export class PasswordBreachedError extends Error {
+  readonly count: number;
+  constructor(count: number) {
+    super(
+      "This password has appeared in a known data breach. Please choose a different one.",
+    );
+    this.name = "PasswordBreachedError";
+    this.count = count;
+  }
+}
+
+export interface CheckOptions {
+  /**
+   * Minimum occurrence count to treat as "breached". Passwords that
+   * appear exactly once in HIBP could plausibly be a user who got
+   * their own account breached elsewhere — rejecting those adds
+   * friction without much value. Threshold of 1 = reject anything
+   * in HIBP at all; default is 1 (strictest).
+   */
+  minCount?: number;
+  /** Override fetch for testing. */
+  fetcher?: typeof fetch;
+  /** Override the current time for cache tests. */
+  now?: () => number;
+}
+
+function sha1Hex(input: string): string {
+  return createHash("sha1").update(input, "utf8").digest("hex").toUpperCase();
+}
+
+async function fetchPrefix(
+  prefix: string,
+  fetcher: typeof fetch,
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetcher(`${HIBP_RANGE_URL}${prefix}`, {
+      headers: { "Add-Padding": "true" },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`HIBP responded ${res.status}`);
+    }
+    return await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function getBreachCount(
+  password: string,
+  opts: CheckOptions = {},
+): Promise<number> {
+  const fetcher = opts.fetcher ?? fetch;
+  const now = opts.now ?? Date.now;
+
+  const hash = sha1Hex(password);
+  const prefix = hash.slice(0, 5);
+  const suffix = hash.slice(5);
+
+  const cached = cache.get(prefix);
+  let body: string;
+  if (cached && cached.expiresAt > now()) {
+    body = cached.body;
+  } else {
+    body = await fetchPrefix(prefix, fetcher);
+    cache.set(prefix, { body, expiresAt: now() + CACHE_TTL_MS });
+  }
+
+  // Response format: one "SUFFIX:count" per line, CRLF-separated.
+  // Suffixes are uppercase. Lines with count=0 are HIBP padding entries
+  // (Add-Padding: true); we only care about rows whose suffix matches.
+  for (const line of body.split(/\r?\n/)) {
+    const idx = line.indexOf(":");
+    if (idx < 0) continue;
+    if (line.slice(0, idx) === suffix) {
+      const count = Number.parseInt(line.slice(idx + 1), 10);
+      return Number.isFinite(count) ? count : 0;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Throws PasswordBreachedError if the password is in HIBP.
+ *
+ * Non-fatal on transport / HIBP-side failures — better to let a user
+ * set a password than brick signup because HIBP is down. Failures are
+ * logged by the caller.
+ */
+export async function assertPasswordNotBreached(
+  password: string,
+  opts: CheckOptions = {},
+): Promise<void> {
+  const min = opts.minCount ?? 1;
+  try {
+    const count = await getBreachCount(password, opts);
+    if (count >= min) {
+      throw new PasswordBreachedError(count);
+    }
+  } catch (err) {
+    if (err instanceof PasswordBreachedError) throw err;
+    // Transport / timeout / non-2xx — swallow. Signup shouldn't fail
+    // because an external service is flaky.
+    return;
+  }
+}
+
+/** Test-only. Clears the prefix cache between runs. */
+export function __resetBreachCacheForTests(): void {
+  cache.clear();
+}

--- a/apps/api/src/routes/v1/auth-account.ts
+++ b/apps/api/src/routes/v1/auth-account.ts
@@ -12,6 +12,7 @@ import {
   sendEmailChangeNotification,
 } from "../../lib/email.js";
 import { passwordSchema } from "../../lib/validation.js";
+import { assertPasswordNotBreached } from "../../lib/password-breach.js";
 
 const EMAIL_CHANGE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -118,6 +119,8 @@ export const authAccountRoutes: FastifyPluginAsync = async (fastify) => {
         }
       }
       // If OAuth-only (null password_hash), skip currentPassword check
+
+      await assertPasswordNotBreached(body.newPassword);
 
       // Hash and update
       const newHash = await hashPassword(body.newPassword);

--- a/apps/api/src/routes/v1/auth-password-reset.ts
+++ b/apps/api/src/routes/v1/auth-password-reset.ts
@@ -4,6 +4,7 @@ import { generateSecureToken, hashPassword, hashToken } from "../../lib/auth.js"
 import { writeAuditLog } from "../../lib/audit.js";
 import { sendPasswordResetEmail } from "../../lib/email.js";
 import { emailSchema, passwordSchema } from "../../lib/validation.js";
+import { assertPasswordNotBreached } from "../../lib/password-breach.js";
 
 const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -147,6 +148,8 @@ export const authPasswordResetRoutes: FastifyPluginAsync = async (fastify) => {
     if (new Date(tokenRow.expires_at) < new Date()) {
       return reply.badRequest("This reset link has expired. Please request a new one.");
     }
+
+    await assertPasswordNotBreached(body.newPassword);
 
     // Hash the new password
     const passwordHash = await hashPassword(body.newPassword);

--- a/apps/api/src/routes/v1/auth.ts
+++ b/apps/api/src/routes/v1/auth.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { generateSecureToken, hashPassword, hashToken, issueAccessToken, issueRefreshToken, verifyPassword } from "../../lib/auth.js";
+import { assertPasswordNotBreached } from "../../lib/password-breach.js";
 import { writeAuditLog } from "../../lib/audit.js";
 import { emailSchema, passwordSchema } from "../../lib/validation.js";
 import { sendVerificationEmail, sendMemberInviteEmail } from "../../lib/email.js";
@@ -70,6 +71,8 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
     if (existing.length > 0) {
       return reply.code(409).send({ error: "An account with this email already exists." });
     }
+
+    await assertPasswordNotBreached(body.password);
 
     const passwordHash = await hashPassword(body.password);
 

--- a/apps/api/src/routes/v1/invitations.ts
+++ b/apps/api/src/routes/v1/invitations.ts
@@ -14,6 +14,7 @@ import { emailSchema, passwordSchema } from "../../lib/validation.js";
 import { sendMemberInviteEmail } from "../../lib/email.js";
 import { writeAuditLog } from "../../lib/audit.js";
 import { hashPassword, issueAccessToken, issueRefreshToken } from "../../lib/auth.js";
+import { assertPasswordNotBreached } from "../../lib/password-breach.js";
 import { assertSeatAvailable, SeatCapReachedError } from "../../lib/seat-cap.js";
 import { assertMfaIfRequired, MfaEnrollmentRequiredError } from "../../lib/mfa-gate.js";
 import { getProjectMembershipAccess, upsertProjectMembership } from "../../lib/project-memberships.js";
@@ -310,6 +311,7 @@ export const invitationsRoutes: FastifyPluginAsync = async (fastify) => {
             "Password is required to create an account for this invitation.",
           );
         }
+        await assertPasswordNotBreached(body.password);
         const passwordHash = await hashPassword(body.password);
         const displayName = body.displayName?.trim() || inv.email.split("@")[0];
         const ins = await client.query<{ id: string }>(

--- a/apps/api/src/routes/v1/invite-links.ts
+++ b/apps/api/src/routes/v1/invite-links.ts
@@ -14,6 +14,7 @@ import { getProjectMembershipAccess } from "../../lib/project-memberships.js";
 import { emailSchema, passwordSchema } from "../../lib/validation.js";
 import { writeAuditLog } from "../../lib/audit.js";
 import { hashPassword, issueAccessToken, issueRefreshToken, verifyPassword } from "../../lib/auth.js";
+import { assertPasswordNotBreached } from "../../lib/password-breach.js";
 import { assertSeatAvailable, SeatCapReachedError } from "../../lib/seat-cap.js";
 
 const ProjectRoleEnum = z.enum(["owner", "editor", "viewer"]);
@@ -227,6 +228,7 @@ export const inviteLinksRoutes: FastifyPluginAsync = async (fastify) => {
         }
         userId = existing.rows[0].id;
       } else {
+        await assertPasswordNotBreached(body.password);
         const passwordHash = await hashPassword(body.password);
         const displayName = body.displayName?.trim() || body.email.split("@")[0];
         const ins = await client.query<{ id: string }>(

--- a/docs/security/login-audit-2026-04-19.md
+++ b/docs/security/login-audit-2026-04-19.md
@@ -68,33 +68,18 @@ enrolment UI.
 
 ### P2 — backlog
 
-**✅ Shipped in `fix/auth-p2-polish`:**
+**✅ Shipped in `fix/auth-p2-polish` (PR #129):**
 - Email trim+normalise ordering: `emailSchema` now `.transform(trim+lower).pipe(.email())` so pasted addresses with stray whitespace validate correctly instead of silently failing.
 - Refresh-token reuse detection: `/v1/auth/refresh` now, when a revoked token is replayed, revokes every active refresh token for `(user_id, tenant_id)`, writes an `auth.refresh_reuse_detected` audit log, and emails the user. Stolen-token replay can no longer keep a quiet parallel branch alive.
 - Session rotation on re-login: `/v1/auth/login` now revokes every prior active refresh token for `(user_id, tenant_id)` before issuing the new one. Stale sessions on forgotten devices no longer linger.
+
+**✅ Shipped in `fix/password-breach-check`:**
+- Password breach check (HIBP k-anonymous): new `apps/api/src/lib/password-breach.ts` with `assertPasswordNotBreached` wired into signup, password reset, change-password, invitation accept, and invite-link redeem. SHA-1 the password locally, send the first 5 hex chars to HIBP's Range API, reject anything in the returned list. Fails open on HIBP downtime (signup shouldn't break because an external service is flaky). 1h in-memory prefix cache. New `PasswordBreachedError` mapped to a 400 "Password Compromised" response by the global error handler.
 
 **Device fingerprint.** `auth.ts:321-322` does exact `(ip, user_agent)` match
 for known-device detection. Mobile clients rotate UA on each OS update and
 change IP on every Wi-Fi handoff, producing constant "new device" emails.
 Replace with a persistent `device_id` cookie + loose fingerprint.
-
-**Password breach check.** NIST SP 800-63B recommends comparing new passwords
-against HaveIBeenPwned's k-anonymous breach API. Currently any policy-passing
-password is accepted even if it's in the top-10k breached list.
-
-**Email trim pre-validation.** `emailSchema` runs `.email()` before
-`.transform()` so leading/trailing whitespace in pasted addresses fails
-validation. Reorder with a pre-transform pass (`.string().transform(trim).pipe(z.string().email())`).
-
-**Refresh token reuse detection.** If an already-revoked refresh token is
-presented, we return 401 but don't revoke the whole session family. An
-attacker who steals a refresh token and races the legitimate owner can keep
-one branch alive. Industry standard: revoke all sibling tokens when a
-revoked one is reused.
-
-**Session rotation on login.** Existing active sessions aren't invalidated
-when the user logs in again. Low impact since refresh rotation covers this
-on every /refresh cycle, but best practice is to kill the prior family.
 
 ### P3 — nice to have
 

--- a/docs/superpowers/specs/2026-04-19-timeline-larry-integration-design.md
+++ b/docs/superpowers/specs/2026-04-19-timeline-larry-integration-design.md
@@ -1,0 +1,605 @@
+# Timeline × Larry — Integration, Polish, and Gantt v5 Roadmap
+
+**Date:** 2026-04-19
+**Status:** Draft — awaiting Fergus review
+**Author:** Claude (Opus 4.7, 1M context)
+**Builds on:** `2026-04-18-gantt-v4-subcategories-sync-design.md`, `2026-04-15-modify-action-design.md`
+**Source:** brainstorming exchange 2026-04-19 (post-launch review)
+**Scope type:** Multi-slice feature + polish + roadmap
+
+---
+
+## 0. Context
+
+Gantt v4 (shipped 2026-04-18) delivered the full Category → Subcategory → Project → Task → Subtask tree with shared cache, DnD, and context-menu actions. It works, but day-one usage surfaced three concrete gaps plus the absence of Larry itself from the surface that most visually represents the organisation's work.
+
+### Inbound items
+
+1. **Larry has no timeline-organisation capabilities** — the intelligence engine knows the whole project/task graph but cannot suggest categorisation, colour schemes, or project groupings. The timeline's organisational quality depends entirely on manual user effort.
+2. **Task creation from the timeline drops the description field** — `AddNodeModal` exposes title + optional dates only. `tasks.description TEXT` (`schema.sql:254`) and the `/api/workspace/tasks` Zod schema (`apps/api/src/routes/v1/tasks.ts:19`, accepts up to 4000 chars) both support it.
+3. **Colour flash switching between org and project timelines** — `PortfolioGanttClient` reads `/api/workspace/timeline` into cache key `["timeline","org"]`; `ProjectGanttClient` reads `/api/workspace/categories` + `/api/workspace/projects` into `["categories"]` + `["projects"]`. The org payload contains every category colour already, but the project view never reads from it, so the first paint on a cold project visit renders neutral grey (`NEUTRAL_ROW_COLOUR = #bdb7d0`) until the dedicated queries resolve.
+4. **Polish debt** — `ErrorBanner` in `PortfolioGanttClient` uses hard-coded `#fdecef`/`#f5c1cb`/`#8a1f33`; an unused `useEffect` import sits on line 2; the org query has no `staleTime` so it refetches on every visit.
+5. **Gantt industry-standard features absent** — the timeline API returns `dependencies`, the UI ignores them. No bar resize, no milestones, no critical path, no export. Called out by Fergus as the "overall technical review" lens; shipped as a v5 roadmap of individual PRs, not a single design.
+
+### Scope framing (Option 2, locked in 2026-04-19)
+
+Three slices, stacked PRs:
+
+- **Slice 1 — Polish + cache + description.** No AI, low risk, ships first and removes day-to-day friction.
+- **Slice 2 — Larry timeline tools.** The headline feature. Larry proposes category/colour/regroup actions via the existing Action Centre + NotificationBell banner pipeline; user accepts or dismisses.
+- **Slice 3 — Gantt v5 feature roadmap.** Dependency arrows first; bar resize, milestones, critical path, export follow as independent PRs.
+
+### In scope
+
+- `apps/web/src/components/workspace/gantt/**` — AddNodeModal description field, banner token migration
+- `apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx` — cache cross-pollination, stale-time, import cleanup
+- `packages/ai/src/**` — new tool module `timeline-tools.ts`, prompt additions in `intelligence.ts`
+- `packages/db/src/schema.sql` + `migrations/**` — `larry_events.project_id` nullable with CHECK
+- `apps/api/src/lib/timeline-suggestion-executor.ts` — new module
+- `apps/api/src/routes/v1/larry.ts` — accept handler dispatch for `timeline_*` action types
+- `apps/web/src/components/workspace/TimelineSuggestionPreview.tsx` — new component
+- `apps/web/src/lib/action-types.ts` — three new action-type tags
+
+### Out of scope
+
+- Slice 3 individual implementations (roadmap only — each feature gets its own PR-time spec)
+- Auto-execution of timeline suggestions (every suggestion stays gated behind user accept, matching Larry's existing suggestion UX)
+- Drag-to-reschedule on the Gantt bar (earmarked for Slice 3)
+- Mobile/tablet layouts — desktop only, same as v4
+- Any changes to the Gantt visual tokens established in v3/v4
+- Auth, worker, rate-limiting, or unrelated API surfaces
+
+---
+
+## 1. Slice 1 — Polish + cache + description
+
+### 1.1 Description field on `AddNodeModal`
+
+**File:** `apps/web/src/components/workspace/gantt/AddNodeModal.tsx`
+
+**Change:**
+- Add `description: string` state, initialised `""`.
+- Add an `<details><summary>Add description</summary></details>` collapsible block rendered only when `mode === "task" || mode === "subtask"`. Inside: a `<textarea>` bound to `description`, `maxLength={4000}`, placeholder `"What does this task cover? (optional)"`, `rows={3}`, styled with the same `inputStyle` constant.
+- Collapsed by default to keep the modal height unchanged for the common case.
+- In the task/subtask branch of `handleSave`, add `if (description.trim()) body.description = description.trim();` before the POST.
+
+**No API change needed** — `CreateTaskSchema` (`apps/api/src/routes/v1/tasks.ts:19`) already accepts `description: z.string().max(4_000).optional()`.
+
+**Keyboard parity:** `Enter` inside the textarea should insert a newline (default browser behaviour), NOT submit. The existing `onKeyDown={(e) => { if (e.key === "Enter") void handleSave(); ... }}` is on the **title** input only — no change needed there, but verify the textarea doesn't inherit it.
+
+### 1.2 Cross-surface cache — shared hook, no cross-writing
+
+**Originally** this section proposed warming `["categories"]` + `["projects"]` cache keys from inside `PortfolioGanttClient` via `useEffect`. On review, writing across sibling cache keys from one component is a TanStack Query anti-pattern — it creates a last-write-wins race if ProjectGanttClient is mounted concurrently (prefetched link, open tab) and can silently overwrite an optimistic update mid-mutation.
+
+**Replacement design: extract a shared hook.**
+
+**New file:** `apps/web/src/hooks/useTimelineSnapshot.ts`
+
+```ts
+import { useQuery } from "@tanstack/react-query";
+import type { PortfolioTimelineResponse } from "@larry/shared";
+import { toCategorySummaries, toProjectSummaries } from "@larry/shared/timeline";
+
+export const QK_TIMELINE_ORG = ["timeline", "org"] as const;
+
+// Single source of truth for the timeline payload. Both Portfolio- and
+// Project-GanttClient read from this hook; no component ever writes into
+// `["categories"]` or `["projects"]` directly for read purposes.
+export function useTimelineSnapshot() {
+  return useQuery({
+    queryKey: QK_TIMELINE_ORG,
+    queryFn: async (): Promise<PortfolioTimelineResponse> => {
+      const res = await fetch("/api/workspace/timeline", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json();
+    },
+    staleTime: 30_000,
+  });
+}
+
+// Derived-view helpers. Consumers call useCategoriesFromTimeline() and
+// useProjectsFromTimeline() instead of running their own `/api/workspace/…`
+// query; both derive from the same cached org payload.
+export function useCategoriesFromTimeline() {
+  const { data, ...rest } = useTimelineSnapshot();
+  return { ...rest, data: data ? { categories: toCategorySummaries(data) } : undefined };
+}
+
+export function useProjectsFromTimeline() {
+  const { data, ...rest } = useTimelineSnapshot();
+  return { ...rest, data: data ? { items: toProjectSummaries(data) } : undefined };
+}
+```
+
+**Change in `ProjectGanttClient.tsx`** — replace the two standalone `useQuery` calls (categories + projects) with `useCategoriesFromTimeline()` and `useProjectsFromTimeline()`. Only write-path mutations retain `qc.invalidateQueries({ queryKey: QK_TIMELINE_ORG })`, which in turn re-derives both views.
+
+**Change in `PortfolioGanttClient.tsx`** — replace the inline `useQuery` with `useTimelineSnapshot()`. No `useEffect`, no cache cross-writing.
+
+**Shared types** (§1.3 below) — `toCategorySummaries` and `toProjectSummaries` live in `packages/shared/src/timeline.ts` so any payload-shape drift is a compile error on both server and client.
+
+**Result:** one round-trip serves both surfaces. Cold project visit after an org-timeline visit has zero additional network. No race, no write-side-effect, no stale optimistic updates overwritten.
+
+### 1.3 Shared mapping types
+
+**File:** `packages/shared/src/timeline.ts` (new)
+
+```ts
+import type { PortfolioTimelineResponse, ProjectCategory } from "./index";
+
+export interface ProjectSummary { id: string; categoryId: string | null; }
+
+export function toCategorySummaries(
+  resp: PortfolioTimelineResponse,
+): ProjectCategory[] {
+  return resp.categories
+    .filter((c) => c.id !== null)
+    .map((c) => ({
+      id: c.id as string,
+      name: c.name,
+      colour: c.colour,
+      sortOrder: c.sortOrder,
+      parentCategoryId: c.parentCategoryId ?? null,
+      projectId: c.projectId ?? null,
+    }));
+}
+
+export function toProjectSummaries(
+  resp: PortfolioTimelineResponse,
+): ProjectSummary[] {
+  return resp.categories.flatMap((c) =>
+    c.projects.map((p) => ({ id: p.id, categoryId: c.id ?? null })),
+  );
+}
+```
+
+Pure functions, trivially unit-testable. Any field drift in `PortfolioTimelineResponse` breaks these at compile time on both sides of the network.
+
+### 1.4 Polish
+
+- `ErrorBanner` colour migration: replace `background: "#fdecef"` → `"var(--pm-red-light)"`, `border: "1px solid #f5c1cb"` → `"1px solid var(--pm-red)"`, `color: "#8a1f33"` → `"var(--pm-red)"`. Matches ProjectGanttClient's existing banner (`PortfolioGanttClient.tsx:411`).
+- Remove the stray `useEffect` import from line 2 — actually, Slice 1.2 makes it needed; keep.
+- `aria-live="polite"` on the banner so screen readers announce load failures.
+- `WorkspaceTopBar` pill navigation: no change (Timeline is already an entry).
+
+### 1.5 Testing
+
+- **Unit** (`AddNodeModal.test.tsx`, new if absent):
+  - In `task` mode, the description textarea is rendered inside the collapsible block; when typed and submitted, the POST body contains `description`.
+  - In `category` and `project` modes, the description block is not rendered.
+  - Empty/whitespace description is not sent (trimmed → omitted from body).
+- **Unit** (`shared/timeline.test.ts`, new):
+  - `toCategorySummaries(fixture)` returns only real categories (synthetic `null`-id uncategorised bucket excluded) with correct field mapping.
+  - `toProjectSummaries(fixture)` returns one entry per project with the correct `categoryId` re-stitched from its parent category row.
+- **Unit** (`hooks/useTimelineSnapshot.test.tsx`, new):
+  - `useCategoriesFromTimeline()` derives the expected `{ categories }` shape from the cached org payload.
+  - `useProjectsFromTimeline()` derives the expected `{ items }` shape from the same cached payload.
+  - With the org query already warm, mounting `ProjectGanttClient` does not fire a network request (asserted by a `fetch` spy).
+- **API** (`tasks.test.ts`, extend if not covered):
+  - POST `/api/workspace/tasks` with `description: "x".repeat(4001)` → 400.
+  - POST with a valid description persists and reads back via GET `/api/workspace/tasks`.
+
+---
+
+## 2. Slice 2 — Larry timeline tools
+
+### 2.1 DB migration
+
+**File:** `packages/db/src/migrations/027_larry_events_nullable_project.sql` (next after `026_invites_project_scope_and_links.sql`)
+
+```sql
+BEGIN;
+
+-- Relax the NOT NULL so org-scope suggestions (no single project anchor)
+-- can live in the same table as project-scoped ones.
+ALTER TABLE larry_events
+  ALTER COLUMN project_id DROP NOT NULL;
+
+-- Constrain the new freedom: only timeline_* action types may use null
+-- project_id. Every existing row has a non-null project_id so the CHECK
+-- passes backfill.
+ALTER TABLE larry_events
+  ADD CONSTRAINT larry_events_project_scope_check
+  CHECK (
+    project_id IS NOT NULL
+    OR action_type LIKE 'timeline\_%' ESCAPE '\'
+  );
+
+-- Partial index for the suggestion poll (NotificationBell) — surface pending
+-- org-scope suggestions quickly without scanning the whole table.
+CREATE INDEX IF NOT EXISTS idx_larry_events_org_pending
+  ON larry_events (tenant_id, created_at DESC)
+  WHERE project_id IS NULL AND event_type = 'suggested';
+
+COMMIT;
+```
+
+**Rollback:** single `ALTER TABLE ... ALTER COLUMN project_id SET NOT NULL;` after deleting any org-scope rows. Safe because the forward migration adds new capability without touching existing data.
+
+**Caveat (from prior Larry incident — see memory `feedback-pg-enum-add-value.md`):** no enum adds in this migration, so the "can't use a freshly-added enum value in the same batch" trap doesn't apply. The new `action_type` values are plain TEXT.
+
+### 2.2 AI tool module
+
+**Context architecture (org-wide pass, not a per-project extension).**
+
+`runIntelligence` today runs scoped to a single project and is given that project's snapshot. Timeline reorganisation is inherently cross-project — Larry cannot propose "group 4 projects under a new Customer Onboarding theme" from inside a single-project context because he doesn't know the other 3 projects exist.
+
+To fix this: introduce a **new org-wide intelligence pass** triggered by the existing scheduler (`scripts/run-intelligence.ts` or its worker equivalent — verify filename during implementation) that runs once per tenant per scan window with a dedicated context:
+
+```ts
+interface OrgTimelineContext {
+  tenantId: string;
+  categories: Array<{ id: string; name: string; colour: string | null;
+                      parentCategoryId: string | null; projectId: string | null;
+                      createdAt: string; lastRenamedAt: string | null }>;
+  projects: Array<{ id: string; name: string; categoryId: string | null;
+                    status: string; createdAt: string }>;
+  recentSignals: Array<{ projectId: string; source: string; excerpt: string }>;
+  pendingTimelineSuggestions: string[];   // display_text of open timeline_* events
+}
+```
+
+- Runs at most once per tenant per hour (rate limit via a `larry_org_scan_runs` table, same pattern as existing scan-rate limits).
+- Only the `proposeTimelineRegroup` tool is available in this context — no per-project tools.
+- Skipped entirely when `pendingTimelineSuggestions.length >= 3` so we don't pile up suggestions the user hasn't reviewed.
+- Token budget: capped at 4k output tokens. `categories` and `projects` are sent in a compressed tabular format (`id|name|categoryId`) rather than verbose JSON. `recentSignals` limited to 20 entries, 200 chars each. Hard ceiling under 2k input tokens beyond the system prompt.
+
+Per-project scans are unchanged and do not get the `proposeTimelineRegroup` tool in their tool set.
+
+**File:** `packages/ai/src/timeline-tools.ts` (new)
+
+**Tool registered with the Vercel AI SDK:**
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+
+export const proposeTimelineRegroup = tool({
+  description:
+    "Propose grouping projects under new or existing categories, optionally with colour assignments. " +
+    "Only call when 3+ projects share strong shared signals (meeting transcripts, task-title patterns, shared " +
+    "stakeholders). Do NOT call if a similar timeline_regroup suggestion is already pending for this tenant — " +
+    "that list is provided in the system prompt.",
+  parameters: z.object({
+    displayText: z.string().min(10).max(140),
+    reasoning: z.string().min(20).max(600),
+    createCategories: z
+      .array(z.object({
+        tempId: z.string().regex(/^cat_[a-z0-9]{4,12}$/),
+        name: z.string().min(1).max(60),
+        colour: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+      }))
+      .max(5)
+      .optional(),
+    moveProjects: z
+      .array(z.object({
+        projectId: z.string().uuid(),
+        toCategoryTempId: z.string().optional(),
+        toCategoryId: z.string().uuid().optional(),
+      }).refine((v) => !!v.toCategoryTempId !== !!v.toCategoryId,
+        "exactly one of toCategoryTempId / toCategoryId"))
+      .max(10)
+      .optional(),
+    recolourCategories: z
+      .array(z.object({
+        categoryId: z.string().uuid(),
+        colour: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+      }))
+      .max(10)
+      .optional(),
+  })
+    .refine((v) =>
+      (v.createCategories?.length ?? 0)
+      + (v.moveProjects?.length ?? 0)
+      + (v.recolourCategories?.length ?? 0) >= 1,
+      "At least one change is required"),
+  execute: async (args, context) => {
+    // Writes a single larry_events row with event_type='suggested',
+    // action_type='timeline_regroup', project_id=NULL, payload=args.
+    // Returns { eventId, status: 'pending' } to Larry so follow-up tool
+    // calls can reference it.
+  },
+});
+```
+
+The 10-change cap keeps accepts reviewable. `createCategories` is capped at 5 because most regroupings create at most one or two themes — the ceiling is an anti-hallucination guardrail.
+
+### 2.3 Prompt additions
+
+**File:** `packages/ai/src/intelligence.ts`
+
+Append to the system prompt (near line 202 where "You are Larry" already lives), in its own block so it can be token-trimmed under budget pressure:
+
+```
+# Timeline organisation
+
+You can propose changes to how the workspace's timeline is organised by calling
+`proposeTimelineRegroup`. Use it SPARINGLY. Good triggers:
+- 3+ uncategorised or loosely-grouped projects share a theme (customer name,
+  product area, quarter, stakeholder).
+- An existing category has accumulated projects that clearly split into two
+  sub-themes (suggest a subcategory).
+- A category's colour conflicts with another category's colour (same hex) or
+  uses the default Larry purple when the category is meaningful enough to
+  deserve its own colour.
+
+Do NOT propose:
+- Reorganisation of fewer than 3 projects unless fixing a duplicate colour.
+- Changes that would undo an active-looking manual choice (category named by
+  a human in the last 7 days).
+- A new suggestion when an identical timeline_regroup is already pending.
+
+The list of pending timeline_regroup suggestions is provided in the context
+snapshot under `pendingTimelineSuggestions`.
+```
+
+Context builder in `intelligence.ts` passes `pendingTimelineSuggestions: string[]` (human-readable summaries) so Larry can self-deduplicate.
+
+### 2.4 Executor
+
+**File:** `apps/api/src/lib/timeline-suggestion-executor.ts` (new)
+
+```ts
+type ExecuteResult = {
+  applied: { categories: number; moves: number; recolours: number };
+  skipped: Array<{ reason: string; projectId?: string; categoryId?: string }>;
+};
+
+export async function executeTimelineSuggestion(
+  fastify: FastifyInstance,
+  tenantId: string,
+  eventId: string,
+  payload: TimelineRegroupPayload,
+  actorUserId: string,
+): Promise<ExecuteResult>;
+```
+
+**Behaviour:**
+1. Open a tenant-scoped transaction via `fastify.db.transactionTenant(tenantId, async (tx) => { ... })`.
+2. **Concurrency guard — first statement in the transaction:**
+   ```sql
+   SELECT id, event_type FROM larry_events
+    WHERE id = $1 AND tenant_id = $2
+    FOR UPDATE;
+   ```
+   If the row is missing, or `event_type != 'suggested'`, return `{ applied: {0,0,0}, skipped: [{ reason: 'already_resolved' }] }` immediately (no rollback needed because no writes have happened). This blocks concurrent accepts: the second caller waits on the lock, then finds the event already `accepted` and no-ops.
+3. Resolve `tempId` → real UUID for each entry in `createCategories` by inserting into `project_categories` (reusing the same insert path the `POST /api/workspace/categories` route uses — **extract a shared helper** if the route logic is currently inline).
+   - **Name collision handling:** if an `INSERT` fails on the `(tenant_id, parent_category_id, name)` unique constraint, query the existing category with that name and reuse its id in the tempId map; record `skipped: [{ reason: 'category_name_already_exists', categoryId: existingId }]` so the accept response is honest about having reused rather than created.
+4. For each `moveProjects` entry, resolve `toCategoryTempId` (from step 2's map) or `toCategoryId` (validated to exist in this tenant). If the project no longer exists → skipped with reason `"project_not_found"`. Otherwise UPDATE `projects.category_id`.
+5. For each `recolourCategories` entry, UPDATE `project_categories.colour`. Missing category → skipped with reason `"category_not_found"`.
+6. Update `larry_events` row: `event_type='accepted'`, `approved_by_user_id=actorUserId`, `approved_at=NOW()`, `execution_mode='approval'`, `executed_by_kind='user'`, `executed_by_user_id=actorUserId`.
+7. Return `ExecuteResult`. Transaction commits only if steps 2–6 all succeed; any SQL error rolls back and the event stays `suggested` for retry/dismiss.
+
+**Partial-apply policy:** a missing project or category within a suggestion is NOT a rollback trigger — it's a `skipped` entry. Rollback is reserved for integrity errors (FK violations other than the handled name collision, etc.).
+
+**Write audit:** one entry per mutated entity via the existing `writeAuditLog` helper, with `sourceKind='larry_suggestion'` and `sourceRecordId=eventId`.
+
+### 2.5 Accept handler dispatch
+
+**File:** `apps/api/src/routes/v1/larry.ts`
+
+Wherever the existing suggestion-accept handler lives (find by grep for `event_type` / `accepted`), add a branch:
+
+```ts
+if (event.actionType.startsWith("timeline_")) {
+  // RBAC: org-scope timeline changes require workspace-level authority.
+  // Per-project suggestions already fall through project_memberships gates;
+  // a null project_id event has no project to gate against, so we gate on
+  // workspace role directly. Matches the "pm or above" check used by
+  // POST /api/workspace/categories today.
+  const role = request.user.role;
+  if (!["owner", "admin", "pm"].includes(role)) {
+    return reply.code(403).send({
+      message: "Only owners, admins, and PMs can apply timeline reorganisations.",
+    });
+  }
+  const result = await executeTimelineSuggestion(
+    fastify, tenantId, event.id,
+    TimelineRegroupPayloadSchema.parse(event.payload),
+    request.user.id,
+  );
+  return reply.send({ ok: true, result });
+}
+```
+
+**Dismiss** is unchanged in handler logic, but add the same role gate so non-PMs can't dismiss org-scope suggestions either (keeps the "who sees the banner vs. who acts on it" story consistent). Non-PMs still see the banner but it's read-only with a tooltip explaining who can act.
+
+**Verification step during implementation:** grep for the existing accept handler and confirm the `event.actionType` and `event.payload` field names match what I've written (memory says v4 shipped `larry_events` but field-name casing on the TS side isn't verified here).
+
+### 2.6 Frontend — TimelineSuggestionPreview
+
+**File:** `apps/web/src/components/workspace/TimelineSuggestionPreview.tsx` (new)
+
+**Props:** the `WorkspaceLarryEvent` row (already typed in `apps/web/src/app/dashboard/types.ts`). Only renders for events whose `actionType` starts with `timeline_`.
+
+**Visual:**
+- Header: Larry avatar + `displayText` + action-type tag.
+- Reasoning block: `reasoning` text in `var(--text-2)`, small.
+- Diff preview — a mini-tree:
+  - For each `createCategories` entry: a new `cat:` row with the proposed colour swatch (CategoryDot component, already shared) + name.
+  - Under each, a nested list of `moveProjects` entries that target it, showing the project name + its current category → new category.
+  - For each `recolourCategories` entry: a before/after swatch pair + category name.
+- Footer: `Accept` + `Dismiss` buttons using the existing Action Centre action handlers (route through `useLarryActionCentre`).
+
+**Routing:** `apps/web/src/app/workspace/actions/page.tsx` already picks up custom previews via `ActionDetailPreview` (`components/workspace/ActionDetailPreview.tsx`). Add a branch: if `actionType.startsWith("timeline_")`, render `<TimelineSuggestionPreview>` instead of the default preview.
+
+### 2.7 NotificationBell banner
+
+No code change. NotificationBell already polls `/api/workspace/larry/events?state=pending` (or equivalent — verify) and surfaces `display_text` verbatim as a banner. The three new action types flow through with no additional wiring. Verify by reading `NotificationBell.tsx` during implementation; if it filters by action type, extend the whitelist.
+
+### 2.8 Action-type tags
+
+**File:** `apps/web/src/lib/action-types.ts`
+
+Append to `ACTION_TYPE_MAP`:
+
+```ts
+timeline_regroup:     { key: "timeline_regroup",     label: "Reorganise Timeline", color: "#6c44f6" },
+timeline_categorise:  { key: "timeline_categorise",  label: "New Category",        color: "#6c44f6" },
+timeline_recolour:    { key: "timeline_recolour",    label: "Category Colour",     color: "#6c44f6" },
+```
+
+Colour `#6c44f6` matches Larry's brand purple (memory `larry-design-decisions.md`). The `timeline_regroup` tag covers the omnibus type emitted by the current tool; `timeline_categorise` / `timeline_recolour` are reserved for future narrower tools (see §4) and added now so the UI doesn't render `Other` if Larry ever emits them in isolation.
+
+### 2.9 Context builder additions
+
+**File:** `packages/ai/src/intelligence.ts` (context snapshot construction)
+
+Add to the snapshot passed into `runIntelligence`:
+
+```ts
+pendingTimelineSuggestions: string[];   // display_text of existing timeline_*
+                                        // events with event_type='suggested'
+```
+
+Populated from a new query in the context loader:
+```sql
+SELECT display_text FROM larry_events
+ WHERE tenant_id = $1
+   AND action_type LIKE 'timeline_%'
+   AND event_type = 'suggested'
+ ORDER BY created_at DESC
+ LIMIT 10
+```
+
+Ten is the dedup horizon — Larry sees the most recent pending suggestions and avoids duplicating them.
+
+### 2.10 Invalidation after accept
+
+**File:** client-side, wherever the accept mutation's `onSuccess` lives (hook `useLarryActionCentre` in `apps/web/src/hooks/`).
+
+On accept of a `timeline_*` action:
+
+```ts
+await qc.invalidateQueries({ queryKey: ["timeline", "org"] });
+await qc.invalidateQueries({ queryKey: ["categories"] });
+await qc.invalidateQueries({ queryKey: ["projects"] });
+```
+
+Both timeline surfaces refetch; colour + groupings reflect the applied diff.
+
+### 2.11 Error handling
+
+- **Tool rejection** (Zod validation fails on the arguments): Larry sees the error in the tool loop and can retry with a fixed payload. No UI surface.
+- **Executor transaction rollback**: `larry_events` row stays `suggested`. Surface error to the accept caller as a 500 with a structured message; ActionDetailPreview shows the error inline with a Retry button.
+- **Partial apply** (some projects or categories skipped but others applied): accept succeeds, UI shows a summary — "Applied 3 of 4 moves. 1 skipped: project no longer exists." — via the existing toast system.
+- **Scan budget exhausted**: timeline tool is gated by the same budget guard in `packages/ai/src/budget.ts` that already protects other tools. If budget is below threshold, Larry sees the tool as unavailable and doesn't try.
+
+### 2.12 Testing
+
+- **Unit — executor** (`timeline-suggestion-executor.test.ts`):
+  - Full apply: 2 createCategories + 3 moveProjects + 1 recolourCategories → all applied, event marked accepted.
+  - Partial apply: one projectId doesn't exist → applied returns 2 moves, skipped returns 1 entry with reason.
+  - Rollback: second `createCategories` name collides with existing category → transaction aborts, nothing applied, event stays suggested.
+  - tempId resolution: moveProjects with toCategoryTempId correctly resolves against the category inserted in the same transaction.
+- **Unit — tool** (`timeline-tools.test.ts`):
+  - Valid args → inserts one `larry_events` row with matching payload.
+  - Invalid args (11 moves) → Zod throws, no DB row written.
+  - Duplicate-detection: when `pendingTimelineSuggestions` contains a similar entry, the prompt-level guard is documented in a prompt-regression test (snapshot of the system prompt block).
+- **Unit — TimelineSuggestionPreview** (component test):
+  - Renders createCategories rows, moveProjects nested under them, recolourCategories swatch pairs.
+  - Accept button calls the shared action-centre accept mutation with the event id.
+- **E2E** (`e2e/timeline-suggestion.spec.ts`, Playwright MCP to handle Vercel BotID per memory `larry-botid-blocks-headless-playwright.md`):
+  - Seed a tenant with 4 projects that share onboarding signals.
+  - Trigger a scan (`POST /api/admin/scan/run` or the existing test helper).
+  - Assert one `larry_events` row exists with `action_type='timeline_regroup'`, `event_type='suggested'`, `project_id=null`.
+  - Navigate to `/workspace/actions`, open the preview, click Accept.
+  - Assert the 4 projects now belong to the new category; assert the category's colour matches the payload; assert `/workspace/timeline` renders them grouped.
+
+### 2.13 Observability
+
+- Log (with correlation id) every tool call → event insert; every accept → executor result summary; every skipped entry with reason.
+- Metric counters via existing Railway logging pipeline:
+  - `larry.timeline.suggested.count`
+  - `larry.timeline.accepted.count`
+  - `larry.timeline.dismissed.count`
+  - `larry.timeline.executor.rollback.count`
+  - `larry.timeline.executor.skipped.count{reason}`
+- No PII in logs — only UUIDs and counts.
+
+---
+
+## 3. Slice 3 — Gantt v5 feature roadmap
+
+Roadmap only. Each feature ships as its own PR with a short, focused PR-time spec. Listed in value-per-LOC order so we can stop whenever the budget runs out.
+
+### 3.1 Dependency arrows (highest-value, smallest change)
+
+The server returns `dependencies: { taskId, dependsOnTaskId }[]` in every `/api/workspace/timeline` response and the UI ignores them (`PortfolioTimelineResponse.dependencies` in `packages/shared`). New SVG overlay in `GanttGrid.tsx` painting finish-to-start arrows from the right edge of the predecessor bar to the left edge of the dependent bar, routed around intervening rows with a simple L-shape. Arrow colour: `var(--text-muted)`; highlighted on hover of either endpoint.
+
+Estimated: one PR, one day.
+
+### 3.2 Bar drag-resize for start/due
+
+Left/right 6px resize handles on `GanttBar`. On drag-end, PATCH `/api/workspace/tasks/:id` with the new `startDate` or `dueDate`, snapping to day boundaries in the user's timezone. Optimistic update + rollback on failure, same pattern as Slice 4 DnD.
+
+Estimated: one PR, one-to-two days. Needs tests for timezone correctness (the existing `timezone-context.ts` utility handles this).
+
+### 3.3 Milestones
+
+Tasks where `startDate === dueDate` AND `progressPercent === 0` render as rotated-square diamonds instead of bars. No schema change — it's a visual rule over existing data. Future: add a proper `task_kind` enum if the implicit rule turns out to be too fragile.
+
+Estimated: one PR, half a day.
+
+### 3.4 Critical path
+
+Client-side forward + backward pass over the dependency DAG using the durations already in `GanttTask`. Toolbar toggle paints critical-chain bars in `var(--pm-red)`. Pure compute, no backend change.
+
+Estimated: one PR, one-to-two days.
+
+### 3.5 Export to PNG/PDF
+
+Toolbar button that uses `html-to-image` (already in some projects — verify) + `jspdf` to capture the Gantt panel, preserving colours + arrows. For long timelines, paginate by month.
+
+Estimated: one PR, one day.
+
+---
+
+## 4. Future tools (documented, not built in this spec)
+
+Slice 2 ships one omnibus `proposeTimelineRegroup` tool. Once usage data tells us which shapes of suggestion Larry actually emits, split into narrower tools:
+
+- `proposeNewCategory({ name, colour, underProjects })` — single-category create.
+- `proposeRecolour({ categoryId, colour, reasoning })` — single-colour recolour.
+- `proposeProjectMove({ projectId, toCategoryId })` — single-move.
+
+Narrower tools give Larry clearer affordances and make Zod validation sharper. Deferred because it's premature to optimise the surface before seeing real usage.
+
+---
+
+## 5. Sequencing and risk
+
+**Order:**
+1. Slice 1 — ships first, all three pieces (description, cache, polish) in one PR. Low risk.
+2. Slice 2 — migration first (own PR, backward-compatible), then tool + executor + frontend (own PR). Two-PR gate because the migration needs to be live on prod before the code that relies on nullable `project_id`.
+3. Slice 3 — feature-by-feature as capacity allows. Dependency arrows first.
+
+**Risks and mitigations:**
+- *Larry hallucinating poor groupings.* Mitigated by prompt guards (3+ project minimum, 7-day recent-manual-change filter), 10-change payload cap, and the accept/dismiss gate. Every suggestion is reversible because each individual move can be undone via the existing timeline UI.
+- *Accept executes on stale data.* Partial-apply policy tolerates missing projects/categories; user sees a summary of what did and didn't apply.
+- *Cache warming writes wrong shape.* Unit-tested in Slice 1.4; shape mismatches are caught at compile time by the existing `ProjectCategory` and `ProjectSummary` types.
+- *Migration blocks on prod.* The `ALTER TABLE ... DROP NOT NULL` is instant on Postgres and has no data rewrite. Safe to run during business hours.
+- *Gantt v5 features conflicting with v4 DnD.* Each v5 feature is additive; dependency arrows are a pure render-layer overlay, resize handles live on `GanttBar` not `GanttOutlineRow`. No mutation-path collision.
+
+---
+
+## 6. Design follow-ups (flagged for post-launch discussion)
+
+These are *known gaps* — not oversights. The spec ships without resolving them because each one either depends on usage data we don't have yet, is cheap to add later, or would expand scope beyond what's needed for the first shipping version.
+
+1. **Semantic dedup is prompt-only.** `pendingTimelineSuggestions` stops Larry from emitting the same *wording* twice. It doesn't stop him from emitting semantically-identical suggestions in different words. Server-side hardening: reject a tool insert if a pending suggestion has >50% overlap on `moveProjects.projectId` set. Deferred until we see whether this actually happens in practice.
+
+2. **Token-cost monitoring for the org-wide pass.** §2.2 caps context at ~2k input + 4k output. We should track actual consumption via the existing `larry.tokens.*` metric family and tune the cap once we have real numbers. If the org-wide pass turns out to cost more than a batch of per-project scans, we may want to run it daily instead of hourly.
+
+3. **Undo.** Once Larry applies a regroup, there's no single-click revert — you'd have to manually move each project back and delete the created category. For a feature marketed as "Larry organises your timeline", an "undo last Larry regroup" action is a reasonable v2. Design sketch: store the pre-state in `larry_events.previous_payload` (already a column), add a `POST /api/workspace/larry/events/:id/undo` endpoint, gate by same RBAC and a 7-day TTL.
+
+4. **NotificationBell.tsx hasn't been verified** to pass `timeline_*` action types through unchanged. Low-risk but an explicit implementation-time check: read the component, confirm it filters by event_type only (not action_type), extend the whitelist if needed.
+
+5. **Org-scope dismiss with `project_id IS NULL`.** The existing dismiss handler presumably keys off the event id, not `project_id`. Presumed-working but un-tested; implementation-time smoke test.
+
+6. **Slice 3 effort estimates removed.** Original spec had "one day / half a day" estimates. Dropped because without checking Gantt row virtualisation, axis renderer architecture, etc., those numbers would mislead at PR time. Each Slice 3 feature gets a real estimate at its own PR-time spec.
+
+7. **Accept-handler field-name audit.** §2.5 references `event.actionType` and `event.payload`. Casing on the TS side of `larry_events` is unverified here. If the code uses snake_case on the JSON boundary, adjust. Zero-risk fix at implementation time.
+
+## 7. Open questions (none at time of writing)
+
+All questions raised during brainstorming (Larry autonomy level, surfacing mechanism, project_id nullability, slice sequencing, org-wide context architecture, concurrent accepts, RBAC on accept, cache anti-pattern, schema drift) are resolved inline above. Any new questions that surface during implementation should be added here and re-confirmed before proceeding.


### PR DESCRIPTION
P2-2 from the 2026-04-19 login audit. NIST SP 800-63B recommends comparing new passwords against breach corpora; our policy (12 chars + upper + digit + symbol) catches complexity but not reuse. \"Password1!\" passes the regex.

## What
- New `apps/api/src/lib/password-breach.ts` with `assertPasswordNotBreached(pw)` using HIBP's k-anonymous Range API. Password is SHA-1'd locally; only the first 5 hex chars leave the process.
- Wired into all 5 password-accepting routes: signup, password reset, change-password, invitation accept, invite-link redeem.
- 1h in-memory prefix cache, 2.5s request timeout, `Add-Padding: true` to neutralise count-based timing leaks.
- Fails open on HIBP downtime — signup shouldn't break because an external service is flaky. A compromised password slipping through a HIBP outage is strictly better than users locked out.
- `PasswordBreachedError` mapped to a 400 \"Password Compromised\" response by the global error handler so clients can surface the message directly.

## Tests
- 10 new unit tests in `src/lib/password-breach.test.ts`: breach count parsing, suffix mismatch, cache hit + TTL expiry, correct prefix format, fail-open on throw / 502, minCount threshold.
- Full API suite: 566/566 green, typecheck clean.

## Audit doc
`docs/security/login-audit-2026-04-19.md` P2 section: password-breach paragraph moved into the \"✅ Shipped\" block.

## Test plan
- [ ] CI green
- [ ] Post-deploy: try to sign up with \"Password1!\" (HIBP count 2.9M+) → 400 \"Password Compromised\"
- [ ] Try to sign up with a truly unique long passphrase → 201
- [ ] Same on /reset-password and /change-password surfaces

Remaining audit P2 backlog: device fingerprint cookie. P1-2 MFA still deferred to a dedicated session (see `docs/security/NEXT-AGENT-PROMPT-login-hardening.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)