### PR TITLE
docs(security): next-agent handoff — MFA + P2 device-fingerprint, self-contained

### DIFF
--- a/docs/security/NEXT-AGENT-PROMPT-login-hardening.md
+++ b/docs/security/NEXT-AGENT-PROMPT-login-hardening.md
@@ -1,285 +1,464 @@
-# Next agent — Larry login hardening sprint
+# Next agent — Larry login hardening: MFA + P2 backlog
 
-Hand this file to the next Claude session. It is self-contained: read it
-top to bottom, then start work without asking clarifying questions beyond
-the stop conditions at the end.
+**How to use this doc:** hand it to a fresh Claude Code session. It is
+self-contained. Read it top to bottom, confirm your understanding
+against the repo, then start work without asking clarifying questions
+beyond the stop conditions at the end.
+
+Paste prompt for the next session:
+
+> Read `C:/Dev/larry/site-deploys/larry-site/docs/security/NEXT-AGENT-PROMPT-login-hardening.md` and work through it.
 
 ---
 
-## What you're walking into
+## Current status as of 2026-04-19 afternoon
 
 Larry is a B2B PM tool (Next.js App Router on Vercel + Fastify API on
-Railway, Postgres). It launched on **2026-04-19** on `larry-pm.com`.
+Railway, Postgres). Launched 2026-04-19 on `larry-pm.com`.
 
-A launch-eve audit of the login stack was completed and the three
-highest-impact fixes shipped in PR #126. The full audit lives at:
+The 2026-04-19 launch-eve audit lives at
+[`docs/security/login-audit-2026-04-19.md`](./login-audit-2026-04-19.md)
+— read it first; it's the full inventory of what meets the bar and
+what doesn't.
 
-- **`docs/security/login-audit-2026-04-19.md`** — read this first. It
-  has the inventory of what meets industry standard, the three fixes
-  that shipped, and the ranked list of P1/P2 follow-ups.
+**Shipped in this sprint (all merged + prod-verified):**
 
-Memory context worth pulling in (already indexed in the user's memory
-system — check `memory/MEMORY.md` if running in this harness):
+| PR    | Scope                                                                 |
+|-------|-----------------------------------------------------------------------|
+| #126  | Launch-eve polish: accept-UX confirm, case-insensitive email lookup, password policy bumped 8→12 |
+| #128  | P1-1 CSRF enforcement: middleware on `/api/:path*` validates `X-CSRF-Token` against `session.csrfToken` on mutating methods; `window.fetch` patch in root layout injects the header on same-origin `/api/**` mutations so 130 client call sites migrated without edits |
+| #129  | Post-launch CSRF bootstrap fix (co-mint `larry_csrf` cookie at every session-mint site so signup-wizard step transitions don't 403) + P2-1/P2-4/P2-5 (refresh-token reuse detection with family-nuke, session rotation on re-login, email-trim ordering) |
+| #130  | P2-2 HIBP password breach check on all 5 password-setting routes, `PasswordBreachedError` → 400 via global error handler, 1h prefix cache, fails-open on HIBP downtime |
 
-- `larry-login-audit-2026-04-19.md` — what shipped in #126.
-- `larry-invites-project-scope-shipped.md` — PR #121, project-scoped
-  invites + invite_links.
-- `larry-login-tenant-fix.md` — PR #124 tenant switcher design.
-- `larry-rate-limiting.md` — Redis-backed limits, email caps, LLM token
-  budgets.
-- `testing-on-production.md` — Fergus (the user) tests on deployed prod,
-  not locally. Always push → verify deploy → then ask him to test.
-- `feedback-autonomy-default.md` — drive through a queue of work without
-  asking permission between steps; only pause for destructive/ambiguous
-  actions.
+**Remaining from the audit:**
 
-Repo root: `C:/Dev/larry/site-deploys/larry-site`. Branch strategy:
-branch from `master`, open a PR per scoped work unit, squash-merge.
-Never force-push master.
-
-## Your mission
-
-Work through the P1 items in order, then P2 as time allows. Each item is
-its own PR with tests + audit-doc update. Verify on prod after merge
-using the pattern established in PR #124/#126 (curl + direct DB peek via
-Railway CLI if needed).
+1. **P1-2 MFA enforcement on `/login`** — this is the main job.
+2. **P2-3 Device fingerprint cookie** — nice second task.
+3. That's it for P1/P2. P3 items in the audit doc are backlog.
 
 ---
 
-## P1 — MUST ship
+## Memory context worth pulling in
 
-### P1-1. CSRF enforcement middleware (web layer)
+Already indexed in the user's memory system (check
+`C:/Users/oreil/.claude/projects/C--Users-oreil/memory/MEMORY.md`
+if running in that harness):
 
