### PR TITLE
fix(shared): add missing categoryId to GanttTask test fixture

### DIFF
--- a/packages/shared/src/gantt-types.test.ts
+++ b/packages/shared/src/gantt-types.test.ts
@@ -13,7 +13,7 @@ describe("gantt types", () => {
 
   it("GanttTask allows parentTaskId null or string", () => {
     const t: GanttTask = {
-      id: "t1", projectId: "p1", parentTaskId: null, title: "Task",
+      id: "t1", projectId: "p1", parentTaskId: null, categoryId: null, title: "Task",
       status: "not_started", priority: "medium",
       assigneeUserId: null, assigneeName: null,
       startDate: null, endDate: null, dueDate: null, progressPercent: 0,


### PR DESCRIPTION
## Summary
- Unblocks production build. GanttTask gained a required `categoryId` field in `c71754c feat(gantt): tasks nest under selected group from category row` but the test fixture in `gantt-types.test.ts` wasn't updated. `tsc -p packages/shared` has been failing on master since that push.
- The break was only exposed when PR #139 merged and triggered the first production deploy since the Gantt work landed.
- One-line fix: add `categoryId: null` to the test object.

## Test plan
- [x] Vercel preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)