### PR TITLE
feat(web): X-Frame-Options + Referrer-Policy on auth pages (P2-6)

### DIFF
--- a/apps/web/src/middleware.test.ts
+++ b/apps/web/src/middleware.test.ts
@@ -95,3 +95,48 @@ describe("middleware — CSRF gating on /api/**", () => {
     expect(res.status).toBe(200);
   });
 });
+
+function pageReq(path: string, opts: { sessionJwt?: string } = {}): NextRequest {
+  const headers = new Headers();
+  if (opts.sessionJwt) headers.set("cookie", `larry_session=${opts.sessionJwt}`);
+  return new NextRequest(new Request(`https://larry-pm.com${path}`, { method: "GET", headers }));
+}
+
+describe("middleware — P2-6 auth page security headers", () => {
+  it("injects X-Frame-Options: DENY + Referrer-Policy: no-referrer on /login (unauth)", async () => {
+    const middleware = await loadMiddleware();
+    const res = await middleware(pageReq("/login"));
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer");
+  });
+
+  it("injects headers on /signup, /forgot-password, /reset-password, /verify-email, /confirm-email-change", async () => {
+    const middleware = await loadMiddleware();
+    for (const path of [
+      "/signup",
+      "/forgot-password",
+      "/reset-password",
+      "/verify-email",
+      "/confirm-email-change",
+    ]) {
+      const res = await middleware(pageReq(path));
+      expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+      expect(res.headers.get("Referrer-Policy")).toBe("no-referrer");
+    }
+  });
+
+  it("injects headers on /login even when a valid session exists (authed user hitting /login)", async () => {
+    const middleware = await loadMiddleware();
+    const jwt = await makeSessionJwt({ sub: "u1", csrfToken: "tok-A" });
+    const res = await middleware(pageReq("/login", { sessionJwt: jwt }));
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("Referrer-Policy")).toBe("no-referrer");
+  });
+
+  it("does NOT inject auth headers on workspace pages", async () => {
+    const middleware = await loadMiddleware();
+    const jwt = await makeSessionJwt({ sub: "u1", csrfToken: "tok-A" });
+    const res = await middleware(pageReq("/workspace", { sessionJwt: jwt }));
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
+});

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -74,6 +74,29 @@ async function apiMiddleware(req: NextRequest) {
   return NextResponse.next();
 }
 
+// Paths that serve the user's credentials or account-recovery flows. We
+// harden these against clickjacking (X-Frame-Options) and referrer leaks
+// (Referrer-Policy). Login audit P2-6.
+const AUTH_CREDENTIAL_PAGES: ReadonlySet<string> = new Set([
+  "/login",
+  "/signup",
+  "/forgot-password",
+  "/reset-password",
+  "/verify-email",
+  "/verify-email-required",
+  "/confirm-email-change",
+  "/mfa/enrol",
+]);
+
+function applyAuthPageSecurityHeaders(res: NextResponse, pathname: string) {
+  if (!AUTH_CREDENTIAL_PAGES.has(pathname)) return;
+  if (pathname.startsWith("/invite/")) return;
+  // DENY (not SAMEORIGIN) — Larry never embeds its own auth pages in an
+  // iframe. If that changes later, relax to SAMEORIGIN, not wildcard.
+  res.headers.set("X-Frame-Options", "DENY");
+  res.headers.set("Referrer-Policy", "no-referrer");
+}
+
 // ── Page-level session gate (existing behaviour) ────────────────────────────
 async function pageMiddleware(req: NextRequest) {
   const token = req.cookies.get(SESSION_COOKIE)?.value;
@@ -82,7 +105,11 @@ async function pageMiddleware(req: NextRequest) {
   if (!token) {
     // Unauth'd visit to a public auth page (signup, login, etc.) — just
     // render. No CSRF cookie to mirror yet.
-    if (isPublicAuth) return NextResponse.next();
+    if (isPublicAuth) {
+      const res = NextResponse.next();
+      applyAuthPageSecurityHeaders(res, req.nextUrl.pathname);
+      return res;
+    }
     return NextResponse.redirect(new URL("/login", req.url));
   }
 
@@ -95,12 +122,14 @@ async function pageMiddleware(req: NextRequest) {
       ? NextResponse.next()
       : NextResponse.redirect(new URL("/login", req.url));
     res.cookies.set({ name: SESSION_COOKIE, value: "", maxAge: 0, path: "/" });
+    applyAuthPageSecurityHeaders(res, req.nextUrl.pathname);
     return res;
   }
 
   try {
     const { payload } = await jwtVerify(token, secret);
     const res = NextResponse.next();
+    applyAuthPageSecurityHeaders(res, req.nextUrl.pathname);
 
     // CSRF double-submit cookie: mirror the session-bound CSRF token
     // into a non-httpOnly cookie so the client can echo it back on
@@ -146,6 +175,7 @@ async function pageMiddleware(req: NextRequest) {
       ? NextResponse.next()
       : NextResponse.redirect(new URL("/login", req.url));
     res.cookies.set({ name: SESSION_COOKIE, value: "", maxAge: 0, path: "/" });
+    applyAuthPageSecurityHeaders(res, req.nextUrl.pathname);
     return res;
   }
 }

--- a/docs/security/login-audit-2026-04-19.md
+++ b/docs/security/login-audit-2026-04-19.md
@@ -85,7 +85,9 @@ Replace with a persistent `device_id` cookie + loose fingerprint.
 
 - `HSTS` / `Strict-Transport-Security` header from the web layer (Vercel
   already sets it, confirm for completeness).
-- `X-Frame-Options: DENY` on the auth pages to block clickjacking.
+- ✅ `X-Frame-Options: DENY` + `Referrer-Policy: no-referrer` on the auth
+  pages (login, signup, forgot/reset-password, verify-email,
+  confirm-email-change, mfa/enrol) shipped in `feat/auth-page-security-headers`.
 - Move `SESSION_COOKIE` name to `__Host-larry_session` once `path=/` +
   `secure` are guaranteed — unlocks extra browser-level isolation.
 - Add `/v1/auth/sessions` endpoint for users to view + revoke active devices.


### PR DESCRIPTION
## Summary
Login audit P2-6 / P3. Adds two headers to every auth page response:
- `X-Frame-Options: DENY` (clickjacking)
- `Referrer-Policy: no-referrer` (prevents leaking login/reset URLs with tokens to third parties)

Applies to: `/login`, `/signup`, `/forgot-password`, `/reset-password`, `/verify-email`, `/verify-email-required`, `/confirm-email-change`, `/mfa/enrol`.

Workspace pages are untouched (kept iframe-embeddable for any future oembed / internal previews). `DENY` not `SAMEORIGIN` — Larry never embeds its own auth pages.

Headers land on all four middleware code paths: unauth public render, session-OK render, SESSION_SECRET-missing fallback, expired-token clear+render.

## Test plan
- [x] `npx vitest run src/middleware.test.ts` — 10/10 green, 4 new cases covering header injection across auth pages + negative case for workspace pages.
- [x] `npx tsc --noEmit` clean

## Prod verification (post-merge)
- [ ] `curl -I https://larry-pm.com/login` returns both headers
- [ ] Same for `/signup`, `/forgot-password`, `/reset-password`
- [ ] `curl -I https://larry-pm.com/workspace` (authed) does NOT return the auth headers

Stacks cleanly on top of PR #132 (MFA). Merges in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)