-**Why it matters.** A `csrfToken` is already minted into the session JWT
-at login (`apps/web/src/lib/auth.ts:55`, via `randomUUID()`) but **no
-middleware ever reads it or compares**. `sameSite=lax` mitigates most
-classical CSRF for browser-initiated top-level navigations, but B2B
-bar is defence-in-depth double-submit.
-
-**Scope.**
-
-1. Add a Next.js middleware or per-route guard that, for every
-   **state-changing** request to `/api/**` (POST/PUT/PATCH/DELETE),
-   requires an `X-CSRF-Token` request header that matches
-   `session.csrfToken`.
-2. Exempt the bootstrap endpoints that CANNOT have a CSRF token yet:
-   `POST /api/auth/login`, `POST /api/auth/signup`,
-   `POST /api/invitations/[token]/accept`,
-   `POST /api/invite-links/[token]/redeem`,
-   `POST /api/auth/password-reset` start/confirm,
-   `POST /api/auth/verify-email`. Their auth flow IS the CSRF boundary
-   (they take an unauth'd body and mint a session). Every other mutating
-   `/api/**` route MUST require the header.
-3. Expose the token to client components via a server component reading
-   `getSession()` and rendering a `<meta name="csrf-token">` or via
-   `GET /api/auth/csrf` that returns the current session's token.
-4. Update the main `fetch` wrappers used by the app to include the header
-   automatically on mutating methods. Search for mutating fetches:
-   `rg "method: \"(POST|PUT|PATCH|DELETE)\""` in `apps/web/src`.
-   Centralize in a `fetchWithCsrf` helper rather than touching every
-   call site (30+). Update only those helpers used for mutations; leave
-   GETs alone.
-5. Rotate the `csrfToken` on every `persistSession` call
-   (`apps/web/src/lib/workspace-proxy.ts:50`) so refresh/switch-tenant
-   get fresh values — the existing `createSessionToken` already
-   re-defaults to `randomUUID()` when `csrfToken` is undefined, so the
-   fix is "don't pass the old token when persisting after a mutation".
-
-**Tests.** Add `apps/web/src/__tests__/csrf-middleware.test.ts` with
-vitest covering: (a) mutating request without header → 403, (b) with
-wrong header → 403, (c) with correct header → passes through, (d) GET
-with no header → passes through (read requests never require CSRF), (e)
-exempt routes (login/signup/accept/redeem) accept no header. Integration
-test against the actual Fastify proxy using `app.inject` if feasible;
-unit-level is acceptable.
-
-**Acceptance criteria.**
-- `rg "csrfToken" apps/web/src` shows the token compared in middleware.
-- Full suite green, including any new tests.
-- Manual prod curl: POST without header → 403; POST with header from
-  `/api/auth/csrf` → succeeds.
-- `docs/security/login-audit-2026-04-19.md` updated (move CSRF from
-  "Recommended follow-ups > P1" to "What already meets the bar").
+- `larry-login-audit-2026-04-19.md` — PR #126 launch-eve polish details.
+- `larry-login-csrf-shipped.md` — PR #128 design + prod verification.
+- `larry-csrf-signup-fix.md` — PR #129 CSRF-cookie-at-every-mint-site fix.
+- `larry-login-p2-shipped.md` — PR #129 P2 polish + prod verification.
+- `larry-launch-test-user.md` — test user creds (copied below).
+- `larry-testing-tools.md` — Playwright MCP, Vercel MCP, CLIs.
+- `larry-botid-blocks-headless-playwright.md` — Vercel BotID serves "Code 21" to headless Chromium on larry-pm.com/login. **Use Playwright MCP for prod UI tests**, not raw headless Playwright.
+- `testing-on-production.md` — Fergus tests on deployed prod, not locally. Always push → verify deploy → then ask him to test.
+- `feedback-autonomy-default.md` — drive through a queue of work without asking permission between steps; only pause for destructive/ambiguous actions or the explicit stop conditions below.
+- `feedback-pg-enum-add-value.md` — don't USE a new enum value in the same `schema.sql` batch that ADDs it. Split into two deploys if needed.
 
 ---
 
-### P1-2. MFA enforcement on `/login`
+## Repo + branch + build facts (don't re-discover these)
 
-**Why it matters.** The DB already has `tenants.mfa_required_for_admins`
-(schema.sql around line 1594) and a helper `assertMfaIfRequired` in
-`apps/api/src/lib/mfa-gate.ts`. The helper is only called from invite
-creation in `routes/v1/invitations.ts:47-52`. Login itself doesn't check
-MFA status. An admin in a `mfa_required_for_admins = true` tenant can
-therefore authenticate with just a password.
+- **Repo root:** `C:/Dev/larry/site-deploys/larry-site`
+- **Branch strategy:** branch from `master`, one PR per scoped unit, squash-merge. **Never force-push master.** Force-push feature branches only when necessary (`--force-with-lease`).
+- **Monorepo layout:** `apps/api` (Fastify), `apps/web` (Next.js), `apps/worker`, `packages/{shared,db,config,ai}`.
+- **Tests:** `cd apps/api && npx vitest run` (Node, ~15s). `cd apps/web && npx vitest run`. Web has pre-existing `tsc` errors in the gantt tree (`PortfolioGanttClient.tsx` / `gantt-utils.ts` — `parentCategoryId` / `projectId` drift) — they're not yours; don't try to fix them. Vercel `next build` ships fine past them.
+- **Typecheck:** `cd apps/api && npx tsc -p tsconfig.build.json --noEmit` must be clean. Web `npx tsc --noEmit` has the pre-existing gantt noise — grep your own paths only.
+- **CI:** `.github/workflows/*` runs api-tests + worker-build on every PR. Vercel deploys previews automatically. Railway auto-deploys master on push.
+- **Migrations:** monolithic `packages/db/src/schema.sql` runs at startup (uses `ADD COLUMN IF NOT EXISTS` + `CREATE TABLE IF NOT EXISTS` for idempotency). Historical migrations live as reference files in `packages/db/src/migrations/NNN_name.sql`. Last one shipped is `026_invites_project_scope_and_links.sql`. Your next number is `027`.
+- **`schema.sql` already has:**
+  - `tenants.mfa_required_for_admins BOOLEAN NOT NULL DEFAULT FALSE` (line ~1594)
+  - `users.mfa_enrolled_at TIMESTAMPTZ` (line ~1597)
+  - Helper: `apps/api/src/lib/mfa-gate.ts::assertMfaIfRequired(db, tenantId, userId, role)` — currently only called from invitation creation. **You need to call it from login, and actually gate the response.**
 
-**Scope.**
+---
 
-1. After successful password verification in
-   `apps/api/src/routes/v1/auth.ts:275-307` (the /login handler), and
-   BEFORE issuing the access/refresh tokens at line 336-351:
-   - Read `tenants.mfa_required_for_admins` for `user.tenant_id`.
-   - If required AND `user.role` is `owner`/`admin` AND
-     `users.mfa_enrolled_at IS NULL`:
-     - Return a response shape like
-       `{ code: "mfa_enrolment_required", enrolmentUrl: "/settings/mfa" }`
-       with a 412 or 409 status. NOT the access token.
-   - If required AND user IS enrolled: issue a **short-lived
-     "mfa_pending" token** (e.g. 5 min) instead of the normal access
-     token, and require a `POST /v1/auth/mfa/verify` step that exchanges
-     `{ mfaPendingToken, code }` for real access/refresh tokens.
-2. Implement TOTP enrolment: new endpoints
-   - `POST /v1/auth/mfa/enrol` — requires session; generates a new
-     secret, returns `{ secret, otpauthUrl }` (RFC 6238, SHA1, 30s, 6
-     digits). Persist hashed secret to a new table `user_mfa_secrets`
-     keyed by user_id (nullable scratch codes column for backup).
-   - `POST /v1/auth/mfa/enrol/confirm` — `{ code }`. Verifies TOTP,
-     flips `users.mfa_enrolled_at = NOW()`, returns 10 scratch codes
-     (hashed at rest).
-   - `POST /v1/auth/mfa/verify` — `{ mfaPendingToken, code }`. Accepts
-     a live TOTP OR an unused scratch code; issues real access+refresh.
-3. Minimal UI: a `/workspace/settings/mfa` page with a QR code
-   (encode the otpauthUrl) and a 6-digit confirm input, plus a scratch
-   codes reveal-once panel. Extend the login page with a second-step
-   "Enter your 6-digit code" flow when the API returns `code:
-   "mfa_required"`.
-4. MIGRATION (number 027): `user_mfa_secrets` table with RLS-free
-   design (secrets belong to users not tenants — users table is
-   tenant-less). Scratch codes table if you split.
-5. Add an admin toggle for `mfa_required_for_admins` on the org
-   settings page (if not already there — search
-   `apps/web/src/app/workspace/settings` first).
+## Prod test creds (don't ask the user, just use these)
 
-**Library.** Use `otpauth` or `@otplib/core` — whichever is already in
-the repo. Do a `grep -r "otplib\|otpauth" apps/ packages/` first.
+- **API base:** `https://larry-site-production.up.railway.app`
+- **Web base:** `https://larry-pm.com` (apex 307s to www). Use `https://www.larry-pm.com` in scripts.
+- **Health:** `GET https://larry-site-production.up.railway.app/health` returns `{ok:true, service:"larry-api", ts:...}`. The API path prefix is `/v1/`.
+- **Test user:** `launch-test-2026@larry-pm.com` / `TestLarry123%` — admin/owner of tenant `5d7cd81b-03ed-4309-beba-b8e41ae21ac8` ("Launch Test Org"). Don't rotate unless you restore at the end (I did this for P2-2 verification — check PR #130 for the restore pattern).
+- **Railway CLI is installed + linked.** You can probe the DB via `railway variables --service Postgres --json` to get `DATABASE_PUBLIC_URL`, but **never commit the URL** and clean up any temp scripts that contain it before `git add`.
+- **gh CLI is installed + authed.** Use it freely (`gh pr create/checks/merge/view`).
 
-**Tests.**
-- `apps/api/src/lib/mfa.test.ts` (new) — TOTP generation + verification,
-  scratch-code single-use.
-- `apps/api/tests/auth-mfa.test.ts` — the login-with-MFA flow: required
-  but not enrolled → 412; required + enrolled + correct code → 200; bad
-  code → 401 with attempt counted.
-- Scratch-code reuse → 401.
+---
 
-**Acceptance criteria.**
+## Smoke-test recipes that already work on prod
+
+```bash
+# CSRF enforcement (from PR #128 verification)
+API=https://larry-site-production.up.railway.app
+WEB=https://www.larry-pm.com
+# 1. login, capture session cookie
+curl -c /tmp/cookies -X POST $WEB/api/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"email":"launch-test-2026@larry-pm.com","password":"TestLarry123%"}'
+# 2. fetch csrf
+CSRF=$(curl -s -b /tmp/cookies $WEB/api/auth/csrf | grep -o '"csrfToken":"[^"]*"' | cut -d'"' -f4)
+# 3. mutating POST without header → 403
+curl -s -o /dev/null -w "%{http_code}\n" -b /tmp/cookies -X POST $WEB/api/workspace/tasks -H 'content-type: application/json' -d '{}'
+# 4. with header → 400 (reaches route, fails validation as expected)
+curl -s -b /tmp/cookies -X POST $WEB/api/workspace/tasks \
+  -H 'content-type: application/json' -H "x-csrf-token: $CSRF" -d '{}'
+```
+
+```bash
+# Refresh-reuse + family-nuke (from PR #129 verification)
+LOGIN=$(curl -s -X POST $API/v1/auth/login -H 'content-type: application/json' \
+  -d '{"email":"launch-test-2026@larry-pm.com","password":"TestLarry123%"}')
+REF1=$(echo $LOGIN | grep -o '"refreshToken":"[^"]*"' | cut -d'"' -f4)
+# rotate once
+REF2=$(curl -s -X POST $API/v1/auth/refresh -H 'content-type: application/json' \
+  -d "{\"refreshToken\":\"$REF1\",\"tenantId\":\"5d7cd81b-03ed-4309-beba-b8e41ae21ac8\"}" \
+  | grep -o '"refreshToken":"[^"]*"' | cut -d'"' -f4)
+# replay REF1 → 401 AND REF2 also dies
+curl -s -o /dev/null -w "replay=%{http_code}\n" -X POST $API/v1/auth/refresh -H 'content-type: application/json' \
+  -d "{\"refreshToken\":\"$REF1\",\"tenantId\":\"5d7cd81b-03ed-4309-beba-b8e41ae21ac8\"}"
+curl -s -o /dev/null -w "after-nuke=%{http_code}\n" -X POST $API/v1/auth/refresh -H 'content-type: application/json' \
+  -d "{\"refreshToken\":\"$REF2\",\"tenantId\":\"5d7cd81b-03ed-4309-beba-b8e41ae21ac8\"}"
+```
+
+```bash
+# HIBP enforcement (from PR #130 verification — uses /change-password to avoid burning signup's 5/h rate limit)
+LOGIN=$(curl -s -X POST $API/v1/auth/login -H 'content-type: application/json' \
+  -d '{"email":"launch-test-2026@larry-pm.com","password":"TestLarry123%"}')
+ACCESS=$(echo $LOGIN | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
+# breached password → 400 "Password Compromised"
+curl -s -X POST $API/v1/auth/change-password -H 'content-type: application/json' -H "Authorization: Bearer $ACCESS" \
+  -d '{"currentPassword":"TestLarry123%","newPassword":"Password123!"}'
+# If you rotate for testing, RESTORE to TestLarry123% before you finish.
+```
+
+---
+
+## P1-2 MFA enforcement on `/login` — the main job
+
+### Why it matters
+Schema already has the flag + the column. `assertMfaIfRequired` exists but
+is only called from invite creation (`routes/v1/invitations.ts`). Login
+itself doesn't check MFA status. An admin in an `mfa_required_for_admins =
+true` tenant can authenticate today with just a password.
+
+### Realistic scope estimate: ~7-8 hours
+
+This is a day of work. **Split into two PRs** so each is reviewable and
+you can ship with a review checkpoint in between:
+
+- **PR A (API + gate):** migration 027, TOTP lib, 3 endpoints, login
+  gating, audit logs, rate limit, tests. No UI.
+- **PR B (UI):** `/workspace/settings/mfa` page with QR + confirm, login
+  page MFA step, admin toggle (optional — can ship via direct DB update
+  if scope bites).
+
+API-only is safe to ship solo because no tenant has
+`mfa_required_for_admins = true` yet, so behaviour is unchanged until
+someone flips the flag. UI follow-up unblocks enrolment.
+
+### PR A — API + gate
+
+#### 1. Migration 027 `user_mfa_secrets`
+
+Add to `packages/db/src/schema.sql` (append after the existing MFA lines
+around 1597). Also drop a reference file at
+`packages/db/src/migrations/027_mfa_secrets.sql` matching the style of
+`026_invites_project_scope_and_links.sql`.
+
+```sql
+CREATE TABLE IF NOT EXISTS user_mfa_secrets (
+  user_id      UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  secret_enc   TEXT NOT NULL,                  -- encrypted TOTP secret (see #2)
+  scratch_codes_hashed TEXT[] NOT NULL DEFAULT '{}', -- future-proof, empty for now
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  confirmed_at TIMESTAMPTZ                     -- set by /mfa/enrol/confirm
+);
+```
+
+Secrets belong to users, not tenants — users are tenant-agnostic. Don't
+add a `tenant_id` column; scratch codes can come later (P1-2 follow-up,
+not in this PR).
+
+#### 2. TOTP library
+
+`grep -r "otplib\|otpauth" apps/ packages/` first — none installed as of
+2026-04-19. Add `otpauth` to `apps/api/package.json` (pure JS, works in
+Node 24, maintained). `npm install -w @larry/api otpauth`.
+
+#### 3. Encrypting the TOTP secret at rest
+
+TOTP secrets can't be hashed (you need them to verify). Encrypt with a
+symmetric key derived from `SESSION_SECRET` or a dedicated `MFA_SECRET`
+env var. Use `node:crypto` AES-256-GCM; store `iv:ciphertext:tag` in
+`secret_enc`. Keep the crypto helpers in `apps/api/src/lib/mfa.ts`.
+
+Signature:
+```ts
+export function encryptTotpSecret(plain: string): string;
+export function decryptTotpSecret(encoded: string): string;
+export function generateTotpSecret(): { secret: string; otpauthUrl: (email: string) => string };
+export function verifyTotpCode(secret: string, code: string): boolean;  // 30s window, ±1 step tolerance
+```
+
+#### 4. Endpoints (in a new `apps/api/src/routes/v1/auth-mfa.ts` registered from `auth.ts`)
+
+- `POST /v1/auth/mfa/enrol` (authenticated).
+  - Generates a new base32 secret + otpauth URL for the current user.
+  - Upserts into `user_mfa_secrets` (replacing any unconfirmed row).
+  - Returns `{ secret, otpauthUrl }`. Secret is base32; UI renders a QR from the URL.
+- `POST /v1/auth/mfa/enrol/confirm` (authenticated).
+  - Body: `{ code }`.
+  - Verifies TOTP against the stored (unconfirmed) secret.
+  - On success: `UPDATE user_mfa_secrets SET confirmed_at = NOW()` AND `UPDATE users SET mfa_enrolled_at = NOW()`.
+  - Writes `auth.mfa_enrolled` audit log.
+  - Returns `{ enrolled: true }`.
+- `POST /v1/auth/mfa/verify` (unauthenticated — uses mfaPendingToken).
+  - Body: `{ mfaPendingToken, code }`.
+  - Verifies the `mfaPendingToken` (see #5 login gating).
+  - Verifies TOTP against the user's stored secret.
+  - On success: issues real `accessToken` + `refreshToken` (same shape as `/login`), writes `auth.mfa_verify_success`.
+  - On failure: writes `auth.mfa_verify_failure` with the user_id; increments a per-user-id rate-limit counter.
+
+#### 5. Login gating (`routes/v1/auth.ts` /login handler)
+
+After successful `verifyPassword`, BEFORE the "successful login: reset
+lockout counter" step and BEFORE issuing tokens:
+
+```ts
+// Read tenants.mfa_required_for_admins + users.mfa_enrolled_at
+const mfaRows = await fastify.db.query<{ mfa_required_for_admins: boolean; mfa_enrolled_at: string | null }>(
+  `SELECT t.mfa_required_for_admins, u.mfa_enrolled_at
+     FROM tenants t
+     JOIN users   u ON u.id = $1
+    WHERE t.id = $2`,
+  [user.id, user.tenant_id],
+);
+const mfa = mfaRows[0];
+const protectedRole = user.role === "owner" || user.role === "admin";
+
+if (mfa?.mfa_required_for_admins && protectedRole) {
+  if (!mfa.mfa_enrolled_at) {
+    // Reset lockout (successful password verification) BEFORE returning
+    await fastify.db.query("DELETE FROM login_attempts WHERE user_id = $1", [user.id]);
+    return reply.status(412).send({
+      code: "mfa_enrolment_required",
+      enrolmentUrl: "/workspace/settings/mfa",
+      message: "This organisation requires admins to enrol MFA. Sign in again after completing enrolment.",
+    });
+  }
+  // Enrolled — issue a short-lived mfa_pending token instead of real tokens
+  await fastify.db.query("DELETE FROM login_attempts WHERE user_id = $1", [user.id]);
+  const mfaPendingToken = await fastify.jwt.sign(
+    { sub: user.id, tenantId: user.tenant_id, role: user.role, purpose: "mfa_pending" },
+    { expiresIn: "5m" },
+  );
+  return reply.status(200).send({
+    code: "mfa_required",
+    mfaPendingToken,
+  });
+}
+
+// ... existing reset-lockout + issue-tokens flow
+```
+
+The existing new-device-alert block runs AFTER token issue — keep it
+that way for non-MFA users. For MFA-completing users, move the
+new-device alert into `/v1/auth/mfa/verify` success path so an attacker
+with just a password doesn't trigger the alert.
+
+#### 6. Rate limit on `/v1/auth/mfa/verify`
+
+Use the existing `@fastify/rate-limit` config. Key by user_id (decoded
+from `mfaPendingToken`), not IP — otherwise an attacker rotates IPs and
+the lockout fails. 10 attempts per 15 min per user_id. Example:
+
+```ts
+fastify.post("/mfa/verify", {
+  config: {
+    rateLimit: {
+      max: 10,
+      timeWindow: "15 minutes",
+      keyGenerator: async (req) => {
+        try {
+          const body = (req.body as { mfaPendingToken?: string } | undefined);
+          if (!body?.mfaPendingToken) return req.ip;
+          const decoded = fastify.jwt.decode<{ sub?: string }>(body.mfaPendingToken);
+          return decoded?.sub ?? req.ip;
+        } catch {
+          return req.ip;
+        }
+      },
+    },
+  },
+}, async (request, reply) => { /* ... */ });
+```
+
+#### 7. Tests
+
+- `apps/api/src/lib/mfa.test.ts` — TOTP generation + verification (use
+  `otpauth` to derive the expected code at a fixed timestamp), encrypt
+  round-trip, verify-with-skew tolerance.
+- `apps/api/tests/auth-mfa.test.ts` — integration tests using the same
+  Fastify-inject pattern as `auth-refresh-reuse.test.ts`:
+  - Admin in MFA-required tenant, not enrolled → 412 with
+    `code: "mfa_enrolment_required"`.
+  - Admin in MFA-required tenant, enrolled, wrong code →
+    `auth.mfa_verify_failure` audit, 401.
+  - Admin in MFA-required tenant, enrolled, correct code → 200 +
+    accessToken + refreshToken.
+  - Member (not owner/admin) in MFA-required tenant → bypasses MFA gate
+    (flag is explicitly `mfa_required_for_admins`).
+  - Tenant flag = false → login unchanged for admins.
+  - Reused `mfaPendingToken` → 401 (single-use via the rate limiter;
+    optional: track consumed tokens in Redis).
+
+#### 8. Acceptance criteria for PR A
+
 - Admin in an MFA-required tenant without enrolment cannot log in.
 - After enrolment + verification, login works with code.
-- Scratch code works exactly once.
-- Rate limit on `/v1/auth/mfa/verify` (reuse the existing rate-limit
-  plugin — 10 attempts per 15 min per user_id, not IP).
-- Audit log entries: `auth.mfa_enrolled`, `auth.mfa_verify_success`,
+- Rate limit on `/mfa/verify`: 10/15 min per user_id.
+- Audit logs: `auth.mfa_enrolled`, `auth.mfa_verify_success`,
   `auth.mfa_verify_failure`.
+- Typecheck + full suite green.
+- `schema.sql` migration additive only (no DROP / RENAME on live tables).
+
+#### 9. Enabling on prod for your own verification
+
+After PR A is merged + deployed, manually flip the flag on the
+launch-test tenant (`5d7cd81b-03ed-4309-beba-b8e41ae21ac8`) to test
+end-to-end. Use Railway's SQL editor or `railway connect Postgres`.
+Remember to flip it OFF again before finishing — otherwise PR B
+development is harder because you can't log in without MFA.
+
+### PR B — UI
+
+Start after PR A merges cleanly. Goal: two surfaces.
+
+1. **`/workspace/settings/mfa` page** at
+   `apps/web/src/app/workspace/settings/mfa/page.tsx`. Client component.
+   - "Enrol" button → calls `POST /api/auth/mfa/enrol` (proxied through the BFF).
+     Wait — the BFF proxy routes live at `apps/web/src/app/api/auth/...`; you'll
+     need to add three proxy routes (`mfa/enrol`, `mfa/enrol/confirm`,
+     `mfa/verify`) that use `proxyApiRequest`. Or stand up a single
+     `mfa/[...slug]` catch-all. Pick the catch-all — simpler and future-proof.
+   - Receives `{ secret, otpauthUrl }`. Render QR from `otpauthUrl` (use `qrcode` or
+     `qrcode.react` — check existing deps; if none, add `qrcode` and generate
+     as data URL on server-render).
+   - 6-digit code input → `POST /api/auth/mfa/enrol/confirm`.
+   - On success, flip local state to "enrolled" and show a "disable" button
+     (API endpoint for disable can be a follow-up — stop condition; don't
+     overscope).
+2. **Login page step** at `apps/web/src/app/(auth)/login/page.tsx`.
+   - When `POST /api/auth/login` returns `{ code: "mfa_enrolment_required" }`,
+     show a banner: "This workspace requires MFA. Sign in, enrol, and try
+     again." Link to `/workspace/settings/mfa` (but the user won't have a
+     session — so this link is dead weight; better copy: "Contact your
+     workspace admin".)
+   - When it returns `{ code: "mfa_required", mfaPendingToken }`, show a
+     second input for the 6-digit code. Submit → `POST
+     /api/auth/mfa/verify` with `{ mfaPendingToken, code }`. On success,
+     persist session + redirect to `/workspace`.
+
+Tests: Playwright MCP for UI verification (BotID blocks raw headless —
+see `larry-botid-blocks-headless-playwright.md`).
+
+### Stop conditions for P1-2
+
+- **If scope in PR A blows past 6h of work**, stop and confirm with
+  Fergus whether to drop the "enrolled user gets mfa_pending token" step
+  entirely and instead issue real tokens the moment password verifies —
+  losing the blind-admin MFA requirement but landing SOMETHING. **Don't
+  do this silently.**
+- **If migration 027 would need to drop or rename any column on a live
+  table**, stop — write it additive only.
+- **If you hit the postgres-enum landmine** (see
+  `feedback-pg-enum-add-value.md`), split into two deploys.
 
 ---
 
-## P2 — should ship, no blocker
+## P2-3 Device fingerprint cookie (pick up after MFA)
 
-### P2-1. Refresh-token reuse detection
+Current known-device check at `auth.ts:321-322` does exact
+`(ip, user_agent)` match. Mobile iOS rotates UA on OS updates, and home→
+office Wi-Fi handoffs change IP, so every login triggers the
+new-device email.
 
-If an already-revoked refresh token is presented to `POST /v1/auth/refresh`
-(`routes/v1/auth.ts:377-441`), we return 401 but **do not revoke the
-whole family**. Attacker with a stolen token + slow legit user can keep
-one branch alive.
-
-Fix: when revoked token is reused, revoke **all active refresh tokens
-for that user + tenant** and write an `auth.refresh_reuse_detected`
-audit log. Email the user.
-
-The DB already has `revoked_at` — add a `parent_token_id` column
-(migration 028) so you can trace the family, OR just nuke all active
-tokens for the `(user_id, tenant_id)` pair when reuse is detected.
-Second option is simpler and fine for launch.
-
-### P2-2. Password breach check (HaveIBeenPwned k-anonymous API)
-
-On signup + password reset + password change, SHA-1 the new password,
-send the first 5 hex chars to `https://api.pwnedpasswords.com/range/XXXXX`,
-check the returned list for the rest. If present → reject with
-"This password has appeared in a data breach. Please choose another."
-
-Cache responses in memory for 1 hour to avoid hammering HIBP.
-
-### P2-3. Device fingerprint
-
-Current known-device check is exact `(ip, user_agent)` at
-`auth.ts:321-322`. Mobile OS updates churn the UA and home/office Wi-Fi
-handoffs change IP, so every login triggers the email. Replace with:
-
-- Set a long-lived, httpOnly, secure, sameSite=lax `larry_device_id`
-  cookie on first successful login (random UUID).
-- Persist `device_id` alongside each refresh token.
+**Fix (also one PR):**
+- Set a long-lived (`maxAge: 365 days`), `httpOnly`, `secure`,
+  `sameSite: "lax"` cookie called `larry_device_id` (random UUID) on
+  first successful login.
+- Add `device_id UUID` column to `refresh_tokens` (migration 028, additive).
+- In `issueRefreshToken`, persist `device_id` alongside the token.
 - Known-device = `device_id` cookie matches any non-revoked
-  `refresh_tokens.device_id` for this user within the last 30 days.
+  `refresh_tokens.device_id` for this user in the last 30 days. If
+  unknown AND there are prior sessions for this user, send the
+  new-device alert.
 
-### P2-4. Email trim + bracket normalisation
+Web change: the web layer needs to pass the `larry_device_id` value up
+to the Fastify API on login. Options:
+1. Proxy route reads cookie, passes as `x-device-id` header.
+2. Store the cookie via Next.js, and the Fastify API reads the same
+   cookie (only works if the cookie is set on the root domain — check
+   whether `larry-pm.com` and `larry-site-production.up.railway.app`
+   share a cookie scope; likely they don't, so go with option 1).
 
-`emailSchema` runs `.email()` before `.transform()` so
-`"  user@example.com  "` fails validation. Reorder:
-`z.string().transform((v) => v.trim().toLowerCase()).pipe(z.string().email())`.
-Audit test added in `src/lib/validation.test.ts` but skipped — unskip it.
-
-### P2-5. Session rotation on re-login
-
-When a user logs in while already having an active session, the old
-refresh tokens linger. Add: at the end of the successful /login handler,
-revoke all OTHER active refresh tokens for `(user_id, tenant_id)` that
-were not just issued (exclude the token_hash we minted). Low impact
-because /refresh already rotates, but it's best practice.
-
-### P2-6. Harden headers on auth pages
-
-Add `X-Frame-Options: DENY` and `Referrer-Policy: no-referrer` to the
-`/login`, `/signup`, `/invite/accept`, `/invite/link/[token]`,
-`/verify-email`, `/reset-password` routes. Use a Next.js `middleware.ts`
-matcher, not per-route.
+Tests: unit-level on the device-id resolution, integration via Fastify
+inject with and without the header.
 
 ---
 
-## How to work
+## How to work through this
 
-1. Read `docs/security/login-audit-2026-04-19.md` in full.
-2. Start with P1-1 (CSRF). Create `fix/csrf-enforcement` off master.
-3. For each PR: branch → implement → tests → typecheck
-   (`cd apps/api && npx tsc -p tsconfig.build.json --noEmit`) → full
-   suite (`npx vitest run`) → commit → push → open PR → watch CI → merge
-   → poll Railway until live → prod smoke test → report back to the user.
-4. Update `docs/security/login-audit-2026-04-19.md` as items graduate
-   from "follow-up" to "meets the bar".
-5. Append each shipped PR to memory: create a new
-   `larry-login-<topic>-shipped.md` entry.
+1. Read `docs/security/login-audit-2026-04-19.md` in full, then come
+   back here.
+2. `git checkout master && git pull --ff-only`.
+3. `git checkout -b fix/mfa-api-enforcement` for PR A.
+4. Branch → implement → tests → typecheck
+   (`cd apps/api && npx tsc -p tsconfig.build.json --noEmit`) →
+   full suite (`cd apps/api && npx vitest run`) → commit → push →
+   open PR → watch CI (`gh pr checks NNN --watch --interval 20`) →
+   merge (`gh pr merge NNN --squash --delete-branch --body ""`) →
+   poll Railway health (`curl https://larry-site-production.up.railway.app/health`
+   in an `until` loop) → prod smoke test → report back.
+5. Update `docs/security/login-audit-2026-04-19.md` as items graduate
+   from "follow-up" to "✅ Shipped".
+6. Append each shipped PR to memory: create
+   `larry-login-<topic>-shipped.md` under
+   `C:/Users/oreil/.claude/projects/C--Users-oreil/memory/` and link
+   from `MEMORY.md`.
 
-## When to stop and ask
+---
 
-- If CSRF middleware would require touching >30 call sites in the web
-  app, stop and confirm the central-helper approach is acceptable.
-- If MFA scope blows up beyond 2 days of work, stop and agree on
-  minimal viable surface (TOTP only, no scratch codes, no admin toggle
-  UI — toggle via direct DB update).
-- If a migration would need to drop or rename a column on a live table,
-  stop — write the migration as additive only, deprecate the old column,
-  and schedule removal for a separate cleanup PR.
-- If you hit the postgres-enum landmine (see
-  `feedback-pg-enum-add-value.md`): don't try to USE a new enum value in
-  the same schema.sql batch that ADDs it. Split into two deploys.
+## Tone + autonomy defaults (inherited from the user)
 
-## How to verify on prod
-
-The user's test account: `launch-test-2026@larry-pm.com` /
-`TestLarry123%` (admin, owns tenant `5d7cd81b-03ed-4309-beba-b8e41ae21ac8`
-"Launch Test Org"). API is
-`https://larry-site-production.up.railway.app`. Web is
-`https://larry-pm.com` / `https://www.larry-pm.com`.
-
-Railway CLI is installed and linked; you can probe the DB via
-`railway variables --service Postgres --json` to get DATABASE_PUBLIC_URL,
-but **never commit the URL** and clean up any temp scripts containing it
-before committing.
-
-## Tone + autonomy defaults (from the user)
-
-- Fergus is the user. Terse, concrete replies. No em-dashes unless he
-  uses them. Don't summarize what was just done unless asked.
+- Terse, concrete replies. No em-dashes unless Fergus uses them. Don't
+  summarize what was just done unless asked.
 - Drive through the queue without asking between steps. Self-reflect at
   each decision.
-- Only pause for destructive/ambiguous actions or the stop conditions
-  above.
-- Test on deployed prod, not locally.
+- Only pause for destructive/ambiguous actions or the explicit stop
+  conditions above.
+- Test on deployed prod, not locally (see
+  `testing-on-production.md`).
+- When squash-merging, use `--body ""` to keep the squash commit
+  message clean (the PR title becomes the commit subject).
+- When force-pushing a feature branch, use `--force-with-lease`, never
+  raw `--force`.
+
+---
+
+## One gotcha that bit me twice this sprint
+
+The `gh` CLI occasionally fails the merge with a transient
+`dial tcp ... connection attempt failed` network error. The PR doesn't
+actually merge. Always verify after every merge with:
+
+```bash
+gh pr view NNN --json state,mergedAt,mergeCommit --jq '.'
+```
+
+If `state != "MERGED"`, retry the `gh pr merge` once.
+
+Also: concurrent branch reflow can happen if the user is working on
+other branches in parallel. If you see weird `reset: moving to HEAD~1`
+entries in `git reflog` that you didn't issue, rebase your commit
+cleanly onto master (`git rebase --onto master <base-commit>
+<your-branch>`) and force-push with lease. Don't panic.

--- a/docs/superpowers/plans/2026-04-19-timeline-larry-integration.md
+++ b/docs/superpowers/plans/2026-04-19-timeline-larry-integration.md
@@ -1,0 +1,2436 @@
+# Timeline × Larry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Slice 1 (timeline polish + shared cache + task description field) and Slice 2 (Larry timeline-organisation tools surfaced through the Action Centre). Slice 3 (Gantt v5 features) is roadmap-only in the spec and out of scope for this plan.
+
+**Architecture:** Slice 1 replaces duplicate timeline queries with a single `useTimelineSnapshot` hook feeding both the org and project Gantts; exposes task description in the creation modal; tidies polish debt. Slice 2 introduces an org-wide intelligence pass that emits `timeline_regroup` suggestions into the existing `larry_events` + Action Centre pipeline; a tenant-transactional executor applies accepted suggestions with `SELECT … FOR UPDATE` concurrency safety; frontend adds a preview component and RBAC-gated accept.
+
+**Tech Stack:** PostgreSQL + Fastify 5 (apps/api), Next.js 16 App Router + TanStack Query (apps/web), Vercel AI SDK v6 + Gemini (packages/ai), Vitest for unit tests, Playwright MCP for prod E2E. Types shared via `@larry/shared`.
+
+**Branch:** `feat/timeline-larry-slice-1` for Part A (Slice 1). `feat/timeline-larry-slice-2-migration` and `feat/timeline-larry-slice-2-feature` stacked on top for Part B (Slice 2). Both cut from `master`.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-timeline-larry-integration-design.md`
+
+---
+
+## File map
+
+**Create:**
+- `packages/shared/src/timeline.ts`
+- `packages/shared/src/timeline.test.ts`
+- `apps/web/src/hooks/useTimelineSnapshot.ts`
+- `apps/web/src/hooks/useTimelineSnapshot.test.tsx`
+- `packages/db/src/migrations/027_larry_events_nullable_project.sql`
+- `packages/ai/src/timeline-tools.ts`
+- `packages/ai/src/timeline-tools.test.ts`
+- `packages/ai/src/org-intelligence.ts`
+- `packages/ai/src/org-intelligence.test.ts`
+- `apps/api/src/lib/timeline-suggestion-executor.ts`
+- `apps/api/src/lib/timeline-suggestion-executor.test.ts`
+- `apps/web/src/components/workspace/TimelineSuggestionPreview.tsx`
+- `apps/web/src/components/workspace/TimelineSuggestionPreview.test.tsx`
+
+**Modify:**
+- `packages/shared/src/index.ts` (re-export timeline helpers)
+- `packages/db/src/schema.sql` (reflect migration 027)
+- `apps/web/src/components/workspace/gantt/AddNodeModal.tsx`
+- `apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx`
+- `apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx`
+- `apps/web/src/lib/action-types.ts`
+- `apps/web/src/components/workspace/ActionDetailPreview.tsx`
+- `apps/web/src/hooks/useLarryActionCentre.ts`
+- `packages/ai/src/intelligence.ts` (context builder only — no per-project tool changes)
+- `apps/api/src/routes/v1/larry.ts` (accept handler dispatch)
+- `apps/api/src/routes/v1/index.ts` (register org-scan admin route if new)
+
+---
+
+# PART A — SLICE 1: Polish + Cache + Description
+
+## Task 1: Shared timeline-derivation types and tests
+
+**Files:**
+- Create: `packages/shared/src/timeline.ts`
+- Create: `packages/shared/src/timeline.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/shared/src/timeline.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  toCategorySummaries,
+  toProjectSummaries,
+  type TimelineCategorySummary,
+  type TimelineProjectSummary,
+} from "./timeline";
+import type { PortfolioTimelineResponse } from "./index";
+
+const fixture: PortfolioTimelineResponse = {
+  categories: [
+    {
+      id: "c1", name: "Customer", colour: "#ff0000", sortOrder: 0,
+      parentCategoryId: null, projectId: null,
+      projects: [
+        { id: "p1", name: "Onboarding", status: "active", startDate: null, targetDate: null, tasks: [] },
+        { id: "p2", name: "Renewal",    status: "active", startDate: null, targetDate: null, tasks: [] },
+      ],
+    },
+    {
+      id: null, name: "Uncategorised", colour: null, sortOrder: Number.MAX_SAFE_INTEGER,
+      projects: [
+        { id: "p3", name: "Misc", status: "active", startDate: null, targetDate: null, tasks: [] },
+      ],
+    },
+  ],
+  dependencies: [],
+};
+
+describe("toCategorySummaries", () => {
+  it("skips the synthetic uncategorised bucket", () => {
+    const result = toCategorySummaries(fixture);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("c1");
+  });
+
+  it("normalises optional parent/project fields to null", () => {
+    const result = toCategorySummaries(fixture);
+    expect(result[0].parentCategoryId).toBeNull();
+    expect(result[0].projectId).toBeNull();
+  });
+});
+
+describe("toProjectSummaries", () => {
+  it("returns one entry per project including those under uncategorised", () => {
+    const result = toProjectSummaries(fixture);
+    expect(result).toHaveLength(3);
+  });
+
+  it("stitches the parent categoryId back onto each project", () => {
+    const byId = Object.fromEntries(toProjectSummaries(fixture).map((p) => [p.id, p]));
+    expect(byId.p1.categoryId).toBe("c1");
+    expect(byId.p2.categoryId).toBe("c1");
+    expect(byId.p3.categoryId).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `cd C:/Dev/larry/site-deploys/larry-site && npm --workspace @larry/shared run test`
+Expected: FAIL — `./timeline` module not found.
+
+- [ ] **Step 3: Implement the module**
+
+Create `packages/shared/src/timeline.ts`:
+
+```ts
+import type { PortfolioTimelineResponse } from "./index";
+
+/** Subset of ProjectCategory that's actually needed by timeline renderers. */
+export interface TimelineCategorySummary {
+  id: string;
+  name: string;
+  colour: string | null;
+  sortOrder: number;
+  parentCategoryId: string | null;
+  projectId: string | null;
+}
+
+export interface TimelineProjectSummary {
+  id: string;
+  categoryId: string | null;
+}
+
+export function toCategorySummaries(
+  resp: PortfolioTimelineResponse,
+): TimelineCategorySummary[] {
+  return resp.categories
+    .filter((c): c is (typeof c) & { id: string } => c.id !== null)
+    .map((c) => ({
+      id: c.id,
+      name: c.name,
+      colour: c.colour,
+      sortOrder: c.sortOrder,
+      parentCategoryId: c.parentCategoryId ?? null,
+      projectId: c.projectId ?? null,
+    }));
+}
+
+export function toProjectSummaries(
+  resp: PortfolioTimelineResponse,
+): TimelineProjectSummary[] {
+  return resp.categories.flatMap((c) =>
+    c.projects.map((p) => ({ id: p.id, categoryId: c.id ?? null })),
+  );
+}
+```
+
+- [ ] **Step 4: Re-export from the package root**
+
+Edit `packages/shared/src/index.ts` — append at end of file:
+
+```ts
+export * from "./timeline";
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm --workspace @larry/shared run test`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 6: Build the shared package so downstream workspaces see it**
+
+Run: `npm --workspace @larry/shared run build`
+Expected: no output; `packages/shared/dist/timeline.js` exists.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/shared/src/timeline.ts packages/shared/src/timeline.test.ts packages/shared/src/index.ts
+git commit -m "feat(shared): timeline payload derivation helpers with tests"
+```
+
+---
+
+## Task 2: useTimelineSnapshot hook and tests
+
+**Files:**
+- Create: `apps/web/src/hooks/useTimelineSnapshot.ts`
+- Create: `apps/web/src/hooks/useTimelineSnapshot.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/hooks/useTimelineSnapshot.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PortfolioTimelineResponse } from "@larry/shared";
+import {
+  useTimelineSnapshot,
+  useCategoriesFromTimeline,
+  useProjectsFromTimeline,
+  QK_TIMELINE_ORG,
+} from "./useTimelineSnapshot";
+
+const payload: PortfolioTimelineResponse = {
+  categories: [
+    { id: "c1", name: "X", colour: "#123456", sortOrder: 0, parentCategoryId: null, projectId: null,
+      projects: [{ id: "p1", name: "P", status: "active", startDate: null, targetDate: null, tasks: [] }] },
+  ],
+  dependencies: [],
+};
+
+function makeWrapper(qc: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useTimelineSnapshot", () => {
+  beforeEach(() => { vi.resetAllMocks(); });
+
+  it("fetches and caches the timeline payload", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(payload), { status: 200 }),
+    );
+    const { result } = renderHook(() => useTimelineSnapshot(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => expect(result.current.data).toEqual(payload));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(qc.getQueryData(QK_TIMELINE_ORG)).toEqual(payload);
+  });
+
+  it("does not refetch when the cache is already warm within staleTime", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(QK_TIMELINE_ORG, payload);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { result } = renderHook(() => useCategoriesFromTimeline(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => expect(result.current.data?.categories).toHaveLength(1));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("useProjectsFromTimeline derives items with categoryId stitched", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(QK_TIMELINE_ORG, payload);
+    const { result } = renderHook(() => useProjectsFromTimeline(), { wrapper: makeWrapper(qc) });
+    await waitFor(() => expect(result.current.data?.items).toEqual([{ id: "p1", categoryId: "c1" }]));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `npm --workspace apps/web exec -- vitest run src/hooks/useTimelineSnapshot.test.tsx`
+Expected: FAIL — `./useTimelineSnapshot` not found.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `apps/web/src/hooks/useTimelineSnapshot.ts`:
+
+```ts
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import type { PortfolioTimelineResponse } from "@larry/shared";
+import {
+  toCategorySummaries,
+  toProjectSummaries,
+  type TimelineCategorySummary,
+  type TimelineProjectSummary,
+} from "@larry/shared";
+
+export const QK_TIMELINE_ORG = ["timeline", "org"] as const;
+
+// Single source of truth for the timeline payload. Both the org and
+// project Gantt surfaces read from this hook; no component writes into
+// sibling cache keys.
+export function useTimelineSnapshot() {
+  return useQuery({
+    queryKey: QK_TIMELINE_ORG,
+    queryFn: async (): Promise<PortfolioTimelineResponse> => {
+      const res = await fetch("/api/workspace/timeline", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json();
+    },
+    staleTime: 30_000,
+  });
+}
+
+interface CategoriesView {
+  categories: TimelineCategorySummary[];
+}
+interface ProjectsView {
+  items: TimelineProjectSummary[];
+}
+
+export function useCategoriesFromTimeline() {
+  const { data, ...rest } = useTimelineSnapshot();
+  return {
+    ...rest,
+    data: data ? ({ categories: toCategorySummaries(data) } satisfies CategoriesView) : undefined,
+  };
+}
+
+export function useProjectsFromTimeline() {
+  const { data, ...rest } = useTimelineSnapshot();
+  return {
+    ...rest,
+    data: data ? ({ items: toProjectSummaries(data) } satisfies ProjectsView) : undefined,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --workspace apps/web exec -- vitest run src/hooks/useTimelineSnapshot.test.tsx`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/hooks/useTimelineSnapshot.ts apps/web/src/hooks/useTimelineSnapshot.test.tsx
+git commit -m "feat(web): useTimelineSnapshot hook + derived category/project views"
+```
+
+---
+
+## Task 3: Migrate PortfolioGanttClient to the shared hook
+
+**Files:**
+- Modify: `apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx`
+
+- [ ] **Step 1: Replace the inline useQuery with useTimelineSnapshot**
+
+Edit `PortfolioGanttClient.tsx`:
+
+Replace the import block at lines 4-19:
+
+```ts
+import { useEffect, useMemo, useState } from "react";
+import { Plus, X } from "lucide-react";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+import {
+  DndContext, PointerSensor, useSensor, useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import type { PortfolioTimelineResponse, ContextMenuAction, GanttNode } from "@/components/workspace/gantt/gantt-types";
+import {
+  buildPortfolioTree, buildCategoryColorMap, normalizePortfolioStatuses,
+  validateDrop, type DropContext,
+} from "@/components/workspace/gantt/gantt-utils";
+import { GanttContainer } from "@/components/workspace/gantt/GanttContainer";
+import { AddNodeModal } from "@/components/workspace/gantt/AddNodeModal";
+import { CategoryManagerPanel } from "@/components/workspace/gantt/CategoryManagerPanel";
+import { GanttEmptyState } from "@/components/workspace/gantt/GanttEmptyState";
+import { CategoryColourPopover } from "@/components/workspace/gantt/CategoryColourPopover";
+import type { CategoryOption } from "@/components/workspace/gantt/GanttContextMenu";
+import { useTimelineSnapshot, QK_TIMELINE_ORG } from "@/hooks/useTimelineSnapshot";
+```
+
+Remove lines 23 (`const QK_TIMELINE_ORG = ["timeline", "org"] as const;`) — now imported.
+
+Replace the existing `useQuery` block (roughly lines 46–53) with:
+
+```ts
+const { data, error: queryError, isError: isFetchError, refetch } = useTimelineSnapshot();
+```
+
+Remove the unused `useEffect` import — wait, we now import it but don't use it yet (it was unused before, still unused). Delete `useEffect,` from the React import.
+
+- [ ] **Step 2: Type-check the file**
+
+Run: `npm --workspace apps/web exec -- tsc --noEmit src/app/workspace/timeline/PortfolioGanttClient.tsx`
+Expected: no errors.
+
+(If the tsc invocation fails because the file isn't a project root, run `npm --workspace apps/web exec -- tsc --noEmit` to type-check the whole web app.)
+
+- [ ] **Step 3: Run the existing PortfolioGanttClient suite**
+
+Run: `npm --workspace apps/web exec -- vitest run src/app/workspace/timeline`
+Expected: all pre-existing tests still pass.
+
+- [ ] **Step 4: Manual smoke check on dev server**
+
+```bash
+# Terminal 1
+docker compose up -d
+# Terminal 2
+npm run api:dev
+# Terminal 3
+npm run web:dev
+```
+
+Visit `http://localhost:3000/workspace/timeline`. Confirm: page loads, categories + colours render, DnD still works, add/delete still works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+git commit -m "refactor(web): PortfolioGanttClient reads from useTimelineSnapshot"
+```
+
+---
+
+## Task 4: Migrate ProjectGanttClient to derived views
+
+**Files:**
+- Modify: `apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx`
+
+- [ ] **Step 1: Replace the two standalone queries**
+
+Edit `ProjectGanttClient.tsx`:
+
+At the top, add to imports:
+
+```ts
+import { useCategoriesFromTimeline, useProjectsFromTimeline, QK_TIMELINE_ORG } from "@/hooks/useTimelineSnapshot";
+```
+
+Remove these constants (lines 41-42):
+
+```ts
+const QK_CATEGORIES = ["categories"] as const;
+const QK_PROJECTS = ["projects"] as const;
+```
+
+Replace the two `useQuery` calls (categories + projects, lines 71-88) with:
+
+```ts
+const { data: categoriesData } = useCategoriesFromTimeline();
+const { data: projectsData } = useProjectsFromTimeline();
+```
+
+- [ ] **Step 2: Update the categoryColour lookup**
+
+The function `categoryColour` at lines 95-101 uses `projectsData.items.find` which still works (shape matches). Also uses `categoriesData.categories.map` — still works because the derived view returns `{ categories: TimelineCategorySummary[] }` with the same field names.
+
+But `buildCategoryColorMap` is called with `categoriesData.categories` — verify no extra fields are required. The `TimelineCategorySummary` is missing `tenantId`, `createdAt`, `updatedAt` but `buildCategoryColorMap` only reads `id` and `colour` so we're fine.
+
+Update the type annotation in `allCategories` (line 90):
+
+```ts
+import type { TimelineCategorySummary } from "@larry/shared";
+
+const allCategories: TimelineCategorySummary[] = categoriesData?.categories ?? [];
+```
+
+Remove the old `import type { GanttTask, ProjectCategory, ... }` — keep everything except `ProjectCategory`. Replace with `TimelineCategorySummary`.
+
+(Every remaining reference to `ProjectCategory` in this file should be retyped — `ProjectSummary = { id: string; categoryId: string | null }` can be reused since the derived view matches that shape.)
+
+- [ ] **Step 3: Update the invalidateCategoryCaches helper**
+
+Replace lines 126-129 (`invalidateCategoryCaches`) with:
+
+```ts
+const invalidateCategoryCaches = () => {
+  void qc.invalidateQueries({ queryKey: QK_TIMELINE_ORG });
+};
+```
+
+The single invalidation of the org payload now cascades through both derived views. Drop references to `QK_CATEGORIES` and `QK_PROJECTS` entirely (search-and-delete).
+
+In `moveProjectMutation.onSuccess` (line 168-171), remove `void qc.invalidateQueries({ queryKey: QK_PROJECTS });` — only `invalidateCategoryCaches()` is needed.
+
+In `refreshAll` (lines 240-244), remove `void qc.invalidateQueries({ queryKey: QK_PROJECTS });`.
+
+- [ ] **Step 4: Type-check**
+
+Run: `npm --workspace apps/web exec -- tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Manual smoke test — this is the colour-flash fix**
+
+Dev server running (from Task 3 Step 4). Navigate:
+
+1. Load `/workspace/timeline` — wait for categories to render in colour.
+2. Click into a project row → open its dedicated page (routes through `ProjectWorkspaceView`).
+3. Confirm the project timeline renders category colours on first paint, no neutral-grey flash.
+4. Navigate back to `/workspace/timeline` → confirm no extra network request to `/api/workspace/timeline` (check DevTools Network).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+git commit -m "refactor(web): ProjectGanttClient reads from shared timeline snapshot"
+```
+
+---
+
+## Task 5: AddNodeModal description field
+
+**Files:**
+- Modify: `apps/web/src/components/workspace/gantt/AddNodeModal.tsx`
+- Create: `apps/web/src/components/workspace/gantt/AddNodeModal.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `AddNodeModal.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AddNodeModal } from "./AddNodeModal";
+
+describe("AddNodeModal description field", () => {
+  beforeEach(() => { vi.resetAllMocks(); });
+
+  it("shows the description toggle only in task/subtask modes", () => {
+    const { rerender } = render(
+      <AddNodeModal mode="category" onClose={() => {}} onCreated={() => {}} />,
+    );
+    expect(screen.queryByText(/add description/i)).not.toBeInTheDocument();
+
+    rerender(<AddNodeModal mode="project" onClose={() => {}} onCreated={() => {}} />);
+    expect(screen.queryByText(/add description/i)).not.toBeInTheDocument();
+
+    rerender(<AddNodeModal mode="task" parentProjectId="p" onClose={() => {}} onCreated={() => {}} />);
+    expect(screen.getByText(/add description/i)).toBeInTheDocument();
+
+    rerender(<AddNodeModal mode="subtask" parentProjectId="p" parentTaskId="t" onClose={() => {}} onCreated={() => {}} />);
+    expect(screen.getByText(/add description/i)).toBeInTheDocument();
+  });
+
+  it("sends description in the POST body when typed and submitted", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    const onCreated = vi.fn();
+    render(
+      <AddNodeModal
+        mode="task"
+        parentProjectId="p"
+        onClose={() => {}}
+        onCreated={onCreated}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/task title/i), { target: { value: "New thing" } });
+    fireEvent.click(screen.getByText(/add description/i));
+    fireEvent.change(screen.getByPlaceholderText(/what does this task cover/i), {
+      target: { value: "Investigate why X is slow" },
+    });
+    // both start+due required since requireDates is default-false here;
+    // this test skips the date fields.
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const body = JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body));
+    expect(body.description).toBe("Investigate why X is slow");
+    expect(body.title).toBe("New thing");
+  });
+
+  it("omits description from the POST body when empty", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    render(
+      <AddNodeModal mode="task" parentProjectId="p" onClose={() => {}} onCreated={vi.fn()} />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/task title/i), { target: { value: "Thing" } });
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const body = JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body));
+    expect(body).not.toHaveProperty("description");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm --workspace apps/web exec -- vitest run src/components/workspace/gantt/AddNodeModal.test.tsx`
+Expected: FAIL — `add description` text not found.
+
+- [ ] **Step 3: Implement the description field**
+
+Edit `AddNodeModal.tsx`:
+
+Add `description` state after the existing state hooks (line 37):
+
+```ts
+const [description, setDescription] = useState("");
+const [descOpen, setDescOpen] = useState(false);
+```
+
+In the `handleSave` task/subtask branch (roughly lines 69-81), add before the POST:
+
+```ts
+if (description.trim()) body.description = description.trim();
+```
+
+Insert a collapsible description block into the JSX inside the `isTaskMode && (` block, after the date inputs (roughly line 159, before the `requireDates && datesMissing` hint):
+
+```tsx
+<div>
+  <button
+    type="button"
+    onClick={() => setDescOpen((v) => !v)}
+    style={{
+      background: "transparent",
+      border: 0,
+      padding: 0,
+      fontSize: 11,
+      fontWeight: 600,
+      textTransform: "uppercase",
+      letterSpacing: 1,
+      color: "var(--text-muted)",
+      cursor: "pointer",
+    }}
+  >
+    {descOpen ? "− Description" : "+ Add description"}
+  </button>
+  {descOpen && (
+    <textarea
+      value={description}
+      onChange={(e) => setDescription(e.target.value)}
+      placeholder="What does this task cover? (optional)"
+      rows={3}
+      maxLength={4000}
+      style={{ ...inputStyle, resize: "vertical", marginTop: 6 }}
+    />
+  )}
+</div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --workspace apps/web exec -- vitest run src/components/workspace/gantt/AddNodeModal.test.tsx`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Manual verification**
+
+On dev server, open the timeline, click `+ Task` on a project. Confirm:
+- No description field visible initially.
+- Click "+ Add description" → textarea appears.
+- Type text, submit → new task appears on the timeline.
+- Click the task (hits `TaskDetailDrawer`) → description renders.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/workspace/gantt/AddNodeModal.tsx apps/web/src/components/workspace/gantt/AddNodeModal.test.tsx
+git commit -m "feat(web): optional description field on AddNodeModal"
+```
+
+---
+
+## Task 6: API test for task description persistence
+
+**Files:**
+- Modify: `apps/api/src/routes/v1/tasks.test.ts` (verify exists; create if absent)
+
+- [ ] **Step 1: Check existing coverage**
+
+Run: `grep -n "description" apps/api/src/routes/v1/tasks.test.ts 2>/dev/null || echo "no file"`
+
+If there's no file or no description coverage, proceed; otherwise extend the existing block.
+
+- [ ] **Step 2: Add a description round-trip test**
+
+Append to `tasks.test.ts` (or create with the standard test-server harness used by other `apps/api/src/routes/v1/*.test.ts` files — copy the imports and setup block from `categories.test.ts`):
+
+```ts
+describe("POST /api/v1/tasks — description", () => {
+  it("persists a description and returns it on GET", async () => {
+    const project = await createProject({ tenantId, name: "P" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/tasks",
+      headers: authHeader(user),
+      payload: {
+        projectId: project.id,
+        title: "With desc",
+        description: "A short but meaningful description.",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const created = res.json();
+    const list = await app.inject({
+      method: "GET",
+      url: `/api/v1/tasks?projectId=${project.id}`,
+      headers: authHeader(user),
+    });
+    const found = list.json().items.find((t: { id: string }) => t.id === created.id);
+    expect(found.description).toBe("A short but meaningful description.");
+  });
+
+  it("rejects descriptions over 4000 chars", async () => {
+    const project = await createProject({ tenantId, name: "P" });
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/tasks",
+      headers: authHeader(user),
+      payload: {
+        projectId: project.id,
+        title: "Too long",
+        description: "x".repeat(4001),
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 3: Run the API test**
+
+Run: `npm --workspace apps/api exec -- vitest run src/routes/v1/tasks.test.ts`
+Expected: PASS — new two tests pass plus existing suite.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/routes/v1/tasks.test.ts
+git commit -m "test(api): task description round-trip + length-limit coverage"
+```
+
+---
+
+## Task 7: ErrorBanner colour tokens
+
+**Files:**
+- Modify: `apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx`
+
+- [ ] **Step 1: Replace hard-coded hex with CSS tokens**
+
+Edit the `ErrorBanner` function (bottom of file, starts at line 688).
+
+Replace:
+- `background: "#fdecef"` → `background: "var(--pm-red-light)"`
+- `border: "1px solid #f5c1cb"` → `border: "1px solid var(--pm-red)"`
+- `color: "#8a1f33"` → `color: "var(--pm-red)"`
+
+(There are three occurrences of `#8a1f33` — span, retry button, dismiss button — replace all.)
+
+Add `aria-live="polite"` to the outer `<div role="alert">` element.
+
+- [ ] **Step 2: Type-check and run tests**
+
+Run: `npm --workspace apps/web exec -- tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Visual verification**
+
+Trigger an error on dev (stop the API server, refresh `/workspace/timeline`). Banner should match the existing red used on ProjectGanttClient's mutation-error banner.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+git commit -m "refactor(web): ErrorBanner uses shared pm-red tokens + a11y live region"
+```
+
+---
+
+## Task 8: Slice 1 integration verification and PR
+
+**Files:** (no code — verification)
+
+- [ ] **Step 1: Run the entire affected test surface**
+
+```bash
+npm --workspace @larry/shared run test
+npm --workspace apps/web exec -- vitest run
+npm --workspace apps/api exec -- vitest run
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Build both apps**
+
+```bash
+npm --workspace @larry/shared run build
+npm --workspace apps/web run build
+npm --workspace apps/api run build
+```
+
+Expected: no errors in any of the three.
+
+- [ ] **Step 3: Manual end-to-end smoke on prod test user (Fergus tests on deployed, per memory)**
+
+Push to the feature branch:
+
+```bash
+git push -u origin feat/timeline-larry-slice-1
+```
+
+Once Vercel preview URL is green, log in with `launch-test-2026@larry-pm.com` / `TestLarry123%`. Verify:
+1. `/workspace/timeline` loads, no console errors.
+2. Create a task via the modal — add a description — confirm it saves and reads back in TaskDetailDrawer.
+3. Click into a project → project timeline paints with the correct colours on first frame, no neutral-grey flash.
+4. Navigate back to org timeline → no extra `/api/workspace/timeline` request (Network tab).
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --title "Slice 1: timeline polish, shared cache, task description" --body "$(cat <<'EOF'
+## Summary
+- Single `useTimelineSnapshot` hook feeds both org and project Gantts — kills the colour flash when switching surfaces.
+- `AddNodeModal` gains an optional description field in task/subtask modes (API + DB already supported it).
+- `ErrorBanner` migrated to shared pm-red tokens; `aria-live` for a11y.
+- Shared derivation types in `@larry/shared` so payload drift is a compile error.
+
+Spec: `docs/superpowers/specs/2026-04-19-timeline-larry-integration-design.md` §1.
+
+## Test plan
+- [x] Shared types: 4 unit tests
+- [x] useTimelineSnapshot: 3 unit tests
+- [x] AddNodeModal description: 3 component tests
+- [x] Task description round-trip: 2 API tests
+- [x] Manual: org → project navigation no-flash, description persist
+- [ ] Reviewer smoke on preview URL
+
+Slice 2 (Larry timeline tools) will be stacked on top once this lands.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Monitor the merge + prod deploy**
+
+Once reviewed + merged to master, watch `vercel ls ailarry` and `gh run list --limit 5` for the prod deploy. Verify prod smoke (same four checks as Step 3).
+
+---
+
+# PART B — SLICE 2: Larry timeline tools
+
+Part B is cut from `master` AFTER Part A merges. Migration is its own branch and PR so it lands before the code that relies on it.
+
+---
+
+## Task 9: Migration 027 — nullable `larry_events.project_id`
+
+**Files:**
+- Create: `packages/db/src/migrations/027_larry_events_nullable_project.sql`
+- Modify: `packages/db/src/schema.sql`
+
+- [ ] **Step 1: Write the migration**
+
+Create `packages/db/src/migrations/027_larry_events_nullable_project.sql`:
+
+```sql
+-- Migration 027 — make larry_events.project_id nullable so Larry can
+-- emit org-wide timeline_* suggestions (no single project anchor).
+--
+-- Forward: ALTER column + CHECK constraint + partial index.
+-- Rollback: SET NOT NULL after deleting any org-scope rows.
+-- Safe: instant metadata change on Postgres, no table rewrite.
+
+BEGIN;
+
+ALTER TABLE larry_events
+  ALTER COLUMN project_id DROP NOT NULL;
+
+ALTER TABLE larry_events
+  ADD CONSTRAINT larry_events_project_scope_check
+  CHECK (
+    project_id IS NOT NULL
+    OR action_type LIKE 'timeline\_%' ESCAPE '\'
+  );
+
+CREATE INDEX IF NOT EXISTS idx_larry_events_org_pending
+  ON larry_events (tenant_id, created_at DESC)
+  WHERE project_id IS NULL AND event_type = 'suggested';
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply the migration locally**
+
+```bash
+docker compose up -d
+npm --workspace @larry/db run migrate
+```
+
+Expected: migration runs, no errors. Verify:
+
+```bash
+docker compose exec db psql -U postgres -d larry -c "\d larry_events" | grep project_id
+```
+
+Expected output includes `project_id ... uuid |` (no `not null`).
+
+- [ ] **Step 3: Update schema.sql to reflect the new shape**
+
+Edit `packages/db/src/schema.sql` at line 1067:
+
+Before:
+```sql
+  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+```
+
+After:
+```sql
+  project_id   UUID REFERENCES projects(id) ON DELETE CASCADE,
+```
+
+Then append, at the end of the `larry_events` ALTER TABLE block (after line 1131), the migration's additions so a fresh schema.sql run produces the same shape:
+
+```sql
+-- Migration 027: org-scope suggestions have no single project anchor.
+ALTER TABLE larry_events
+  ALTER COLUMN project_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'larry_events_project_scope_check'
+  ) THEN
+    ALTER TABLE larry_events
+      ADD CONSTRAINT larry_events_project_scope_check
+      CHECK (
+        project_id IS NOT NULL
+        OR action_type LIKE 'timeline\_%' ESCAPE '\'
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_larry_events_org_pending
+  ON larry_events (tenant_id, created_at DESC)
+  WHERE project_id IS NULL AND event_type = 'suggested';
+```
+
+- [ ] **Step 4: Rerun schema.sql on a fresh DB to confirm idempotency**
+
+```bash
+docker compose down -v
+docker compose up -d
+sleep 5
+npm --workspace @larry/db run migrate
+```
+
+Expected: clean apply, same output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db/src/migrations/027_larry_events_nullable_project.sql packages/db/src/schema.sql
+git commit -m "feat(db): migration 027 — larry_events.project_id nullable for timeline actions"
+```
+
+- [ ] **Step 6: Push, open PR, merge and deploy BEFORE writing any code that depends on it**
+
+```bash
+git push -u origin feat/timeline-larry-slice-2-migration
+gh pr create --title "Slice 2 migration: larry_events.project_id nullable" --body "Enables org-scope timeline_* suggestions. Zero-downtime ALTER (metadata only). See spec §2.1."
+```
+
+Wait for merge + Railway deploy. Confirm the constraint is live in prod (use the Railway console) before starting Task 10 et seq.
+
+---
+
+## Task 10: Action-type tags for timeline suggestions
+
+**Files:**
+- Modify: `apps/web/src/lib/action-types.ts`
+
+Branch from `master` onto `feat/timeline-larry-slice-2-feature` for all subsequent tasks.
+
+- [ ] **Step 1: Add the three new entries**
+
+Edit `apps/web/src/lib/action-types.ts`, inside `ACTION_TYPE_MAP` (append before `other:`):
+
+```ts
+timeline_regroup:     { key: "timeline_regroup",     label: "Reorganise Timeline", color: "#6c44f6" },
+timeline_categorise:  { key: "timeline_categorise",  label: "New Category",        color: "#6c44f6" },
+timeline_recolour:    { key: "timeline_recolour",    label: "Category Colour",     color: "#6c44f6" },
+```
+
+- [ ] **Step 2: Smoke-check by calling `getActionTypeTag`**
+
+Add a quick unit test at `apps/web/src/lib/action-types.test.ts` (create if missing):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { getActionTypeTag } from "./action-types";
+
+describe("action-types map", () => {
+  it("returns tags for timeline actions", () => {
+    expect(getActionTypeTag("timeline_regroup").label).toBe("Reorganise Timeline");
+    expect(getActionTypeTag("timeline_categorise").label).toBe("New Category");
+    expect(getActionTypeTag("timeline_recolour").label).toBe("Category Colour");
+  });
+  it("falls back to other for unknown types", () => {
+    expect(getActionTypeTag("nope").label).toBe("Other");
+  });
+});
+```
+
+Run: `npm --workspace apps/web exec -- vitest run src/lib/action-types.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/action-types.ts apps/web/src/lib/action-types.test.ts
+git commit -m "feat(web): action-type tags for timeline_regroup / categorise / recolour"
+```
+
+---
+
+## Task 11: Executor — skeleton, types, concurrency guard (TDD)
+
+**Files:**
+- Create: `apps/api/src/lib/timeline-suggestion-executor.ts`
+- Create: `apps/api/src/lib/timeline-suggestion-executor.test.ts`
+
+- [ ] **Step 1: Write the failing concurrency-guard test**
+
+Create `timeline-suggestion-executor.test.ts` (copy the test-harness setup from any existing API test — `categories.test.ts` is the nearest analogue):
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { makeTestApp, createTenantFixture, createAdminUser, insertLarryEvent } from "../test/test-harness";
+import { executeTimelineSuggestion } from "./timeline-suggestion-executor";
+
+describe("executeTimelineSuggestion — concurrency guard", () => {
+  let app: Awaited<ReturnType<typeof makeTestApp>>;
+  let tenantId: string;
+  let actorUserId: string;
+
+  beforeEach(async () => {
+    app = await makeTestApp();
+    const t = await createTenantFixture(app);
+    tenantId = t.tenantId;
+    actorUserId = (await createAdminUser(app, tenantId)).id;
+  });
+
+  it("no-ops when the event is already accepted", async () => {
+    const eventId = await insertLarryEvent(app, {
+      tenantId, actionType: "timeline_regroup",
+      eventType: "accepted", payload: {},
+    });
+    const result = await executeTimelineSuggestion(
+      app, tenantId, eventId, { displayText: "x", reasoning: "x" }, actorUserId,
+    );
+    expect(result.skipped).toContainEqual({ reason: "already_resolved" });
+    expect(result.applied).toEqual({ categories: 0, moves: 0, recolours: 0 });
+  });
+
+  it("throws when the event does not exist", async () => {
+    await expect(
+      executeTimelineSuggestion(
+        app, tenantId, "00000000-0000-0000-0000-000000000000",
+        { displayText: "x", reasoning: "x" }, actorUserId,
+      ),
+    ).rejects.toThrow(/not found/i);
+  });
+});
+```
+
+(Utility helpers `insertLarryEvent`, `createAdminUser` and `createTenantFixture` — if they don't yet exist in `apps/api/src/test/test-harness.ts`, add them now. They should be small.)
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the skeleton**
+
+Create `apps/api/src/lib/timeline-suggestion-executor.ts`:
+
+```ts
+import type { FastifyInstance } from "fastify";
+
+export interface TimelineRegroupPayload {
+  displayText: string;
+  reasoning: string;
+  createCategories?: Array<{ tempId: string; name: string; colour: string }>;
+  moveProjects?: Array<{ projectId: string; toCategoryTempId?: string; toCategoryId?: string }>;
+  recolourCategories?: Array<{ categoryId: string; colour: string }>;
+}
+
+export interface ExecuteResult {
+  applied: { categories: number; moves: number; recolours: number };
+  skipped: Array<{ reason: string; projectId?: string; categoryId?: string }>;
+}
+
+export async function executeTimelineSuggestion(
+  fastify: FastifyInstance,
+  tenantId: string,
+  eventId: string,
+  payload: TimelineRegroupPayload,
+  actorUserId: string,
+): Promise<ExecuteResult> {
+  return fastify.db.transactionTenant(tenantId, async (tx) => {
+    // Concurrency guard — first statement in the transaction.
+    const rows = await tx.queryTenant<{ id: string; eventType: string }>(
+      tenantId,
+      `SELECT id, event_type AS "eventType" FROM larry_events
+        WHERE id = $1 AND tenant_id = $2
+        FOR UPDATE`,
+      [eventId, tenantId],
+    );
+    if (rows.length === 0) {
+      throw new Error(`larry_events row ${eventId} not found for tenant ${tenantId}`);
+    }
+    if (rows[0].eventType !== "suggested") {
+      return {
+        applied: { categories: 0, moves: 0, recolours: 0 },
+        skipped: [{ reason: "already_resolved" }],
+      };
+    }
+
+    // Slices filled in by Tasks 12-14.
+    const applied = { categories: 0, moves: 0, recolours: 0 };
+    const skipped: ExecuteResult["skipped"] = [];
+
+    // Mark the event accepted (moved into its own function in Task 14).
+    await tx.queryTenant(tenantId,
+      `UPDATE larry_events
+          SET event_type = 'accepted',
+              approved_by_user_id = $2,
+              approved_at = NOW(),
+              execution_mode = 'approval',
+              executed_by_kind = 'user',
+              executed_by_user_id = $2
+        WHERE id = $1 AND tenant_id = $3`,
+      [eventId, actorUserId, tenantId],
+    );
+
+    return { applied, skipped };
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/timeline-suggestion-executor.ts apps/api/src/lib/timeline-suggestion-executor.test.ts
+git commit -m "feat(api): timeline-suggestion executor skeleton with concurrency guard"
+```
+
+---
+
+## Task 12: Executor — createCategories with tempId resolution
+
+**Files:**
+- Modify: `apps/api/src/lib/timeline-suggestion-executor.ts`
+- Modify: `apps/api/src/lib/timeline-suggestion-executor.test.ts`
+
+- [ ] **Step 1: Add failing test for happy-path category creation**
+
+Append to `timeline-suggestion-executor.test.ts`:
+
+```ts
+describe("executeTimelineSuggestion — createCategories", () => {
+  let app: Awaited<ReturnType<typeof makeTestApp>>;
+  let tenantId: string;
+  let actorUserId: string;
+
+  beforeEach(async () => {
+    app = await makeTestApp();
+    const t = await createTenantFixture(app);
+    tenantId = t.tenantId;
+    actorUserId = (await createAdminUser(app, tenantId)).id;
+  });
+
+  it("inserts new categories and returns applied count", async () => {
+    const eventId = await insertLarryEvent(app, {
+      tenantId, actionType: "timeline_regroup",
+      eventType: "suggested", payload: {},
+    });
+    const result = await executeTimelineSuggestion(
+      app, tenantId, eventId,
+      {
+        displayText: "x", reasoning: "x",
+        createCategories: [
+          { tempId: "cat_a", name: "Customer Onboarding", colour: "#5fb4d3" },
+          { tempId: "cat_b", name: "Internal Tooling",    colour: "#f5b143" },
+        ],
+      },
+      actorUserId,
+    );
+    expect(result.applied.categories).toBe(2);
+    const rows = await app.db.queryTenant(tenantId,
+      `SELECT id, name, colour FROM project_categories
+        WHERE tenant_id = $1 AND name IN ('Customer Onboarding', 'Internal Tooling')`,
+      [tenantId]);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("reuses an existing category on unique-name collision", async () => {
+    // Pre-create a category the suggestion will collide with.
+    await app.db.queryTenant(tenantId,
+      `INSERT INTO project_categories (tenant_id, name, colour) VALUES ($1, 'Existing', '#000000')`,
+      [tenantId]);
+    const eventId = await insertLarryEvent(app, {
+      tenantId, actionType: "timeline_regroup",
+      eventType: "suggested", payload: {},
+    });
+    const result = await executeTimelineSuggestion(
+      app, tenantId, eventId,
+      {
+        displayText: "x", reasoning: "x",
+        createCategories: [{ tempId: "cat_x", name: "Existing", colour: "#111111" }],
+      },
+      actorUserId,
+    );
+    expect(result.applied.categories).toBe(0);
+    expect(result.skipped.some((s) => s.reason === "category_name_already_exists")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to see both fail**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: FAIL — executor doesn't process `createCategories` yet.
+
+- [ ] **Step 3: Implement category creation inside the executor**
+
+Edit `timeline-suggestion-executor.ts`. Between the concurrency-guard block and the `UPDATE larry_events` block, insert:
+
+```ts
+const tempIdToRealId = new Map<string, string>();
+
+for (const cat of payload.createCategories ?? []) {
+  try {
+    const [row] = await tx.queryTenant<{ id: string }>(tenantId,
+      `INSERT INTO project_categories (tenant_id, name, colour)
+       VALUES ($1, $2, $3)
+       RETURNING id`,
+      [tenantId, cat.name, cat.colour],
+    );
+    tempIdToRealId.set(cat.tempId, row.id);
+    applied.categories += 1;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "";
+    if (!/unique/i.test(msg)) throw e;
+    const [existing] = await tx.queryTenant<{ id: string }>(tenantId,
+      `SELECT id FROM project_categories
+        WHERE tenant_id = $1 AND name = $2 AND parent_category_id IS NULL AND project_id IS NULL`,
+      [tenantId, cat.name],
+    );
+    if (existing) {
+      tempIdToRealId.set(cat.tempId, existing.id);
+      skipped.push({ reason: "category_name_already_exists", categoryId: existing.id });
+    } else {
+      throw e;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: PASS — 4 tests (2 prior + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/timeline-suggestion-executor.ts apps/api/src/lib/timeline-suggestion-executor.test.ts
+git commit -m "feat(api): executor creates categories with tempId map + collision reuse"
+```
+
+---
+
+## Task 13: Executor — moveProjects with tempId and UUID resolution
+
+**Files:**
+- Modify: `apps/api/src/lib/timeline-suggestion-executor.ts`
+- Modify: `apps/api/src/lib/timeline-suggestion-executor.test.ts`
+
+- [ ] **Step 1: Failing tests — moveProjects happy and missing-project paths**
+
+Append:
+
+```ts
+describe("executeTimelineSuggestion — moveProjects", () => {
+  let app: Awaited<ReturnType<typeof makeTestApp>>;
+  let tenantId: string;
+  let actorUserId: string;
+
+  beforeEach(async () => {
+    app = await makeTestApp();
+    const t = await createTenantFixture(app);
+    tenantId = t.tenantId;
+    actorUserId = (await createAdminUser(app, tenantId)).id;
+  });
+
+  it("moves projects to a tempId-resolved category in the same transaction", async () => {
+    const p1 = await createProject({ tenantId, name: "P1" });
+    const p2 = await createProject({ tenantId, name: "P2" });
+    const eventId = await insertLarryEvent(app, {
+      tenantId, actionType: "timeline_regroup",
+      eventType: "suggested", payload: {},
+    });
+    const result = await executeTimelineSuggestion(
+      app, tenantId, eventId,
+      {
+        displayText: "x", reasoning: "x",
+        createCategories: [{ tempId: "cat_new", name: "Theme", colour: "#222222" }],
+        moveProjects: [
+          { projectId: p1.id, toCategoryTempId: "cat_new" },
+          { projectId: p2.id, toCategoryTempId: "cat_new" },
+        ],
+      },
+      actorUserId,
+    );
+    expect(result.applied.moves).toBe(2);
+    const rows = await app.db.queryTenant(tenantId,
+      `SELECT id, category_id FROM projects WHERE id IN ($1, $2)`,
+      [p1.id, p2.id]);
+    expect(rows.every((r: { category_id: string }) => r.category_id)).toBe(true);
+  });
+
+  it("skips missing project ids", async () => {
+    const eventId = await insertLarryEvent(app, {
+      tenantId, actionType: "timeline_regroup",
+      eventType: "suggested", payload: {},
+    });
+    const fakeId = "00000000-0000-0000-0000-000000000aaa";
+    const result = await executeTimelineSuggestion(
+      app, tenantId, eventId,
+      {
+        displayText: "x", reasoning: "x",
+        moveProjects: [{ projectId: fakeId, toCategoryId: "00000000-0000-0000-0000-000000000bbb" }],
+      },
+      actorUserId,
+    );
+    expect(result.applied.moves).toBe(0);
+    expect(result.skipped).toContainEqual(
+      expect.objectContaining({ reason: "project_not_found", projectId: fakeId }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to see failure**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: FAIL — moveProjects path not implemented.
+
+- [ ] **Step 3: Implement moveProjects in the executor**
+
+Insert after the `createCategories` loop, before the `UPDATE larry_events` block:
+
+```ts
+for (const mv of payload.moveProjects ?? []) {
+  const targetCategoryId =
+    mv.toCategoryTempId ? tempIdToRealId.get(mv.toCategoryTempId) :
+    mv.toCategoryId ?? null;
+  if (mv.toCategoryTempId && !targetCategoryId) {
+    skipped.push({ reason: "category_tempid_not_resolved", categoryId: mv.toCategoryTempId });
+    continue;
+  }
+  const upd = await tx.queryTenant(tenantId,
+    `UPDATE projects SET category_id = $1 WHERE id = $2 AND tenant_id = $3`,
+    [targetCategoryId ?? null, mv.projectId, tenantId],
+  );
+  // queryTenant on a pg pool returns an array of rows; pg's driver attaches
+  // rowCount on the raw result. The project-scoped helper should expose it as
+  // `affectedRowCount`. If it doesn't: run a SELECT pre-check instead.
+  const [existing] = await tx.queryTenant<{ id: string }>(tenantId,
+    `SELECT id FROM projects WHERE id = $1 AND tenant_id = $2`,
+    [mv.projectId, tenantId],
+  );
+  if (!existing) {
+    skipped.push({ reason: "project_not_found", projectId: mv.projectId });
+  } else {
+    applied.moves += 1;
+  }
+}
+```
+
+Note: the comment about `affectedRowCount` handles the likely case that `queryTenant` doesn't return rowcount; using a pre-SELECT for existence keeps the plan robust across drivers. If the driver DOES expose it, simplify at PR time.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/lib/timeline-suggestion-executor.ts apps/api/src/lib/timeline-suggestion-executor.test.ts
+git commit -m "feat(api): executor applies project moves with tempId/UUID resolution"
+```
+
+---
+
+## Task 14: Executor — recolourCategories + audit log
+
+**Files:**
+- Modify: `apps/api/src/lib/timeline-suggestion-executor.ts`
+- Modify: `apps/api/src/lib/timeline-suggestion-executor.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```ts
+describe("executeTimelineSuggestion — recolourCategories", () => {
+  let app: Awaited<ReturnType<typeof makeTestApp>>;
+  let tenantId: string;
+  let actorUserId: string;
+
+  beforeEach(async () => {
+    app = await makeTestApp();
+    const t = await createTenantFixture(app);
+    tenantId = t.tenantId;
+    actorUserId = (await createAdminUser(app, tenantId)).id;
+  });
+
+  it("updates colour on an existing category", async () => {
+    const [{ id: catId }] = await app.db.queryTenant<{ id: string }>(tenantId,
+      `INSERT INTO project_categories (tenant_id, name, colour) VALUES ($1, 'X', '#000000') RETURNING id`,
+      [tenantId]);
+    const eventId = await insertLarryEvent(app, {
+      tenantId, actionType: "timeline_recolour",
+      eventType: "suggested", payload: {},
+    });
+    const result = await executeTimelineSuggestion(
+      app, tenantId, eventId,
+      { displayText: "x", reasoning: "x",
+        recolourCategories: [{ categoryId: catId, colour: "#abcdef" }] },
+      actorUserId,
+    );
+    expect(result.applied.recolours).toBe(1);
+    const [row] = await app.db.queryTenant<{ colour: string }>(tenantId,
+      `SELECT colour FROM project_categories WHERE id = $1`, [catId]);
+    expect(row.colour).toBe("#abcdef");
+  });
+
+  it("skips missing categories", async () => {
+    const eventId = await insertLarryEvent(app, {
+      tenantId, actionType: "timeline_recolour",
+      eventType: "suggested", payload: {},
+    });
+    const result = await executeTimelineSuggestion(
+      app, tenantId, eventId,
+      { displayText: "x", reasoning: "x",
+        recolourCategories: [{ categoryId: "00000000-0000-0000-0000-000000000000", colour: "#fff000" }] },
+      actorUserId,
+    );
+    expect(result.applied.recolours).toBe(0);
+    expect(result.skipped).toContainEqual(
+      expect.objectContaining({ reason: "category_not_found" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to see failure**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: FAIL on the new tests.
+
+- [ ] **Step 3: Implement recolourCategories**
+
+In the executor, after the `moveProjects` loop, insert:
+
+```ts
+for (const rc of payload.recolourCategories ?? []) {
+  const [existing] = await tx.queryTenant<{ id: string }>(tenantId,
+    `SELECT id FROM project_categories WHERE id = $1 AND tenant_id = $2`,
+    [rc.categoryId, tenantId],
+  );
+  if (!existing) {
+    skipped.push({ reason: "category_not_found", categoryId: rc.categoryId });
+    continue;
+  }
+  await tx.queryTenant(tenantId,
+    `UPDATE project_categories SET colour = $1 WHERE id = $2 AND tenant_id = $3`,
+    [rc.colour, rc.categoryId, tenantId],
+  );
+  applied.recolours += 1;
+}
+```
+
+- [ ] **Step 4: Add audit-log writes**
+
+At the top of the executor, import:
+
+```ts
+import { writeAuditLog } from "./audit.js";
+```
+
+After each of the three application loops (categories, moves, recolours), when `applied.*` is incremented, also call:
+
+```ts
+await writeAuditLog(tx, tenantId, actorUserId, {
+  sourceKind: "larry_suggestion",
+  sourceRecordId: eventId,
+  action: "timeline_regroup.category_created",  // or moved / recoloured
+  targetId: row.id,  // or mv.projectId / rc.categoryId
+});
+```
+
+(Check `writeAuditLog` signature in `apps/api/src/lib/audit.ts` — adjust parameters to match.)
+
+- [ ] **Step 5: Run full executor suite**
+
+Run: `npm --workspace apps/api exec -- vitest run src/lib/timeline-suggestion-executor.test.ts`
+Expected: PASS — 8 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/lib/timeline-suggestion-executor.ts apps/api/src/lib/timeline-suggestion-executor.test.ts
+git commit -m "feat(api): executor recolours categories + writes audit log"
+```
+
+---
+
+## Task 15: AI tool definition — proposeTimelineRegroup
+
+**Files:**
+- Create: `packages/ai/src/timeline-tools.ts`
+- Create: `packages/ai/src/timeline-tools.test.ts`
+
+- [ ] **Step 1: Failing tests — schema validation**
+
+Create `packages/ai/src/timeline-tools.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { TimelineRegroupArgsSchema } from "./timeline-tools";
+
+describe("TimelineRegroupArgsSchema", () => {
+  it("accepts a valid payload with all three kinds of change", () => {
+    const parsed = TimelineRegroupArgsSchema.parse({
+      displayText: "Group 4 projects under Customer Onboarding",
+      reasoning: "Four projects share onboarding signals from last month's meetings",
+      createCategories: [{ tempId: "cat_a1", name: "Customer Onboarding", colour: "#5fb4d3" }],
+      moveProjects: [
+        { projectId: "00000000-0000-0000-0000-000000000001", toCategoryTempId: "cat_a1" },
+      ],
+      recolourCategories: [
+        { categoryId: "00000000-0000-0000-0000-000000000002", colour: "#111111" },
+      ],
+    });
+    expect(parsed.createCategories).toHaveLength(1);
+  });
+
+  it("rejects more than 10 moveProjects", () => {
+    const moves = Array.from({ length: 11 }, (_, i) => ({
+      projectId: `00000000-0000-0000-0000-00000000000${i % 10}`.padEnd(36, "0"),
+      toCategoryId: "00000000-0000-0000-0000-000000000aaa",
+    }));
+    const r = TimelineRegroupArgsSchema.safeParse({
+      displayText: "x".repeat(20), reasoning: "y".repeat(40), moveProjects: moves,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects empty payload (no changes)", () => {
+    const r = TimelineRegroupArgsSchema.safeParse({
+      displayText: "x".repeat(20), reasoning: "y".repeat(40),
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects when moveProjects has both toCategoryTempId AND toCategoryId", () => {
+    const r = TimelineRegroupArgsSchema.safeParse({
+      displayText: "x".repeat(20), reasoning: "y".repeat(40),
+      moveProjects: [{
+        projectId: "00000000-0000-0000-0000-000000000001",
+        toCategoryTempId: "cat_x",
+        toCategoryId:     "00000000-0000-0000-0000-000000000aaa",
+      }],
+    });
+    expect(r.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to see failure**
+
+Run: `npm --workspace @larry/ai exec -- vitest run src/timeline-tools.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `packages/ai/src/timeline-tools.ts`:
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+import type { FastifyInstance } from "fastify";
+
+export const TimelineRegroupArgsSchema = z.object({
+  displayText: z.string().min(10).max(140),
+  reasoning: z.string().min(20).max(600),
+  createCategories: z
+    .array(z.object({
+      tempId: z.string().regex(/^cat_[a-z0-9]{4,12}$/),
+      name: z.string().min(1).max(60),
+      colour: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+    }))
+    .max(5)
+    .optional(),
+  moveProjects: z
+    .array(z.object({
+      projectId: z.string().uuid(),
+      toCategoryTempId: z.string().optional(),
+      toCategoryId: z.string().uuid().optional(),
+    }).refine((v) =>
+      (v.toCategoryTempId == null) !== (v.toCategoryId == null),
+      "exactly one of toCategoryTempId / toCategoryId required",
+    ))
+    .max(10)
+    .optional(),
+  recolourCategories: z
+    .array(z.object({
+      categoryId: z.string().uuid(),
+      colour: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+    }))
+    .max(10)
+    .optional(),
+}).refine((v) =>
+  (v.createCategories?.length ?? 0)
+  + (v.moveProjects?.length ?? 0)
+  + (v.recolourCategories?.length ?? 0) >= 1,
+  "At least one change is required"
+);
+
+export type TimelineRegroupArgs = z.infer<typeof TimelineRegroupArgsSchema>;
+
+export interface TimelineToolContext {
+  fastify: FastifyInstance;
+  tenantId: string;
+}
+
+export function buildProposeTimelineRegroupTool(ctx: TimelineToolContext) {
+  return tool({
+    description:
+      "Propose grouping projects under new or existing categories, with optional colour " +
+      "assignments. Only call when 3+ projects share strong signals (meeting transcripts, " +
+      "task-title patterns, shared stakeholders). Do NOT call if a similar timeline_regroup " +
+      "suggestion is already pending — the list of pending suggestions is provided in the " +
+      "system prompt under pendingTimelineSuggestions.",
+    parameters: TimelineRegroupArgsSchema,
+    execute: async (args) => {
+      const [row] = await ctx.fastify.db.queryTenant<{ id: string }>(
+        ctx.tenantId,
+        `INSERT INTO larry_events
+           (tenant_id, project_id, event_type, action_type, display_text, reasoning,
+            payload, triggered_by, execution_mode, source_kind)
+         VALUES ($1, NULL, 'suggested', 'timeline_regroup', $2, $3, $4::jsonb,
+                 'schedule', 'approval', 'schedule')
+         RETURNING id`,
+        [ctx.tenantId, args.displayText, args.reasoning, JSON.stringify(args)],
+      );
+      return { eventId: row.id, status: "pending" as const };
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm --workspace @larry/ai exec -- vitest run src/timeline-tools.test.ts`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ai/src/timeline-tools.ts packages/ai/src/timeline-tools.test.ts
+git commit -m "feat(ai): proposeTimelineRegroup tool with Zod-validated payload"
+```
+
+---
+
+## Task 16: Org-wide intelligence pass
+
+**Files:**
+- Create: `packages/ai/src/org-intelligence.ts`
+- Create: `packages/ai/src/org-intelligence.test.ts`
+
+- [ ] **Step 1: Write the context-builder failing test**
+
+Create `packages/ai/src/org-intelligence.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildOrgTimelineContext, shouldRunOrgPass } from "./org-intelligence";
+
+describe("buildOrgTimelineContext", () => {
+  it("compresses categories + projects into a tabular format", () => {
+    const ctx = buildOrgTimelineContext({
+      tenantId: "t",
+      categories: [
+        { id: "c1", name: "A", colour: "#fff", parentCategoryId: null, projectId: null, createdAt: "", lastRenamedAt: null },
+      ],
+      projects: [
+        { id: "p1", name: "P1", categoryId: "c1", status: "active", createdAt: "" },
+      ],
+      recentSignals: [],
+      pendingTimelineSuggestions: [],
+    });
+    expect(ctx).toMatch(/c1\|A/);
+    expect(ctx).toMatch(/p1\|P1\|c1/);
+  });
+
+  it("truncates recentSignals to 20 × 200 chars", () => {
+    const signals = Array.from({ length: 30 }, (_, i) => ({
+      projectId: "p",
+      source: "email",
+      excerpt: "x".repeat(400) + "_" + i,
+    }));
+    const ctx = buildOrgTimelineContext({
+      tenantId: "t", categories: [], projects: [],
+      recentSignals: signals, pendingTimelineSuggestions: [],
+    });
+    const signalLines = ctx.split("\n").filter((l) => l.startsWith("signal|"));
+    expect(signalLines).toHaveLength(20);
+    for (const line of signalLines) expect(line.length).toBeLessThanOrEqual(250);
+  });
+});
+
+describe("shouldRunOrgPass", () => {
+  it("skips when 3 or more pending timeline suggestions already exist", () => {
+    expect(shouldRunOrgPass({ pendingCount: 3, lastRunMinutesAgo: 120 })).toBe(false);
+    expect(shouldRunOrgPass({ pendingCount: 4, lastRunMinutesAgo: 120 })).toBe(false);
+  });
+  it("skips when the last run was less than an hour ago", () => {
+    expect(shouldRunOrgPass({ pendingCount: 0, lastRunMinutesAgo: 30 })).toBe(false);
+    expect(shouldRunOrgPass({ pendingCount: 0, lastRunMinutesAgo: 60 })).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+Create `packages/ai/src/org-intelligence.ts`:
+
+```ts
+import type { FastifyInstance } from "fastify";
+import { generateText } from "ai";
+import { createModel } from "./provider.js";
+import { buildProposeTimelineRegroupTool } from "./timeline-tools.js";
+
+export interface OrgTimelineContextInput {
+  tenantId: string;
+  categories: Array<{
+    id: string; name: string; colour: string | null;
+    parentCategoryId: string | null; projectId: string | null;
+    createdAt: string; lastRenamedAt: string | null;
+  }>;
+  projects: Array<{
+    id: string; name: string; categoryId: string | null;
+    status: string; createdAt: string;
+  }>;
+  recentSignals: Array<{ projectId: string; source: string; excerpt: string }>;
+  pendingTimelineSuggestions: string[];
+}
+
+// Pipe-separated tabular format: cheap to tokenise, easy for Larry to parse.
+// Keeps context under ~2k tokens for a workspace with up to 200 projects.
+export function buildOrgTimelineContext(input: OrgTimelineContextInput): string {
+  const lines: string[] = [];
+  lines.push("# Categories (id|name|parentId|projectScope)");
+  for (const c of input.categories) {
+    lines.push(`cat|${c.id}|${c.name}|${c.parentCategoryId ?? ""}|${c.projectId ?? ""}`);
+  }
+  lines.push("");
+  lines.push("# Projects (id|name|categoryId|status)");
+  for (const p of input.projects) {
+    lines.push(`proj|${p.id}|${p.name}|${p.categoryId ?? ""}|${p.status}`);
+  }
+  lines.push("");
+  lines.push("# Recent signals (projectId|source|excerpt<=200)");
+  for (const s of input.recentSignals.slice(0, 20)) {
+    const excerpt = s.excerpt.slice(0, 200).replace(/\|/g, "/");
+    lines.push(`signal|${s.projectId}|${s.source}|${excerpt}`);
+  }
+  lines.push("");
+  lines.push("# Pending timeline suggestions — DO NOT duplicate");
+  for (const t of input.pendingTimelineSuggestions.slice(0, 10)) {
+    lines.push(`pending|${t}`);
+  }
+  return lines.join("\n");
+}
+
+export interface OrgPassGateInput {
+  pendingCount: number;
+  lastRunMinutesAgo: number;
+}
+export function shouldRunOrgPass(g: OrgPassGateInput): boolean {
+  if (g.pendingCount >= 3) return false;
+  if (g.lastRunMinutesAgo < 60) return false;
+  return true;
+}
+
+export const ORG_TIMELINE_SYSTEM_PROMPT = `
+You are Larry, a senior PM. You're running the org-wide timeline pass, whose
+only purpose is to notice opportunities to reorganise the workspace's timeline.
+Available tool: proposeTimelineRegroup.
+
+Call the tool AT MOST ONCE per pass. Trigger it when:
+- 3+ uncategorised or loosely-grouped projects share a theme (customer, product
+  area, quarter, stakeholder).
+- An existing category's projects split into two clear sub-themes.
+- A category uses the default Larry purple when it's meaningful enough to
+  deserve its own colour, or two categories share the exact same colour.
+
+Do NOT call the tool when:
+- Fewer than 3 projects would change.
+- A similar pending suggestion already exists (see pendingTimelineSuggestions).
+- The signal is weak — do nothing rather than guess.
+`;
+
+export async function runOrgIntelligencePass(args: {
+  fastify: FastifyInstance;
+  tenantId: string;
+  context: OrgTimelineContextInput;
+}): Promise<{ toolCallMade: boolean }> {
+  const contextBlock = buildOrgTimelineContext(args.context);
+  const regroupTool = buildProposeTimelineRegroupTool({
+    fastify: args.fastify, tenantId: args.tenantId,
+  });
+
+  const result = await generateText({
+    model: createModel(),
+    system: ORG_TIMELINE_SYSTEM_PROMPT,
+    prompt: `Workspace snapshot:\n${contextBlock}`,
+    tools: { proposeTimelineRegroup: regroupTool },
+    maxTokens: 4_000,
+  });
+
+  return { toolCallMade: result.toolCalls.length > 0 };
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm --workspace @larry/ai exec -- vitest run src/org-intelligence.test.ts`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ai/src/org-intelligence.ts packages/ai/src/org-intelligence.test.ts
+git commit -m "feat(ai): org-wide intelligence pass + context builder"
+```
+
+---
+
+## Task 17: Wire org pass into the scheduler
+
+**Files:**
+- Modify: `apps/worker/src/**` (find the scheduler entry — likely `apps/worker/src/index.ts` or a `jobs/*.ts`)
+- Create: rate-limit table migration if needed
+
+- [ ] **Step 1: Locate the scheduler entry**
+
+Run: `grep -rln "runIntelligence\|scan.*run\|scan.*schedule" apps/worker/src`
+
+Identify the main scheduler loop. Read the file and find where per-project scans fan out.
+
+- [ ] **Step 2: Add an org pass branch**
+
+After the per-project scan loop, add:
+
+```ts
+const pending = await fastify.db.queryTenant<{ count: string }>(tenantId,
+  `SELECT count(*)::text FROM larry_events
+    WHERE tenant_id = $1 AND action_type LIKE 'timeline\\_%' ESCAPE '\\'
+      AND event_type = 'suggested'`,
+  [tenantId]);
+const pendingCount = Number(pending[0]?.count ?? 0);
+
+const [lastRun] = await fastify.db.queryTenant<{ minutesAgo: number | null }>(tenantId,
+  `SELECT EXTRACT(EPOCH FROM (NOW() - last_run_at))::int / 60 AS "minutesAgo"
+     FROM larry_org_scan_runs WHERE tenant_id = $1`,
+  [tenantId]);
+const lastRunMinutesAgo = lastRun?.minutesAgo ?? Number.POSITIVE_INFINITY;
+
+if (shouldRunOrgPass({ pendingCount, lastRunMinutesAgo })) {
+  const orgCtx = await loadOrgTimelineContext(fastify, tenantId);  // helper added below
+  await runOrgIntelligencePass({ fastify, tenantId, context: orgCtx });
+  await fastify.db.queryTenant(tenantId,
+    `INSERT INTO larry_org_scan_runs (tenant_id, last_run_at)
+     VALUES ($1, NOW())
+     ON CONFLICT (tenant_id) DO UPDATE SET last_run_at = NOW()`,
+    [tenantId]);
+}
+```
+
+- [ ] **Step 3: Add the rate-limit table migration**
+
+Create `packages/db/src/migrations/028_larry_org_scan_runs.sql`:
+
+```sql
+BEGIN;
+CREATE TABLE IF NOT EXISTS larry_org_scan_runs (
+  tenant_id    UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+  last_run_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+COMMIT;
+```
+
+Append equivalent CREATE TABLE to `schema.sql` after the other Larry tables (around line 1151).
+
+- [ ] **Step 4: Create loadOrgTimelineContext helper**
+
+In `packages/ai/src/org-intelligence.ts`, add:
+
+```ts
+export async function loadOrgTimelineContext(
+  fastify: FastifyInstance,
+  tenantId: string,
+): Promise<OrgTimelineContextInput> {
+  const [categories, projects, pending, signals] = await Promise.all([
+    fastify.db.queryTenant(tenantId,
+      `SELECT id, name, colour,
+              parent_category_id AS "parentCategoryId",
+              project_id         AS "projectId",
+              created_at::text   AS "createdAt",
+              NULL::text         AS "lastRenamedAt"
+         FROM project_categories WHERE tenant_id = $1`, [tenantId]),
+    fastify.db.queryTenant(tenantId,
+      `SELECT id, name, category_id AS "categoryId", status,
+              created_at::text AS "createdAt"
+         FROM projects WHERE tenant_id = $1`, [tenantId]),
+    fastify.db.queryTenant<{ displayText: string }>(tenantId,
+      `SELECT display_text AS "displayText" FROM larry_events
+        WHERE tenant_id = $1
+          AND action_type LIKE 'timeline\\_%' ESCAPE '\\'
+          AND event_type = 'suggested'
+        ORDER BY created_at DESC LIMIT 10`, [tenantId]),
+    fastify.db.queryTenant(tenantId,
+      `SELECT project_id AS "projectId", source_kind AS source, content AS excerpt
+         FROM project_signals WHERE tenant_id = $1
+        ORDER BY created_at DESC LIMIT 20`, [tenantId]),
+  ]);
+  return {
+    tenantId,
+    categories: categories as OrgTimelineContextInput["categories"],
+    projects: projects as OrgTimelineContextInput["projects"],
+    recentSignals: signals as OrgTimelineContextInput["recentSignals"],
+    pendingTimelineSuggestions: pending.map((r) => r.displayText),
+  };
+}
+```
+
+(If `project_signals` isn't the right table name — grep for where the per-project scan sources signals — substitute.)
+
+- [ ] **Step 5: Migrate + restart worker**
+
+```bash
+npm --workspace @larry/db run migrate
+# restart worker
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/worker packages/ai/src/org-intelligence.ts packages/db/src/migrations/028_larry_org_scan_runs.sql packages/db/src/schema.sql
+git commit -m "feat(worker): org-wide timeline intelligence pass in scheduler"
+```
+
+---
+
+## Task 18: Intelligence system prompt — reference the org pass
+
+**Files:**
+- Modify: `packages/ai/src/intelligence.ts`
+
+- [ ] **Step 1: Locate the system prompt**
+
+Open `packages/ai/src/intelligence.ts` at line 202 where "You are Larry" starts.
+
+- [ ] **Step 2: Add a small note that org-scope changes happen elsewhere**
+
+Append to the system prompt block:
+
+```
+# Note on timeline organisation
+
+You cannot call the proposeTimelineRegroup tool from this per-project context —
+timeline reorganisation runs in a separate org-wide pass. In the per-project
+context, focus on the current project only.
+```
+
+This prevents Larry from trying to reach for a tool that isn't in scope here.
+
+- [ ] **Step 3: Run existing intelligence tests**
+
+Run: `npm --workspace @larry/ai exec -- vitest run`
+Expected: all pre-existing pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ai/src/intelligence.ts
+git commit -m "feat(ai): per-project prompt notes that timeline tools live in org pass"
+```
+
+---
+
+## Task 19: Accept handler dispatch + RBAC
+
+**Files:**
+- Modify: `apps/api/src/routes/v1/larry.ts`
+
+- [ ] **Step 1: Locate the existing accept handler**
+
+Run: `grep -n "accept\|event_type.*=.*'accepted'\|approved_by" apps/api/src/routes/v1/larry.ts`
+
+Read the handler to understand the event shape it loads.
+
+- [ ] **Step 2: Add the dispatch branch**
+
+Near the top of the handler (just after the event is loaded and before the default execution path), add:
+
+```ts
+if (typeof event.actionType === "string" && event.actionType.startsWith("timeline_")) {
+  const role = request.user.role;
+  if (!["owner", "admin", "pm"].includes(role)) {
+    return reply.code(403).send({
+      message: "Only owners, admins, and PMs can apply timeline reorganisations.",
+    });
+  }
+  const parsed = TimelineRegroupArgsSchema.parse(event.payload);
+  const result = await executeTimelineSuggestion(
+    fastify,
+    request.user.tenantId,
+    event.id,
+    parsed,
+    request.user.id,
+  );
+  return reply.send({ ok: true, result });
+}
+```
+
+Add imports at top:
+
+```ts
+import { TimelineRegroupArgsSchema } from "@larry/ai/timeline-tools";
+import { executeTimelineSuggestion } from "../../lib/timeline-suggestion-executor.js";
+```
+
+(If `@larry/ai` doesn't re-export from subpath, add the re-export in `packages/ai/src/index.ts`: `export * from "./timeline-tools";`.)
+
+- [ ] **Step 3: Apply the same RBAC to dismiss**
+
+Find the dismiss handler in the same file; add the identical role gate.
+
+- [ ] **Step 4: Test manually**
+
+```bash
+npm run api:dev
+```
+
+Insert a mock suggestion:
+
+```sql
+INSERT INTO larry_events
+  (tenant_id, project_id, event_type, action_type, display_text, reasoning, payload, triggered_by)
+VALUES
+  ('<tenant uuid>', NULL, 'suggested', 'timeline_regroup',
+   'Test regroup', 'Test reasoning',
+   '{"displayText":"Test regroup","reasoning":"Test reasoning","createCategories":[{"tempId":"cat_test","name":"Test Theme","colour":"#123456"}]}'::jsonb,
+   'schedule');
+```
+
+POST to the accept endpoint with an admin user — expect 200 + category created. POST with a member user — expect 403.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/v1/larry.ts packages/ai/src/index.ts
+git commit -m "feat(api): accept/dismiss dispatch timeline_* to executor with RBAC"
+```
+
+---
+
+## Task 20: TimelineSuggestionPreview component
+
+**Files:**
+- Create: `apps/web/src/components/workspace/TimelineSuggestionPreview.tsx`
+- Create: `apps/web/src/components/workspace/TimelineSuggestionPreview.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Create `TimelineSuggestionPreview.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TimelineSuggestionPreview } from "./TimelineSuggestionPreview";
+import type { WorkspaceLarryEvent } from "@/app/dashboard/types";
+
+const baseEvent: WorkspaceLarryEvent = {
+  id: "e1", projectId: null as unknown as string, eventType: "suggested",
+  actionType: "timeline_regroup",
+  displayText: "Group 3 projects under Customer Onboarding",
+  reasoning: "They share onboarding signals from last month.",
+  payload: {
+    displayText: "Group 3 projects under Customer Onboarding",
+    reasoning: "They share onboarding signals from last month.",
+    createCategories: [{ tempId: "cat_a", name: "Customer Onboarding", colour: "#5fb4d3" }],
+    moveProjects: [
+      { projectId: "p1", toCategoryTempId: "cat_a" },
+      { projectId: "p2", toCategoryTempId: "cat_a" },
+      { projectId: "p3", toCategoryTempId: "cat_a" },
+    ],
+  },
+  createdAt: "2026-04-19T00:00:00Z",
+  // other required fields — fill to match WorkspaceLarryEvent
+} as unknown as WorkspaceLarryEvent;
+
+describe("TimelineSuggestionPreview", () => {
+  it("renders the suggested category name and colour swatch", () => {
+    render(<TimelineSuggestionPreview event={baseEvent} />);
+    expect(screen.getByText("Customer Onboarding")).toBeInTheDocument();
+  });
+
+  it("summarises the number of projects moved", () => {
+    render(<TimelineSuggestionPreview event={baseEvent} />);
+    expect(screen.getByText(/3 projects/i)).toBeInTheDocument();
+  });
+
+  it("shows the reasoning text", () => {
+    render(<TimelineSuggestionPreview event={baseEvent} />);
+    expect(screen.getByText(/onboarding signals/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `npm --workspace apps/web exec -- vitest run src/components/workspace/TimelineSuggestionPreview.test.tsx`
+Expected: FAIL — component missing.
+
+- [ ] **Step 3: Implement the component**
+
+Create `TimelineSuggestionPreview.tsx`:
+
+```tsx
+"use client";
+import type { WorkspaceLarryEvent } from "@/app/dashboard/types";
+import { CategoryDot } from "@/components/workspace/gantt/CategoryDot";
+
+interface TimelinePayload {
+  displayText: string;
+  reasoning: string;
+  createCategories?: Array<{ tempId: string; name: string; colour: string }>;
+  moveProjects?: Array<{ projectId: string; toCategoryTempId?: string; toCategoryId?: string }>;
+  recolourCategories?: Array<{ categoryId: string; colour: string }>;
+}
+
+export function TimelineSuggestionPreview({ event }: { event: WorkspaceLarryEvent }) {
+  const payload = event.payload as unknown as TimelinePayload;
+  const newCats = payload.createCategories ?? [];
+  const moves = payload.moveProjects ?? [];
+  const recolours = payload.recolourCategories ?? [];
+
+  const movesByCatTemp = new Map<string, number>();
+  for (const m of moves) {
+    const key = m.toCategoryTempId ?? m.toCategoryId ?? "unknown";
+    movesByCatTemp.set(key, (movesByCatTemp.get(key) ?? 0) + 1);
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <p style={{ fontSize: 13, color: "var(--text-2)", margin: 0 }}>{event.reasoning}</p>
+
+      {newCats.length > 0 && (
+        <section>
+          <h4 style={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase",
+                       letterSpacing: 1, margin: 0, marginBottom: 8, color: "var(--text-muted)" }}>
+            New categories
+          </h4>
+          {newCats.map((c) => (
+            <div key={c.tempId}
+                 style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 0" }}>
+              <CategoryDot colour={c.colour} />
+              <span style={{ fontSize: 13, fontWeight: 500 }}>{c.name}</span>
+              <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
+                {movesByCatTemp.get(c.tempId) ?? 0} projects
+              </span>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {moves.length > 0 && (
+        <section>
+          <h4 style={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase",
+                       letterSpacing: 1, margin: 0, marginBottom: 4, color: "var(--text-muted)" }}>
+            Project moves
+          </h4>
+          <p style={{ fontSize: 13, margin: 0 }}>
+            {moves.length} {moves.length === 1 ? "project" : "projects"} will be moved.
+          </p>
+        </section>
+      )}
+
+      {recolours.length > 0 && (
+        <section>
+          <h4 style={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase",
+                       letterSpacing: 1, margin: 0, marginBottom: 4, color: "var(--text-muted)" }}>
+            Colour changes
+          </h4>
+          <p style={{ fontSize: 13, margin: 0 }}>
+            {recolours.length} {recolours.length === 1 ? "category" : "categories"} will be recoloured.
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm --workspace apps/web exec -- vitest run src/components/workspace/TimelineSuggestionPreview.test.tsx`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/workspace/TimelineSuggestionPreview.tsx apps/web/src/components/workspace/TimelineSuggestionPreview.test.tsx
+git commit -m "feat(web): TimelineSuggestionPreview renders regroup diffs"
+```
+
+---
+
+## Task 21: Route the preview into ActionDetailPreview
+
+**Files:**
+- Modify: `apps/web/src/components/workspace/ActionDetailPreview.tsx`
+
+- [ ] **Step 1: Add the dispatch branch**
+
+Open `ActionDetailPreview.tsx`. Inside the component function, at the top (before the existing branch logic), add:
+
+```tsx
+if (typeof event.actionType === "string" && event.actionType.startsWith("timeline_")) {
+  return <TimelineSuggestionPreview event={event} />;
+}
+```
+
+Add the import at the top of the file:
+
+```tsx
+import { TimelineSuggestionPreview } from "./TimelineSuggestionPreview";
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm --workspace apps/web exec -- tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/workspace/ActionDetailPreview.tsx
+git commit -m "feat(web): ActionDetailPreview routes timeline_* to dedicated preview"
+```
+
+---
+
+## Task 22: Invalidate timeline caches on accept
+
+**Files:**
+- Modify: `apps/web/src/hooks/useLarryActionCentre.ts`
+
+- [ ] **Step 1: Locate the accept mutation**
+
+Open `useLarryActionCentre.ts`. Find the mutation that POSTs to the accept endpoint.
+
+- [ ] **Step 2: Extend the onSuccess handler**
+
+Inside the `onSuccess` callback of the accept mutation (before any existing invalidations), add:
+
+```ts
+const acceptedEvent = /* the event from the mutation variables */ ;
+if (typeof acceptedEvent?.actionType === "string"
+    && acceptedEvent.actionType.startsWith("timeline_")) {
+  void qc.invalidateQueries({ queryKey: ["timeline", "org"] });
+}
+```
+
+(If the mutation's variables don't include the event, either pass the full event in or check the response payload's shape.)
+
+- [ ] **Step 3: Manual verification on dev**
+
+With the dev suggestion inserted earlier, accept it via the UI. Navigate back to `/workspace/timeline` — confirm the new category is visible immediately, no hard refresh needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/hooks/useLarryActionCentre.ts
+git commit -m "feat(web): invalidate timeline snapshot after timeline_* accept"
+```
+
+---
+
+## Task 23: NotificationBell verification
+
+**Files:**
+- Read only: `apps/web/src/app/workspace/NotificationBell.tsx`
+
+- [ ] **Step 1: Read the component**
+
+Confirm it doesn't filter by `actionType` in a way that excludes the new types.
+
+- [ ] **Step 2: If it filters by action type:**
+
+Extend the whitelist to include `timeline_regroup`, `timeline_categorise`, `timeline_recolour`.
+
+- [ ] **Step 3: Manual verification**
+
+With the suggestion inserted earlier still `event_type='suggested'`, refresh `/workspace` — banner should appear with the `display_text`.
+
+- [ ] **Step 4: Commit (if changed)**
+
+```bash
+git add apps/web/src/app/workspace/NotificationBell.tsx
+git commit -m "feat(web): NotificationBell passes timeline_* actions through"
+```
+
+---
+
+## Task 24: E2E test on prod preview
+
+**Files:** (no code — validation)
+
+- [ ] **Step 1: Push branch and get Vercel preview URL**
+
+```bash
+git push -u origin feat/timeline-larry-slice-2-feature
+gh pr create --title "Slice 2: Larry timeline tools" --body-file - <<'EOF'
+## Summary
+- proposeTimelineRegroup tool emits suggestions into larry_events
+- Org-wide intelligence pass, rate-limited to once/hour/tenant, skipped if 3+ pending
+- Transactional executor with SELECT FOR UPDATE, tempId resolution, partial-apply, audit
+- Accept/dismiss gated by owner/admin/pm role
+- TimelineSuggestionPreview in Action Centre + banner
+Spec: docs/superpowers/specs/2026-04-19-timeline-larry-integration-design.md §2
+## Test plan
+- [x] AI tool Zod schema: 4 unit tests
+- [x] Executor: 8 unit tests
+- [x] Org context builder: 4 unit tests
+- [x] Preview component: 3 unit tests
+- [x] Accept handler RBAC: manual dev verification
+- [ ] Reviewer E2E on preview: see body below
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 2: Preview-URL E2E via Playwright MCP (BotID-safe per memory)**
+
+Using the Playwright MCP server in this Claude Code session, drive:
+
+```
+1. Navigate to <preview-url>/login
+2. Log in as launch-test-2026@larry-pm.com
+3. Open SQL console on Railway preview DB and insert a seed suggestion
+   for the test user's tenant (use the INSERT from Task 19 Step 4).
+4. Navigate to /workspace — assert NotificationBell banner text matches displayText.
+5. Click the banner → lands on /workspace/actions with the suggestion open
+   in the preview pane.
+6. Assert the preview shows the category name + project count.
+7. Click Accept — assert success toast.
+8. Navigate to /workspace/timeline — assert the new category exists and the
+   projects are under it.
+```
+
+- [ ] **Step 3: Write-up the manual runbook into `docs/reports/2026-04-19-slice-2-e2e.md` with screenshots**
+
+Capture before/after screenshots of:
+- The banner
+- The preview pane
+- The timeline post-accept
+
+---
+
+## Task 25: Merge, deploy, and monitor
+
+**Files:** (none)
+
+- [ ] **Step 1: Merge the PR after review**
+
+- [ ] **Step 2: Monitor Railway deploy logs for migration 027 idempotency + no errors**
+
+- [ ] **Step 3: Monitor Vercel deploy**
+
+- [ ] **Step 4: Insert a real seed suggestion on prod and accept it as owner**
+
+Verify the full flow end-to-end on production. Record the five metrics from spec §2.13 (suggested, accepted, dismissed, rollback, skipped counters) show up in the logs.
+
+- [ ] **Step 5: Update memory**
+
+Add a `larry-timeline-larry-integration-shipped.md` memory entry noting which PRs shipped, migration number, and the known design follow-ups from spec §6 that are still open.
+
+---
+
+# Appendix — Spec traceability
+
+| Spec section | Tasks |
+|---|---|
+| §1.1 Description field | Task 5, 6 |
+| §1.2 Shared-hook cache | Tasks 2, 3, 4 |
+| §1.3 Shared types | Task 1 |
+| §1.4 Polish | Task 7 |
+| §1.5 Testing | Tasks 1, 2, 5, 6 |
+| §2.1 Migration 027 | Task 9 |
+| §2.2 AI tool + org context | Tasks 15, 16, 17 |
+| §2.3 Prompt additions | Tasks 16, 18 |
+| §2.4 Executor | Tasks 11, 12, 13, 14 |
+| §2.5 Accept handler + RBAC | Task 19 |
+| §2.6 Preview component | Task 20, 21 |
+| §2.7 NotificationBell | Task 23 |
+| §2.8 Action-type tags | Task 10 |
+| §2.9 Context builder | Task 16, 17 |
+| §2.10 Cache invalidation | Task 22 |
+| §2.11 Error handling | Tasks 11-14 (transactional), 19 (RBAC) |
+| §2.12 Testing | Distributed across Tasks 11-16, 20, 24 |
+| §2.13 Observability | Task 25 Step 4 |
+| §3 Slice 3 roadmap | Deferred to separate plans |
+| §6 Design follow-ups | Captured in memory at Task 25 Step 5 |


### PR DESCRIPTION
Rewrites `docs/security/NEXT-AGENT-PROMPT-login-hardening.md` so a fresh Claude Code session can paste the file path and start work without clarifying questions.

**The paste prompt is in the first block of the doc:**
> Read `C:/Dev/larry/site-deploys/larry-site/docs/security/NEXT-AGENT-PROMPT-login-hardening.md` and work through it.

Contents:
- What's already shipped (#126/#128/#129/#130 with one-line scope each)
- Memory-file index the next agent should pull in
- Repo + build facts (monorepo layout, test/typecheck commands, pre-existing gantt tsc noise to ignore, migration numbering, where `schema.sql` lives)
- Prod creds + smoke-test recipes for CSRF / refresh-reuse / HIBP (copy-paste runnable)
- P1-2 MFA: full scope, API/UI PR split recommendation, TOTP lib choice, migration 027 schema, endpoint contracts, login-gating pseudocode, rate-limit keying by user_id (not IP), acceptance criteria, stop conditions
- P2-3 device fingerprint writeup with migration 028 outline
- Autonomy defaults + gotchas (transient gh merge failures, concurrent branch reflow)

Doc-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)