### PR TITLE
Slice 2 migration: larry_events.project_id nullable (030)

### DIFF
--- a/packages/db/src/migrations/030_larry_events_nullable_project.sql
+++ b/packages/db/src/migrations/030_larry_events_nullable_project.sql
@@ -1,0 +1,24 @@
+-- Migration 030 — make larry_events.project_id nullable so Larry can
+-- emit org-wide timeline_* suggestions (no single project anchor).
+--
+-- Forward: ALTER column + CHECK constraint + partial index.
+-- Rollback: SET NOT NULL after deleting any org-scope rows.
+-- Safe: instant metadata change on Postgres, no table rewrite.
+
+BEGIN;
+
+ALTER TABLE larry_events
+  ALTER COLUMN project_id DROP NOT NULL;
+
+ALTER TABLE larry_events
+  ADD CONSTRAINT larry_events_project_scope_check
+  CHECK (
+    project_id IS NOT NULL
+    OR action_type LIKE 'timeline\_%' ESCAPE '\'
+  );
+
+CREATE INDEX IF NOT EXISTS idx_larry_events_org_pending
+  ON larry_events (tenant_id, created_at DESC)
+  WHERE project_id IS NULL AND event_type = 'suggested';
+
+COMMIT;

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -1064,7 +1064,7 @@ EXCEPTION WHEN duplicate_object THEN null; END $$;
 CREATE TABLE IF NOT EXISTS larry_events (
   id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   tenant_id    UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  project_id   UUID REFERENCES projects(id) ON DELETE CASCADE,
 
   -- Lifecycle state
   event_type   TEXT NOT NULL CHECK (event_type IN ('auto_executed', 'suggested', 'accepted', 'dismissed')),
@@ -1146,6 +1146,29 @@ WHERE executed_by_kind IS NULL
 UPDATE larry_events
 SET source_kind = triggered_by
 WHERE source_kind IS NULL;
+
+-- Migration 030: org-scope suggestions have no single project anchor.
+ALTER TABLE larry_events
+  ALTER COLUMN project_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'larry_events_project_scope_check'
+  ) THEN
+    ALTER TABLE larry_events
+      ADD CONSTRAINT larry_events_project_scope_check
+      CHECK (
+        project_id IS NOT NULL
+        OR action_type LIKE 'timeline\_%' ESCAPE '\'
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_larry_events_org_pending
+  ON larry_events (tenant_id, created_at DESC)
+  WHERE project_id IS NULL AND event_type = 'suggested';
 
 CREATE INDEX IF NOT EXISTS idx_larry_events_project
   ON larry_events (project_id, event_type, created_at DESC);


### PR DESCRIPTION
## Summary

Enables org-scope timeline_* suggestions by making `larry_events.project_id` nullable. A CHECK constraint restricts nulls to rows where `action_type LIKE 'timeline_%'`. Adds a partial index for the pending-suggestion poll.

Zero-downtime: `ALTER TABLE ... DROP NOT NULL` is a metadata-only change on Postgres — no table rewrite. Safe to run during business hours.

Gated before Slice 2 feature code (#137) per spec §2.1 / plan §5.

**Migration number:** 030 (bumped from 027 during review to avoid collision with `027_mfa_secrets.sql` from PR #126).

## Test plan

- [x] Migration applies cleanly on empty DB
- [x] Migration applies cleanly on existing DB (idempotent schema.sql re-run)
- [x] `project_id` is nullable after migration
- [x] CHECK constraint `larry_events_project_scope_check` exists
- [ ] Reviewer confirms Railway prod migration runs cleanly before Slice 2 feature PR (#137) merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)