### PR TITLE
fix(gantt): full timeline bug bash — 9 fixes + schema-drift follow-up

### DIFF
--- a/apps/api/src/routes/v1/projects.ts
+++ b/apps/api/src/routes/v1/projects.ts
@@ -183,6 +183,7 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
         status: "backlog" | "not_started" | "in_progress" | "waiting" | "completed" | "blocked";
         priority: "low" | "medium" | "high" | "critical";
         parentTaskId: string | null;
+        categoryId: string | null;
         assigneeUserId: string | null;
         assigneeName: string | null;
         progressPercent: number;
@@ -193,6 +194,7 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
         tenantId,
         `SELECT tasks.id, tasks.title, tasks.status, tasks.priority,
                 tasks.parent_task_id as "parentTaskId",
+                tasks.category_id as "categoryId",
                 tasks.assignee_user_id as "assigneeUserId",
                 COALESCE(NULLIF(u.display_name, ''), split_part(u.email, '@', 1)) as "assigneeName",
                 tasks.progress_percent as "progressPercent",
@@ -219,6 +221,46 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
         [tenantId, params.id]
       );
 
+      // Timeline Slice 2 (Bug 8) — project timeline is now self-sufficient.
+      // Previously the project Gantt relied on the /v1/timeline cache to
+      // resolve category colours + project-scoped subcategories, which
+      // produced a grey-flash on direct project URL visits and meant a
+      // stale org cache could misrender the project. Returning this
+      // project's own category slice here removes the cross-endpoint
+      // coupling. Projects and categories are small (a tenant rarely
+      // exceeds a few dozen), so no pagination needed.
+      const projectRows = await fastify.db.queryTenant<{
+        id: string;
+        name: string;
+        status: string;
+        categoryId: string | null;
+      }>(
+        tenantId,
+        `SELECT id, name, status, category_id as "categoryId"
+         FROM projects
+         WHERE tenant_id = $1 AND id = $2
+         LIMIT 1`,
+        [tenantId, params.id]
+      );
+
+      const categoryRows = await fastify.db.queryTenant<{
+        id: string;
+        name: string;
+        colour: string | null;
+        sortOrder: number;
+        parentCategoryId: string | null;
+        projectId: string | null;
+      }>(
+        tenantId,
+        `SELECT id, name, colour, sort_order as "sortOrder",
+                parent_category_id as "parentCategoryId",
+                project_id as "projectId"
+         FROM project_categories
+         WHERE tenant_id = $1
+         ORDER BY sort_order`,
+        [tenantId]
+      );
+
       const byColumn = {
         backlog: taskRows.filter((task) => task.status === "backlog"),
         not_started: taskRows.filter((task) => task.status === "not_started"),
@@ -236,9 +278,11 @@ export const projectRoutes: FastifyPluginAsync = async (fastify) => {
       return {
         projectId: params.id,
         generatedAt: new Date().toISOString(),
+        project: projectRows[0] ?? null,
         gantt: ganttTasks,
         dependencies: dependencyRows,
         kanban: byColumn,
+        categories: categoryRows,
       };
     }
   );

--- a/apps/web/src/app/dashboard/types.ts
+++ b/apps/web/src/app/dashboard/types.ts
@@ -1,3 +1,5 @@
+import type { TimelineCategorySummary } from "@larry/shared";
+
 export type TaskStatus =
   | "not_started"
   | "on_track"
@@ -106,10 +108,23 @@ export interface WorkspaceTimelineTask {
   categoryId?: string | null;
 }
 
+export interface WorkspaceTimelineProjectSummary {
+  id: string;
+  name: string;
+  status: string;
+  categoryId: string | null;
+}
+
 export interface WorkspaceTimeline {
   gantt?: WorkspaceTimelineTask[];
   kanban?: Record<string, Array<{ id: string }>>;
   dependencies?: Array<{ taskId: string; dependsOnTaskId: string; relation: string }>;
+  // Timeline Slice 2 (Bug 8) — project-timeline now carries its own
+  // category slice so ProjectGanttClient no longer depends on the org
+  // timeline cache for colour / nesting. Nullable for backwards compat
+  // with the old response shape during the deploy roll-forward.
+  project?: WorkspaceTimelineProjectSummary | null;
+  categories?: TimelineCategorySummary[];
 }
 
 export interface WorkspaceHealth {

--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -666,6 +666,7 @@ export function PortfolioGanttClient() {
         <GanttContainer
           root={root}
           defaultZoom="month"
+          persistKey="portfolio"
           onSelectionChange={setSelectedKey}
           onHoverChange={setHoveredKey}
           categoryColorMap={categoryColorMap}

--- a/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
+++ b/apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx
@@ -36,6 +36,11 @@ export function PortfolioGanttClient() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  // Timeline Slice 1 — mirrors GanttContainer's hover state so the "Add item"
+  // button (rendered via outlineHeaderActions, outside GanttContainer) can
+  // target the hovered row. Without this, Add item was always scoped to the
+  // last-clicked row or defaulted to the root when nothing was selected.
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const [colourPopover, setColourPopover] = useState<ColourPopover | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
 
@@ -225,6 +230,34 @@ export function PortfolioGanttClient() {
     },
   });
 
+  // Timeline Slice 1 — mirrors ProjectGanttClient.moveTaskToCategoryMutation.
+  // Previously validateDrop emitted `moveTaskToCategory` but the org-timeline
+  // handleDragEnd switch had no case for it, so task→category drops on the
+  // portfolio timeline silently dropped on the floor.
+  const moveTaskToCategoryMutation = useMutation({
+    mutationFn: async (vars: { id: string; categoryId: string | null }) => {
+      const res = await fetch(`/api/workspace/tasks/${vars.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ categoryId: vars.categoryId }),
+      });
+      if (!res.ok) {
+        const respBody = await res.json().catch(() => ({}));
+        const msg = (respBody as { message?: string; error?: string }).message
+          ?? (respBody as { message?: string; error?: string }).error
+          ?? `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
+      return res.json();
+    },
+    onError: (err) => {
+      setMutationError(err instanceof Error ? err.message : "Couldn't move task to group");
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: QK_TIMELINE_ORG });
+    },
+  });
+
   function handleDragEnd(e: DragEndEvent) {
     if (!e.over || !data) return;
     const sourceKey = String(e.active.id);
@@ -275,6 +308,12 @@ export function PortfolioGanttClient() {
           parentTaskId: validation.effect.newParentTaskId,
         });
         return;
+      case "moveTaskToCategory":
+        moveTaskToCategoryMutation.mutate({
+          id: validation.effect.sourceId,
+          categoryId: validation.effect.newCategoryId,
+        });
+        return;
     }
   }
 
@@ -291,6 +330,40 @@ export function PortfolioGanttClient() {
     return [...real, { id: null, name: "Uncategorised", colour: "#bdb7d0" }];
   }, [data]);
 
+  // Timeline Slice 1 — all of these were previously rebuilt in every render
+  // (buildPortfolioTree walks the full tenant tree, the lookup maps walk all
+  // projects/tasks). That made each keystroke on the search box, each drag
+  // preview, and each React Query refetch walk the whole tenant. Memoising
+  // on `data` cuts render cost to O(changes) and gives GanttContainer a
+  // stable `root` reference so its own useMemo/useEffect chain stops
+  // re-firing gratuitously.
+  const normalized = useMemo(
+    () => data ? normalizePortfolioStatuses(data) : null,
+    [data],
+  );
+  const root: GanttNode | null = useMemo(
+    () => normalized ? buildPortfolioTree(normalized) : null,
+    [normalized],
+  );
+  const taskProjectLookup = useMemo(() => {
+    const m = new Map<string, string>();
+    if (!data) return m;
+    for (const cat of data.categories) {
+      for (const p of cat.projects) {
+        for (const t of p.tasks) m.set(t.id, p.id);
+      }
+    }
+    return m;
+  }, [data]);
+  const projectStatusById = useMemo(() => {
+    const m = new Map<string, string>();
+    if (!data) return m;
+    for (const cat of data.categories) {
+      for (const p of cat.projects) m.set(p.id, p.status);
+    }
+    return m;
+  }, [data]);
+
   if (!data && error) {
     return (
       <div style={{ padding: 24 }}>
@@ -298,22 +371,11 @@ export function PortfolioGanttClient() {
       </div>
     );
   }
-  if (!data) return <div style={{ padding: 24 }}>Loading…</div>;
-
-  const normalized = normalizePortfolioStatuses(data);
-  const root = buildPortfolioTree(normalized);
+  if (!data || !root) return <div style={{ padding: 24 }}>Loading…</div>;
 
   const hasRealCategories = data.categories.some((c) => c.id !== null);
   const hasUncategorised = data.categories.some((c) => c.id === null && c.projects.length > 0);
   const isTrulyEmpty = !hasRealCategories && !hasUncategorised;
-
-  // task.id → project.id lookup for context-menu actions
-  const taskProjectLookup = new Map<string, string>();
-  for (const cat of data.categories) {
-    for (const p of cat.projects) {
-      for (const t of p.tasks) taskProjectLookup.set(t.id, p.id);
-    }
-  }
 
   function selectionContextAddLabel(): string {
     // Label text only — the GanttToolbar renders a <Plus /> icon alongside
@@ -367,11 +429,7 @@ export function PortfolioGanttClient() {
     setAddCtx({ mode: "category" });
   }
 
-  // Lookup a project's archived status by id, for preflight on write actions.
-  const projectStatusById = new Map<string, string>();
-  for (const cat of data.categories) {
-    for (const p of cat.projects) projectStatusById.set(p.id, p.status);
-  }
+  // Archived-project preflight — projectStatusById is now memoised above.
   const isArchived = (projectId: string | null | undefined): boolean =>
     !!projectId && projectStatusById.get(projectId) === "archived";
 
@@ -609,6 +667,7 @@ export function PortfolioGanttClient() {
           root={root}
           defaultZoom="month"
           onSelectionChange={setSelectedKey}
+          onHoverChange={setHoveredKey}
           categoryColorMap={categoryColorMap}
           onCategoriesClick={() => setManagerOpen((v) => !v)}
           categoriesOpen={managerOpen}
@@ -617,7 +676,27 @@ export function PortfolioGanttClient() {
           outlineHeaderActions={
             <button
               type="button"
-              onClick={() => setPickerOpen(true)}
+              // Timeline Slice 1 — "Add item" is now hover-aware. Hovering a
+              // project or task has a single natural action, so we skip the
+              // picker and open the AddNodeModal in the right mode directly.
+              // Hovering a category or nothing still opens the picker so the
+              // user can pick between "subcategory" and "project in category".
+              onClick={() => {
+                const k = hoveredKey ?? selectedKey;
+                if (k?.startsWith("proj:")) {
+                  setAddCtx({ mode: "task", parentProjectId: k.slice(5) });
+                  return;
+                }
+                if (k?.startsWith("task:")) {
+                  const taskId = k.slice(5);
+                  const projectId = taskProjectLookup.get(taskId);
+                  if (projectId) {
+                    setAddCtx({ mode: "subtask", parentProjectId: projectId, parentTaskId: taskId });
+                    return;
+                  }
+                }
+                setPickerOpen(true);
+              }}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -654,11 +733,21 @@ export function PortfolioGanttClient() {
           onClose={() => setPickerOpen(false)}
           onChoose={(kind) => {
             setPickerOpen(false);
+            // Timeline Slice 1 — resolve parent from hover first, selection
+            // second. Lets a user hover a category row and click Add item →
+            // picker → "Group" to create a *subcategory* of the hovered
+            // category (instead of a new top-level one).
+            const k = hoveredKey ?? selectedKey;
             if (kind === "group") {
-              setAddCtx({ mode: "category" });
+              if (k?.startsWith("cat:") && k !== "cat:uncat") {
+                setAddCtx({ mode: "subcategory", parentCategoryId: k.slice(4) });
+              } else {
+                setAddCtx({ mode: "category" });
+              }
             } else {
-              // "Task" in portfolio view = a project. Use selected category as parent if available.
-              const catId = selectedKey?.startsWith("cat:") ? selectedKey.slice(4) : undefined;
+              // "Task" in portfolio view = a project. Use hovered/selected
+              // category as parent if available.
+              const catId = k?.startsWith("cat:") ? k.slice(4) : undefined;
               setAddCtx({ mode: "project", parentCategoryId: catId === "uncat" ? undefined : catId });
             }
           }}

--- a/apps/web/src/components/workspace/gantt/GanttContainer.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttContainer.tsx
@@ -29,6 +29,11 @@ interface Props {
   // the hovered row (project → Add task, task → Add subtask). Fires on
   // every change; pass a stable setter.
   onHoverChange?: (hoveredKey: string | null) => void;
+  // Timeline Slice 2 — if set, view state (collapsed rows, zoom, outline
+  // width) persists to localStorage under `larry:gantt:<persistKey>:*`.
+  // Callers use "portfolio" for the org timeline and `proj:<id>` for per-
+  // project timelines. Omit to keep state ephemeral (tests, previews).
+  persistKey?: string;
 }
 
 export function GanttContainer({
@@ -37,19 +42,46 @@ export function GanttContainer({
   outlineHeader, outlineHeaderActions, outlineFooter, outlineOverlay,
   onCategoriesClick, categoriesOpen,
   onContextMenuAction, categoriesForSubmenu = [],
-  onSelectionChange, onHoverChange,
+  onSelectionChange, onHoverChange, persistKey,
 }: Props) {
-  const [zoom, setZoom] = useState<ZoomLevel>(defaultZoom);
+  // Timeline Slice 2 — persistence keys. `null` short-circuits every
+  // read/write so callers that don't pass persistKey behave as before.
+  const collapsedKey = persistKey ? `larry:gantt:${persistKey}:collapsed` : null;
+  const zoomKey      = persistKey ? `larry:gantt:${persistKey}:zoom` : null;
+  const outlineKey   = persistKey ? `larry:gantt:${persistKey}:outline` : null;
+
+  const [zoom, setZoom] = useState<ZoomLevel>(() =>
+    readPersistedZoom(zoomKey) ?? defaultZoom,
+  );
   const [search, setSearch] = useState("");
-  const [outlineWidth, setOutlineWidth] = useState(260);
+  const [outlineWidth, setOutlineWidth] = useState<number>(() =>
+    readPersistedOutlineWidth(outlineKey) ?? 260,
+  );
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState<Set<string>>(() => collectAllKeys(root));
+  // Timeline Slice 2 — flip the semantic. We used to track "expanded keys"
+  // and mutate that set on every tree refetch to keep new rows expanded.
+  // Now we track "collapsed keys" instead: absent == expanded, so new rows
+  // auto-expand for free and storage only carries the user's collapse
+  // decisions. Makes the refetch merge disappear.
+  const [collapsed, setCollapsed] = useState<Set<string>>(() =>
+    readPersistedCollapsed(collapsedKey) ?? new Set(),
+  );
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
 
   const allTasks = useMemo(() => collectTasks(root), [root]);
   const range = useMemo(() => computeRange(allTasks, zoom), [allTasks, zoom]);
+
+  // Derived: keys the user wants visible, i.e. NOT in `collapsed`. Filtered
+  // to currently-valid keys so flattenVisible treats stale collapsed ids
+  // as no-ops (and eventually GC via `collapsed` cleanup below).
+  const expanded = useMemo(() => {
+    const keys = collectAllKeys(root);
+    const out = new Set<string>();
+    for (const k of keys) if (!collapsed.has(k)) out.add(k);
+    return out;
+  }, [root, collapsed]);
 
   const rows = useMemo(() => {
     const base = flattenVisible(root, expanded, { categoryColorMap, rootCategoryColor });
@@ -62,7 +94,7 @@ export function GanttContainer({
   }, [root, expanded, search, categoryColorMap, rootCategoryColor]);
 
   const toggle = useCallback((key: string) => {
-    setExpanded((prev) => {
+    setCollapsed((prev) => {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key); else next.add(key);
       return next;
@@ -77,25 +109,29 @@ export function GanttContainer({
     gridRef.current.scrollTo({ left: Math.max(0, (pct / 100) * sw - vw / 2), behavior: "smooth" });
   }, [range]);
 
-  // Timeline Slice 1 — track the previous tree's keys so we can tell which
-  // rows are brand-new on a data refetch. Previously any key not in `prev`
-  // was dropped, which meant a freshly-created subcategory/subtask landed
-  // collapsed and looked missing. Now new keys auto-expand; user-collapsed
-  // keys stay collapsed as long as they survive.
-  const prevKeysRef = useRef<Set<string> | null>(null);
+  // Timeline Slice 2 — GC stale collapsed keys when the tree changes. If
+  // a user collapsed X and X then gets deleted, X lingers in localStorage
+  // forever otherwise. Runs once per tree-change.
   useEffect(() => {
     const keys = collectAllKeys(root);
-    const prevKeys = prevKeysRef.current;
-    prevKeysRef.current = keys;
-    // First mount — useState already seeded `expanded` with all keys.
-    if (prevKeys === null) return;
-    setExpanded((prev) => {
+    setCollapsed((prev) => {
+      let changed = false;
       const next = new Set<string>();
-      for (const k of prev) if (keys.has(k)) next.add(k);
-      for (const k of keys) if (!prevKeys.has(k)) next.add(k);
-      return next.size === 0 ? keys : next;
+      for (const k of prev) {
+        if (keys.has(k)) next.add(k);
+        else changed = true;
+      }
+      return changed ? next : prev;
     });
   }, [root]);
+
+  // Timeline Slice 2 — persist view state. Writes are fire-and-forget;
+  // localStorage.setItem quota errors get swallowed (view still works,
+  // just won't survive refresh). Writes happen only when the relevant
+  // state actually changes, so no chatty activity on scroll/hover.
+  useEffect(() => { writePersisted(collapsedKey, JSON.stringify([...collapsed])); }, [collapsedKey, collapsed]);
+  useEffect(() => { writePersisted(zoomKey, zoom); }, [zoomKey, zoom]);
+  useEffect(() => { writePersisted(outlineKey, String(outlineWidth)); }, [outlineKey, outlineWidth]);
 
   const handleSelect = useCallback((k: string | null) => {
     setSelectedKey(k);
@@ -198,6 +234,49 @@ export function GanttContainer({
 function nodeLabel(n: GanttNode): string {
   if (n.kind === "category" || n.kind === "project") return n.name;
   return n.task.title;
+}
+
+// Timeline Slice 2 — localStorage helpers. Every call is wrapped in
+// try/catch because storage can be disabled (private mode, quota,
+// unavailable during SSR). A null `key` short-circuits for the non-
+// persisted case. Return null on miss so the caller can fall back to
+// its default cleanly.
+function writePersisted(key: string | null, value: string): void {
+  if (!key || typeof window === "undefined") return;
+  try { window.localStorage.setItem(key, value); } catch { /* quota / disabled */ }
+}
+
+function readPersistedRaw(key: string | null): string | null {
+  if (!key || typeof window === "undefined") return null;
+  try { return window.localStorage.getItem(key); } catch { return null; }
+}
+
+function readPersistedCollapsed(key: string | null): Set<string> | null {
+  const raw = readPersistedRaw(key);
+  if (raw === null) return null;
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return null;
+    const out = new Set<string>();
+    for (const v of arr) if (typeof v === "string") out.add(v);
+    return out;
+  } catch { return null; }
+}
+
+function readPersistedZoom(key: string | null): ZoomLevel | null {
+  const raw = readPersistedRaw(key);
+  if (raw === "week" || raw === "month" || raw === "quarter") return raw;
+  return null;
+}
+
+function readPersistedOutlineWidth(key: string | null): number | null {
+  const raw = readPersistedRaw(key);
+  if (raw === null) return null;
+  const n = Number(raw);
+  // Clamp: outline width under 120 or over 600 is clearly junk/stale
+  // (e.g. from an old resize bug). Fall back to default in that case.
+  if (!Number.isFinite(n) || n < 120 || n > 600) return null;
+  return n;
 }
 
 function collectTasks(root: GanttNode): GanttTask[] {

--- a/apps/web/src/components/workspace/gantt/GanttContainer.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttContainer.tsx
@@ -202,9 +202,11 @@ function nodeLabel(n: GanttNode): string {
 
 function collectTasks(root: GanttNode): GanttTask[] {
   const out: GanttTask[] = [];
+  // Timeline Slice 2 — subtask now carries `children`; walk them too so
+  // deeply-nested subtask bars still contribute to range/date calcs.
   function walk(n: GanttNode) {
     if (n.kind === "task" || n.kind === "subtask") out.push(n.task);
-    if (n.kind !== "subtask") for (const c of n.children) walk(c);
+    for (const c of n.children) walk(c);
   }
   walk(root);
   return out;
@@ -220,7 +222,7 @@ function collectAllKeys(root: GanttNode): Set<string> {
   }
   function walk(n: GanttNode, isRoot: boolean) {
     if (!isRoot) out.add(keyOf(n));
-    if (n.kind !== "subtask") for (const c of n.children) walk(c, false);
+    for (const c of n.children) walk(c, false);
   }
   walk(root, true);
   return out;

--- a/apps/web/src/components/workspace/gantt/GanttContainer.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttContainer.tsx
@@ -11,7 +11,7 @@ interface Props {
   root: GanttNode;
   defaultZoom?: ZoomLevel;
   onOpenDetail?: (key: string) => void;
-  onAdd?: (context: { selectedKey: string | null }) => void;
+  onAdd?: (context: { selectedKey: string | null; hoveredKey: string | null }) => void;
   addLabel?: string;
   categoryColorMap?: CategoryColorMap;
   rootCategoryColor?: string;
@@ -25,6 +25,10 @@ interface Props {
   onContextMenuAction?: (action: ContextMenuAction, args: { rowKey: string; rowKind: GanttNode["kind"]; categoryId?: string | null }) => void;
   categoriesForSubmenu?: CategoryOption[];
   onSelectionChange?: (selectedKey: string | null) => void;
+  // Timeline Slice 1 — expose hover so the parent's "Add item" can target
+  // the hovered row (project → Add task, task → Add subtask). Fires on
+  // every change; pass a stable setter.
+  onHoverChange?: (hoveredKey: string | null) => void;
 }
 
 export function GanttContainer({
@@ -33,7 +37,7 @@ export function GanttContainer({
   outlineHeader, outlineHeaderActions, outlineFooter, outlineOverlay,
   onCategoriesClick, categoriesOpen,
   onContextMenuAction, categoriesForSubmenu = [],
-  onSelectionChange,
+  onSelectionChange, onHoverChange,
 }: Props) {
   const [zoom, setZoom] = useState<ZoomLevel>(defaultZoom);
   const [search, setSearch] = useState("");
@@ -73,11 +77,22 @@ export function GanttContainer({
     gridRef.current.scrollTo({ left: Math.max(0, (pct / 100) * sw - vw / 2), behavior: "smooth" });
   }, [range]);
 
+  // Timeline Slice 1 — track the previous tree's keys so we can tell which
+  // rows are brand-new on a data refetch. Previously any key not in `prev`
+  // was dropped, which meant a freshly-created subcategory/subtask landed
+  // collapsed and looked missing. Now new keys auto-expand; user-collapsed
+  // keys stay collapsed as long as they survive.
+  const prevKeysRef = useRef<Set<string> | null>(null);
   useEffect(() => {
+    const keys = collectAllKeys(root);
+    const prevKeys = prevKeysRef.current;
+    prevKeysRef.current = keys;
+    // First mount — useState already seeded `expanded` with all keys.
+    if (prevKeys === null) return;
     setExpanded((prev) => {
-      const keys = collectAllKeys(root);
       const next = new Set<string>();
       for (const k of prev) if (keys.has(k)) next.add(k);
+      for (const k of keys) if (!prevKeys.has(k)) next.add(k);
       return next.size === 0 ? keys : next;
     });
   }, [root]);
@@ -87,6 +102,8 @@ export function GanttContainer({
     onSelectionChange?.(k);
     if (k) onOpenDetail?.(k);
   }, [onOpenDetail, onSelectionChange]);
+
+  useEffect(() => { onHoverChange?.(hoveredKey); }, [hoveredKey, onHoverChange]);
 
   const handleContextMenu = useCallback(
     (rowKey: string, rowKind: GanttNode["kind"], e: React.MouseEvent) => {
@@ -131,7 +148,7 @@ export function GanttContainer({
         zoom={zoom} search={search}
         onZoom={setZoom} onJumpToToday={jumpToToday}
         onSearch={setSearch}
-        onAdd={() => onAdd?.({ selectedKey })}
+        onAdd={() => onAdd?.({ selectedKey, hoveredKey })}
         canAdd={Boolean(onAdd)}
         addLabel={addLabel}
         onCategoriesClick={onCategoriesClick}

--- a/apps/web/src/components/workspace/gantt/GanttRow.tsx
+++ b/apps/web/src/components/workspace/gantt/GanttRow.tsx
@@ -18,9 +18,11 @@ interface Props {
 
 function gatherDescendantTasks(node: GanttNode): GanttTask[] {
   const out: GanttTask[] = [];
+  // Timeline Slice 2 — subtask now carries `children`; walk them too so a
+  // parent task's rolled-up bar includes deeply-nested subtask spans.
   function walk(n: GanttNode) {
     if (n.kind === "task" || n.kind === "subtask") out.push(n.task);
-    if (n.kind !== "subtask") for (const c of n.children) walk(c);
+    for (const c of n.children) walk(c);
   }
   walk(node);
   return out;

--- a/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+++ b/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
@@ -62,26 +62,34 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
   const source = (timeline?.gantt && timeline.gantt.length > 0) ? timeline.gantt : tasks;
   const ganttTasks = useMemo(() => (source as WorkspaceTimelineTask[]).map(toGanttTask), [source]);
 
-  // v4 Slice 4 — categories + projects come from the same React Query cache that
-  // the portfolio timeline populates. If the user navigated here from
-  // /workspace/timeline within staleTime, the first render already has the
-  // real colour + category tree (fixes the Larry-purple flash reproduced
-  // 2026-04-18 at t=12,367 ms → t=13,006 ms).
+  // Timeline Slice 2 (Bug 8) — the project timeline response is now
+  // self-sufficient. It carries its own `categories` slice and a
+  // `project.categoryId` so the Gantt no longer has to wait for the org
+  // timeline cache to resolve colours. The org hooks stay as a fallback
+  // during the API roll-forward window (if `timeline.categories` is
+  // undefined, we degrade to the old path — no grey flash worse than
+  // before, but no regression either).
   const { data: categoriesData } = useCategoriesFromTimeline();
   const { data: projectsData } = useProjectsFromTimeline();
 
-  const allCategories: TimelineCategorySummary[] = categoriesData?.categories ?? [];
+  const allCategories: TimelineCategorySummary[] = useMemo(() => {
+    if (timeline?.categories) return timeline.categories;
+    return categoriesData?.categories ?? [];
+  }, [timeline?.categories, categoriesData]);
 
-  // The project row's category colour — resolved synchronously from the shared
-  // cache. Returns null when data isn't loaded yet; the Gantt renders neutral
-  // grey (NEUTRAL_ROW_COLOUR) in that case, never Larry purple.
+  // Resolve the project's category colour. Prefer the timeline response's
+  // project.categoryId (authoritative for this project); fall back to the
+  // org-cache projects list if the API hasn't deployed the new shape yet.
   const categoryColour: string | null = useMemo(() => {
-    if (!projectsData || !categoriesData) return null;
-    const proj = projectsData.items.find((p: ProjectSummary) => p.id === projectId);
-    if (!proj?.categoryId) return null;
-    const map = buildCategoryColorMap(categoriesData.categories.map((c: TimelineCategorySummary) => ({ id: c.id, colour: c.colour })));
-    return map.get(`cat:${proj.categoryId}`) ?? null;
-  }, [categoriesData, projectsData, projectId]);
+    const categoryId =
+      timeline?.project?.categoryId
+      ?? projectsData?.items.find((p: ProjectSummary) => p.id === projectId)?.categoryId
+      ?? null;
+    if (!categoryId) return null;
+    if (allCategories.length === 0) return null;
+    const map = buildCategoryColorMap(allCategories.map((c) => ({ id: c.id, colour: c.colour })));
+    return map.get(`cat:${categoryId}`) ?? null;
+  }, [timeline?.project, projectsData, projectId, allCategories]);
 
   const root = useMemo(
     () => buildProjectTree(

--- a/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+++ b/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
@@ -104,6 +104,9 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
   const [addCtx, setAddCtx] = useState<AddCtx | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  // Timeline Slice 1 — parallel hover tracking to PortfolioGanttClient so
+  // "Add item" targets the hovered row.
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [colourPopover, setColourPopover] = useState<ColourPopover | null>(null);
 
@@ -430,13 +433,25 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
           root={root}
           defaultZoom="month"
           onSelectionChange={setSelectedKey}
+          onHoverChange={setHoveredKey}
           rootCategoryColor={categoryColour ?? NEUTRAL_ROW_COLOUR}
           onContextMenuAction={handleContextMenuAction}
           categoriesForSubmenu={categoriesForSubmenu}
           outlineHeaderActions={
             <button
               type="button"
-              onClick={() => setPickerOpen(true)}
+              // Timeline Slice 1 — hover-aware. Hovering a task skips the
+              // picker and opens the Add-subtask modal directly (since a
+              // task's only addable child is a subtask). Hovering a
+              // category / nothing still opens the picker.
+              onClick={() => {
+                const k = hoveredKey ?? selectedKey;
+                if (k?.startsWith("task:")) {
+                  setAddCtx({ mode: "subtask", parentTaskId: k.slice(5) });
+                  return;
+                }
+                setPickerOpen(true);
+              }}
               style={{
                 display: "inline-flex", alignItems: "center", gap: 5,
                 height: 26, padding: "0 10px", fontSize: 12, fontWeight: 600,
@@ -455,18 +470,20 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
           onClose={() => setPickerOpen(false)}
           onChoose={(kind) => {
             setPickerOpen(false);
+            // Timeline Slice 1 — resolve parent from hover first, selection second.
+            const k = hoveredKey ?? selectedKey;
             if (kind === "group") {
               setAddCtx(
-                selectedKey?.startsWith("cat:") && selectedKey !== "cat:uncat"
-                  ? { mode: "subcategory", parentCategoryId: selectedKey.slice(4) }
+                k?.startsWith("cat:") && k !== "cat:uncat"
+                  ? { mode: "subcategory", parentCategoryId: k.slice(4) }
                   : { mode: "category" }
               );
             } else {
-              if (selectedKey?.startsWith("task:")) {
-                setAddCtx({ mode: "subtask", parentTaskId: selectedKey.slice(5) });
+              if (k?.startsWith("task:")) {
+                setAddCtx({ mode: "subtask", parentTaskId: k.slice(5) });
               } else {
-                const catId = selectedKey?.startsWith("cat:") && selectedKey !== "cat:uncat"
-                  ? selectedKey.slice(4) : undefined;
+                const catId = k?.startsWith("cat:") && k !== "cat:uncat"
+                  ? k.slice(4) : undefined;
                 setAddCtx({ mode: "task", categoryId: catId });
               }
             }

--- a/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
+++ b/apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx
@@ -432,6 +432,7 @@ export function ProjectGanttClient({ projectId, projectName, tasks, timeline, re
         <GanttContainer
           root={root}
           defaultZoom="month"
+          persistKey={`proj:${projectId}`}
           onSelectionChange={setSelectedKey}
           onHoverChange={setHoveredKey}
           rootCategoryColor={categoryColour ?? NEUTRAL_ROW_COLOUR}

--- a/apps/web/src/components/workspace/gantt/gantt-types.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-types.ts
@@ -2,11 +2,15 @@ import type { GanttTask, GanttTaskStatus, ProjectCategory, PortfolioTimelineResp
 
 export type { GanttTask, GanttTaskStatus, ProjectCategory, PortfolioTimelineResponse };
 
+// Timeline Slice 2 — subtasks now carry `children` so the tree supports
+// arbitrary depth (task → subtask → subtask → …). The DB schema already
+// allows it via `tasks.parent_task_id` chaining; the cap was a frontend
+// artifact that made the feature look missing.
 export type GanttNode =
   | { kind: "category"; id: string | null; name: string; colour: string | null; children: GanttNode[] }
   | { kind: "project";  id: string; name: string; status: string; children: GanttNode[] }
   | { kind: "task";     id: string; task: GanttTask; children: GanttNode[] }
-  | { kind: "subtask";  id: string; task: GanttTask };
+  | { kind: "subtask";  id: string; task: GanttTask; children: GanttNode[] };
 
 export type ZoomLevel = "week" | "month" | "quarter";
 export const ROW_HEIGHT = 32;            // category + project (v3)

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -15,7 +15,7 @@ import type { PortfolioTimelineResponse, GanttTask, GanttNode } from "./gantt-ty
 import { ROW_HEIGHT, ROW_HEIGHT_TASK } from "./gantt-types";
 
 const baseTask = (over: Partial<GanttTask> = {}): GanttTask => ({
-  id: "t", projectId: "p", parentTaskId: null, title: "T",
+  id: "t", projectId: "p", parentTaskId: null, categoryId: null, title: "T",
   status: "not_started", priority: "medium",
   assigneeUserId: null, assigneeName: null,
   startDate: null, endDate: null, dueDate: null, progressPercent: 0,
@@ -609,6 +609,27 @@ describe("validateDrop", () => {
     expect(r).toEqual({
       ok: true,
       effect: { kind: "moveTask", sourceId: "t3", newProjectId: "p2", newParentTaskId: null },
+    });
+  });
+
+  // Timeline Slice 1 — regression guard. `moveTaskToCategory` is a
+  // validateDrop output the portfolio handleDragEnd switch forgot to handle,
+  // causing task→category drops to silently fail on the org timeline. The
+  // switch now has a case for it; this test pins the effect shape so the
+  // case can't drift out of sync with the validator again.
+  it("task → category emits moveTaskToCategory", () => {
+    const r = validateDrop("dnd-task:t1", "dnd-cat:c1", mkCtx());
+    expect(r).toEqual({
+      ok: true,
+      effect: { kind: "moveTaskToCategory", sourceId: "t1", newCategoryId: "c1" },
+    });
+  });
+
+  it("subtask → category emits moveTaskToCategory", () => {
+    const r = validateDrop("dnd-sub:t3", "dnd-cat:c1", mkCtx());
+    expect(r).toEqual({
+      ok: true,
+      effect: { kind: "moveTaskToCategory", sourceId: "t3", newCategoryId: "c1" },
     });
   });
 

--- a/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.test.ts
@@ -90,6 +90,61 @@ describe("buildPortfolioTree", () => {
     const topLevel = (tree as Extract<GanttNode, { kind: "category" }>).children as Array<Extract<GanttNode, { kind: "category" }>>;
     expect(topLevel.map((n) => n.id)).toEqual(["c-org"]);
   });
+
+  // Timeline Slice 2 — subtask depth used to be capped at 1. Now it's
+  // unlimited: task → subtask → subtask → … renders as a chain as long as
+  // the parentTaskId links stay valid.
+  it("builds arbitrarily-deep subtask chains", () => {
+    const resp: PortfolioTimelineResponse = {
+      categories: [{
+        id: "c1", name: "C", colour: null, sortOrder: 0,
+        projects: [{
+          id: "p1", name: "P", status: "active", startDate: null, targetDate: null,
+          tasks: [
+            baseTask({ id: "t1", projectId: "p1" }),                         // root task
+            baseTask({ id: "t2", projectId: "p1", parentTaskId: "t1" }),     // subtask
+            baseTask({ id: "t3", projectId: "p1", parentTaskId: "t2" }),     // sub-subtask
+            baseTask({ id: "t4", projectId: "p1", parentTaskId: "t3" }),     // depth 3
+          ],
+        }],
+      }],
+      dependencies: [],
+    };
+    const tree = buildPortfolioTree(resp);
+    const cats = (tree as Extract<GanttNode, { kind: "category" }>).children;
+    const c1 = cats[0] as Extract<GanttNode, { kind: "category" }>;
+    const p1 = c1.children[0] as Extract<GanttNode, { kind: "project" }>;
+    const t1 = p1.children[0] as Extract<GanttNode, { kind: "task" }>;
+    expect(t1.children.map((c) => c.id)).toEqual(["t2"]);
+    const t2 = t1.children[0] as Extract<GanttNode, { kind: "subtask" }>;
+    expect(t2.children.map((c) => c.id)).toEqual(["t3"]);
+    const t3 = t2.children[0] as Extract<GanttNode, { kind: "subtask" }>;
+    expect(t3.children.map((c) => c.id)).toEqual(["t4"]);
+  });
+
+  // Defensive — a corrupt DB loop (a.parent = b, b.parent = a) must not
+  // hang the render. buildTaskForest guards via a `visited` set; the
+  // second time a task id is seen on a descent, its children are empty.
+  it("breaks out of a parentTaskId cycle", () => {
+    const resp: PortfolioTimelineResponse = {
+      categories: [{
+        id: "c1", name: "C", colour: null, sortOrder: 0,
+        projects: [{
+          id: "p1", name: "P", status: "active", startDate: null, targetDate: null,
+          tasks: [
+            // t1 has no parent → becomes a root. t1 and t2 point at each
+            // other; since t1 is in `top` via parentTaskId=null we start
+            // there, and when we re-encounter t1 under t2 the visited
+            // guard stops recursion.
+            baseTask({ id: "t1", projectId: "p1" }),
+            baseTask({ id: "t2", projectId: "p1", parentTaskId: "t1" }),
+          ],
+        }],
+      }],
+      dependencies: [],
+    };
+    expect(() => buildPortfolioTree(resp)).not.toThrow();
+  });
 });
 
 describe("buildProjectTree", () => {
@@ -160,7 +215,7 @@ describe("buildProjectTree", () => {
 describe("flattenVisible", () => {
   it("respects expandedSet", () => {
     const task1 = { kind: "task" as const, id: "t1", task: baseTask({ id: "t1" }),
-      children: [{ kind: "subtask" as const, id: "t2", task: baseTask({ id: "t2", parentTaskId: "t1" }) }] };
+      children: [{ kind: "subtask" as const, id: "t2", task: baseTask({ id: "t2", parentTaskId: "t1" }), children: [] }] };
     const project: GanttNode = { kind: "project", id: "p1", name: "P", status: "active", children: [task1] };
     const cat: GanttNode = { kind: "category", id: "c1", name: "C", colour: null, children: [project] };
     // Use synthetic __root__ wrapper (mirrors portfolio usage; root is always skipped)
@@ -252,7 +307,7 @@ describe("resolveCategoryColor", () => {
 });
 
 describe("flattenVisible populates categoryColor", () => {
-  const sub: GanttNode = { kind: "subtask", id: "t2", task: baseTask({ id: "t2", parentTaskId: "t1" }) };
+  const sub: GanttNode = { kind: "subtask", id: "t2", task: baseTask({ id: "t2", parentTaskId: "t1" }), children: [] };
   const task1: GanttNode = { kind: "task", id: "t1", task: baseTask({ id: "t1" }), children: [sub] };
   const project: GanttNode = { kind: "project", id: "p1", name: "P", status: "active", children: [task1] };
   const category: GanttNode = { kind: "category", id: "c1", name: "C", colour: "#123456", children: [project] };
@@ -377,7 +432,7 @@ describe("contextMenuItemsFor", () => {
 
 describe("flattenVisible assigns per-level heights", () => {
   it("category/project rows use ROW_HEIGHT=32 and task/subtask use 28", () => {
-    const sub: GanttNode = { kind: "subtask", id: "t2", task: baseTask({ id: "t2", parentTaskId: "t1" }) };
+    const sub: GanttNode = { kind: "subtask", id: "t2", task: baseTask({ id: "t2", parentTaskId: "t1" }), children: [] };
     const task1: GanttNode = { kind: "task", id: "t1", task: baseTask({ id: "t1" }), children: [sub] };
     const project: GanttNode = { kind: "project", id: "p1", name: "P", status: "active", children: [task1] };
     const category: GanttNode = { kind: "category", id: "c1", name: "C", colour: null, children: [project] };
@@ -569,7 +624,10 @@ describe("validateDrop", () => {
     });
   });
 
-  it("task → subtask makes source a sibling (same parent)", () => {
+  // Timeline Slice 2 — depth cap removed. Dropping a task onto a subtask
+  // now nests it under the subtask (previously it became a sibling because
+  // the old rule said "subtasks can't parent subtasks").
+  it("task → subtask becomes a child of the target subtask", () => {
     const r = validateDrop("dnd-task:t1", "dnd-sub:t3", mkCtx({
       tasksById: new Map([
         ["t1", { projectId: "p1", parentTaskId: null }],
@@ -579,8 +637,21 @@ describe("validateDrop", () => {
     }));
     expect(r).toEqual({
       ok: true,
-      effect: { kind: "moveTask", sourceId: "t1", newProjectId: "p1", newParentTaskId: "t2" },
+      effect: { kind: "moveTask", sourceId: "t1", newProjectId: "p1", newParentTaskId: "t3" },
     });
+  });
+
+  it("rejects task cycle — drop a task onto one of its own descendants", () => {
+    // t2 is a descendant of t1 (t2.parent = t1). Dragging t1 onto t2 must
+    // be rejected so we don't create an a → b → a cycle.
+    const r = validateDrop("dnd-task:t1", "dnd-task:t2", mkCtx({
+      tasksById: new Map([
+        ["t1", { projectId: "p1", parentTaskId: null }],
+        ["t2", { projectId: "p1", parentTaskId: "t1" }],
+      ]),
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/descendant/i);
   });
 
   it("task → task cross-project is allowed", () => {

--- a/apps/web/src/components/workspace/gantt/gantt-utils.ts
+++ b/apps/web/src/components/workspace/gantt/gantt-utils.ts
@@ -195,6 +195,9 @@ function buildProjectScopedCategoryForest(
   return (childrenByParent.get(null) ?? []).map(buildNode);
 }
 
+// Timeline Slice 2 — recursive so task trees can be arbitrarily deep
+// (task → subtask → subtask → …). Cycle-guard via `visited` so a corrupt
+// parentTaskId loop in the DB can't hang the render.
 function buildTaskForest(tasks: GanttTask[]): GanttNode[] {
   const byParent = new Map<string | null, GanttTask[]>();
   for (const t of tasks) {
@@ -202,15 +205,22 @@ function buildTaskForest(tasks: GanttTask[]): GanttNode[] {
     list.push(t);
     byParent.set(t.parentTaskId, list);
   }
+  function build(t: GanttTask, isSub: boolean, visited: Set<string>): GanttNode {
+    if (visited.has(t.id)) {
+      // Defensive — skip descendants to break the cycle. The row still
+      // renders so the user can see and fix the bad data.
+      return isSub
+        ? { kind: "subtask", id: t.id, task: t, children: [] }
+        : { kind: "task", id: t.id, task: t, children: [] };
+    }
+    const nextVisited = new Set(visited).add(t.id);
+    const children = (byParent.get(t.id) ?? []).map((c) => build(c, true, nextVisited));
+    return isSub
+      ? { kind: "subtask", id: t.id, task: t, children }
+      : { kind: "task", id: t.id, task: t, children };
+  }
   const top = byParent.get(null) ?? [];
-  return top.map<GanttNode>((t) => ({
-    kind: "task",
-    id: t.id,
-    task: t,
-    children: (byParent.get(t.id) ?? []).map<GanttNode>((sub) => ({
-      kind: "subtask", id: sub.id, task: sub,
-    })),
-  }));
+  return top.map((t) => build(t, false, new Set()));
 }
 
 /* ─── Flatten for rendering ────────────────────────────────────────── */
@@ -262,7 +272,8 @@ export function flattenVisible(
   }
 
   function walk(node: GanttNode, depth: number, isSyntheticRoot: boolean, inherited: string) {
-    const children: GanttNode[] = (node.kind === "subtask") ? [] : node.children;
+    // Timeline Slice 2 — subtask now carries `children`; no special-case.
+    const children: GanttNode[] = node.children;
     const hasChildren = children.length > 0;
     const key = keyOf(node);
     const categoryColor = colourFor(node, inherited);
@@ -334,7 +345,7 @@ export function resolveCategoryColor(
 
   function find(node: GanttNode, ancestors: GanttNode[]): GanttNode[] | null {
     if (keyOf(node) === nodeKey) return [...ancestors, node];
-    if (node.kind === "subtask") return null;
+    // Timeline Slice 2 — subtask now has `children`; walk them too.
     for (const c of node.children) {
       const hit = find(c, [...ancestors, node]);
       if (hit) return hit;
@@ -634,7 +645,7 @@ export function searchUnDimmedKeys(root: GanttNode, rawQuery: string): Set<strin
   function addSubtree(node: GanttNode): void {
     const isSyntheticRoot = node.kind === "category" && node.id === "__root__";
     if (!isSyntheticRoot) out.add(keyOf(node));
-    if (node.kind === "subtask") return;
+    // Timeline Slice 2 — subtask now has `children`; walk them too.
     for (const child of node.children) addSubtree(child);
   }
 
@@ -646,11 +657,9 @@ export function searchUnDimmedKeys(root: GanttNode, rawQuery: string): Set<strin
     const k = keyOf(node);
     const selfMatch = !isSyntheticRoot && labelOf(node).toLowerCase().includes(query);
     let descendantMatch = false;
-    if (node.kind !== "subtask") {
-      const nextAncestors = isSyntheticRoot ? ancestors : [...ancestors, k];
-      for (const child of node.children) {
-        if (walk(child, nextAncestors)) descendantMatch = true;
-      }
+    const nextAncestors = isSyntheticRoot ? ancestors : [...ancestors, k];
+    for (const child of node.children) {
+      if (walk(child, nextAncestors)) descendantMatch = true;
     }
     if (selfMatch) {
       // Propagate up + keep the whole subtree in context.
@@ -721,6 +730,24 @@ function isAncestorCategory(
     seen.add(cursor);
     const row = ctx.categoriesById.get(cursor);
     cursor = row?.parentCategoryId ?? null;
+  }
+  return false;
+}
+
+// Timeline Slice 2 — task equivalent. Used to reject a task drop that would
+// create a cycle (drop-target is a descendant of the source).
+function isAncestorTask(
+  ctx: DropContext,
+  ancestorId: string,
+  possibleDescendantId: string,
+): boolean {
+  let cursor: string | null = possibleDescendantId;
+  const seen = new Set<string>();
+  while (cursor && !seen.has(cursor)) {
+    if (cursor === ancestorId) return true;
+    seen.add(cursor);
+    const row = ctx.tasksById.get(cursor);
+    cursor = row?.parentTaskId ?? null;
   }
   return false;
 }
@@ -796,18 +823,23 @@ export function validateDrop(
   }
 
   // task/subtask → task/subtask  (reparent + potential cross-project)
+  //
+  // Timeline Slice 2 — the depth cap is gone. Dropping any task onto any
+  // task/subtask makes the source a child of the target. Cycle detection
+  // mirrors the category rule: can't drop a task under one of its own
+  // descendants.
   if ((src.kind === "task" || src.kind === "sub") && (tgt.kind === "task" || tgt.kind === "sub")) {
     const tgtTask = ctx.tasksById.get(tgt.id);
     if (!tgtTask) return { ok: false, reason: "Target task not found." };
-    // Task depth cap = 1: a subtask cannot parent another subtask, so if the
-    // target is itself a subtask the source becomes a sibling (same parent).
-    const newParentTaskId = tgt.kind === "task" ? tgt.id : tgtTask.parentTaskId;
-    if (newParentTaskId === src.id) {
+    if (tgt.id === src.id) {
       return { ok: false, reason: "Task cannot be its own parent." };
+    }
+    if (isAncestorTask(ctx, src.id, tgt.id)) {
+      return { ok: false, reason: "Can't move a task under its own descendant." };
     }
     return {
       ok: true,
-      effect: { kind: "moveTask", sourceId: src.id, newProjectId: tgtTask.projectId, newParentTaskId },
+      effect: { kind: "moveTask", sourceId: src.id, newProjectId: tgtTask.projectId, newParentTaskId: tgt.id },
     };
   }
 

--- a/docs/timeline-bug-bash-2026-04-20.md
+++ b/docs/timeline-bug-bash-2026-04-20.md
@@ -1,0 +1,408 @@
+# Timeline Bug Bash — 2026-04-20 (PR #141)
+
+Manual test sheet for the 9 timeline fixes landed on branch
+`fix/timeline-slice-1-dnd-hover-expand-memo`. Run these on the Vercel
+preview deploy for the PR, then again on production once merged. Every
+case has a pre-condition, steps, and a pass/fail criterion — tick each
+one off as you go.
+
+> Tests on BotID-protected routes (anything under `/login` and
+> `/workspace/**`) must use a real Chromium (Playwright MCP, manual
+> browser) — headless Chromium is served a "Code 21" block page.
+
+---
+
+## 0. Setup — run once before starting
+
+**Test account:** `launch-test-2026@larry-pm.com` / `TestLarry123%`
+(admin, own tenant; seeded 2026-04-18).
+
+**Seed data prep** (open the browser devtools console on
+`/workspace/timeline` after login and paste):
+
+```js
+// Wipes the persisted Gantt state for a clean run. Skip if you want
+// to test the persistence behaviour from a pre-existing state.
+Object.keys(localStorage)
+  .filter((k) => k.startsWith("larry:gantt:"))
+  .forEach((k) => localStorage.removeItem(k));
+```
+
+Create the following tree via right-click → Add actions (or the
+toolbar "Add item" button), if the seed tenant doesn't already have
+them. You'll reuse these in the cases below.
+
+```
+[Category] Bug Bash 2026-04-20
+  ├─ [Subcategory] Client Work
+  │   └─ [Project] Website Redesign
+  │       └─ [Task] Wireframes (start: 2026-04-21, due: 2026-05-01)
+  │           └─ [Subtask] Home (start: 2026-04-21, due: 2026-04-25)
+  │               └─ [Sub-subtask] Hero (start: 2026-04-21, due: 2026-04-23)
+  └─ [Project] Internal Tools
+      └─ [Task] Rewrite invoicing (start: 2026-04-22, due: 2026-05-30)
+```
+
+---
+
+## 1. Bug 1 — DnD: task → category completes silently (was no-op)
+
+**Was:** Dragging a task onto a category row on `/workspace/timeline`
+did nothing — validateDrop emitted `moveTaskToCategory` but the
+portfolio handler had no case for it.
+
+**Case 1.1 — Org timeline, task onto category**
+- [ ] On `/workspace/timeline`, drag "Rewrite invoicing" onto the
+      "Bug Bash 2026-04-20" category row.
+- [ ] **Pass:** The task now renders under that category's bucket
+      (the project stays where it was, but the task's `categoryId` is
+      set). Network tab: `PATCH /api/workspace/tasks/<id>` returned
+      200. No "silent no-op", no error toast.
+
+**Case 1.2 — Org timeline, subtask onto category**
+- [ ] Drag "Home" (a subtask) onto any category. Same expected
+      outcome as 1.1.
+
+**Case 1.3 — Regression: other DnD combos still work**
+- [ ] Drag a subcategory onto another category → reparents
+      (moveCategory).
+- [ ] Drag a project onto a different category → reparents
+      (moveProject).
+- [ ] Drag a task onto a different project → cross-project move
+      (moveTask with newProjectId).
+- [ ] Drag a task onto another task → nests as subtask (see Bug 4
+      for the deeper case).
+- [ ] Attempt: drag category onto its own descendant → toast
+      "Can't move a category under its own descendant.", drop
+      rejected.
+
+---
+
+## 2. Bug 2 — "Add item" is hover-aware
+
+**Was:** Clicking the toolbar "Add item" button always opened the
+Category/Project picker, ignoring the row you were hovering.
+
+**Case 2.1 — Hover a project, click Add**
+- [ ] Hover the row "Website Redesign".
+- [ ] Click "Add item".
+- [ ] **Pass:** AddNodeModal opens directly in **task** mode with
+      Website Redesign as parent (visible via the modal heading
+      "New task"). No picker step.
+
+**Case 2.2 — Hover a task, click Add**
+- [ ] Expand the project row so "Wireframes" is visible.
+- [ ] Hover "Wireframes".
+- [ ] Click "Add item".
+- [ ] **Pass:** AddNodeModal opens directly in **subtask** mode with
+      Wireframes as parentTaskId ("New subtask" heading).
+
+**Case 2.3 — Hover a subtask, click Add (Slice 2)**
+- [ ] Hover "Home" (a subtask).
+- [ ] Click "Add item".
+- [ ] **Pass:** AddNodeModal opens in **subtask** mode with Home as
+      parentTaskId — a nested subtask under Home (unlimited depth,
+      see Bug 4).
+
+**Case 2.4 — Hover a category, click Add**
+- [ ] Hover "Client Work".
+- [ ] Click "Add item".
+- [ ] **Pass:** Picker opens (because both "subcategory" and "new
+      project in this category" are reasonable actions). Selecting
+      **Group** → AddNodeModal opens as subcategory of Client Work.
+      Selecting **Task** (labelled "Project" on the picker) → new
+      project in Client Work.
+
+**Case 2.5 — Nothing hovered, click Add**
+- [ ] Move mouse outside any row, click "Add item".
+- [ ] **Pass:** Picker opens. Group → new root category. Task → new
+      top-level project.
+
+**Case 2.6 — Same behaviour inside a project timeline**
+- [ ] Navigate to `/workspace/projects/<id>?tab=timeline` (e.g. use
+      Internal Tools).
+- [ ] Hover a task, click Add → subtask modal directly.
+- [ ] Hover a subtask, click Add → subtask modal directly (not task).
+- [ ] Hover nothing, click Add → picker.
+
+---
+
+## 3. Bug 3 — New subcategories/subtasks land expanded
+
+**Was:** Creating a subcategory via right-click inserted it into the
+tree collapsed, so it looked missing until the user clicked the
+chevron.
+
+**Case 3.1 — Create a new subcategory**
+- [ ] Right-click "Bug Bash 2026-04-20" → "Add subcategory".
+- [ ] Name it "TEMP-001" and save.
+- [ ] **Pass:** The new subcategory appears **expanded** (its chevron
+      points down, no collapse).
+
+**Case 3.2 — Create a new subtask**
+- [ ] Right-click "Wireframes" and use the add-subtask flow (or hover
+      + Add item — Case 2.2).
+- [ ] Name it "TEMP-sub" with today's dates.
+- [ ] **Pass:** The new subtask appears under Wireframes immediately,
+      and the parent row is still expanded.
+
+**Case 3.3 — Previously-collapsed siblings stay collapsed**
+- [ ] Collapse "Client Work" (click its chevron).
+- [ ] Create a new top-level category via the Add picker.
+- [ ] **Pass:** The new category appears expanded. "Client Work"
+      remains collapsed.
+
+**(Cleanup)** Delete TEMP-001 and TEMP-sub via right-click → Delete.
+
+---
+
+## 4. Bug 4 — Unlimited subtask depth
+
+**Was:** `buildTaskForest` capped subtasks at one level and
+`validateDrop` forced deeper drops to become siblings of the target.
+Depth > 1 was architecturally impossible via the UI.
+
+**Case 4.1 — Create depth-3 chain**
+- [ ] On Website Redesign → Wireframes → Home, right-click "Home" →
+      Add subtask (or hover + Add item).
+- [ ] Name the new subtask "Hero" with today's dates.
+- [ ] **Pass:** The Gantt shows three levels under Wireframes
+      (Wireframes → Home → Hero). Each level is clickable and
+      expandable.
+
+**Case 4.2 — Drag to deepen**
+- [ ] Create a sibling subtask "Gallery" under Wireframes.
+- [ ] Drag "Gallery" onto "Hero".
+- [ ] **Pass:** Gallery now nests under Hero (depth 4). Previously
+      it would have become a sibling of Home, at depth 2.
+
+**Case 4.3 — Cycle rejection on task drops**
+- [ ] Drag "Wireframes" onto "Hero" (Hero is a descendant of
+      Wireframes).
+- [ ] **Pass:** Error toast "Can't move a task under its own
+      descendant." No mutation sent.
+
+**Case 4.4 — Roll-up bars span deep children**
+- [ ] Set Hero dates to 2026-04-23 → 2026-04-30 (i.e. extend past
+      the parent Wireframes due date).
+- [ ] **Pass:** The Wireframes parent bar visually extends to cover
+      through 2026-04-30 (roll-up includes deep descendants via
+      `gatherDescendantTasks`).
+
+**(Cleanup)** Delete the test rows you created.
+
+---
+
+## 5. Bug 5 — Latency
+
+**Was:** `buildPortfolioTree`, `normalizePortfolioStatuses`, and two
+lookup maps rebuilt in render on every parent state change, so a
+1000-project tenant walked the full tree on every keystroke.
+
+**Case 5.1 — Search-box responsiveness**
+- [ ] On `/workspace/timeline`, type slowly into the search box:
+      `T-I-M-E-L-I-N-E`.
+- [ ] **Pass:** Each keystroke paints within ~16ms. No noticeable
+      freeze between letters. Dimming animation flows smoothly.
+
+**Case 5.2 — Scroll the grid**
+- [ ] Scroll the timeline horizontally with trackpad / scroll wheel.
+- [ ] **Pass:** No jank. Smooth 60fps scroll.
+
+**Case 5.3 — Zoom switcher**
+- [ ] Cycle Week → Month → Quarter a few times.
+- [ ] **Pass:** Each switch paints in <100ms. No "Loading…" flash.
+
+**Case 5.4 — Pragmatic perf sanity (devtools Profiler)**
+- [ ] React DevTools → Profiler → record → expand a category → stop.
+- [ ] **Pass:** `GanttContainer` / `PortfolioGanttClient` don't
+      appear repeatedly in the render flame graph. `root` is the
+      same object ref between parent renders (check via Profiler
+      props diff).
+
+---
+
+## 6. Bug 6 — Sub-groups paint in a single frame
+
+**Was:** Sub-groups appeared staggered because each parent re-render
+rebuilt `root`, triggering the expand-state useEffect cascade.
+
+**Case 6.1 — Hard refresh → timeline paints as one batch**
+- [ ] On a tenant with ≥ 3 categories + subcategories, hard-refresh
+      the org timeline URL (Cmd/Ctrl-Shift-R).
+- [ ] **Pass:** After the "Loading…" flash, the full tree paints in
+      a single frame. No visible cascade of rows appearing one by
+      one.
+
+---
+
+## 7. Bug 7 — View state persists across refresh
+
+**Was:** Zoom, collapsed rows, and outline width reset to defaults on
+every page load.
+
+**Case 7.1 — Collapse some rows, refresh**
+- [ ] On `/workspace/timeline`, collapse "Client Work" and "Bug Bash
+      2026-04-20" by clicking their chevrons.
+- [ ] Hard-refresh the page.
+- [ ] **Pass:** Both rows are still collapsed after reload. Other
+      rows remain expanded.
+
+**Case 7.2 — Set Quarter zoom, refresh**
+- [ ] Switch zoom to Quarter.
+- [ ] Hard-refresh.
+- [ ] **Pass:** Page reloads in Quarter zoom, not Month.
+
+**Case 7.3 — Resize the outline panel, refresh**
+- [ ] Drag the outline-panel divider right to widen it (to ~400px).
+- [ ] Hard-refresh.
+- [ ] **Pass:** Outline is ~400px wide on reload.
+
+**Case 7.4 — Per-project scope**
+- [ ] On the Website Redesign project timeline, collapse a task row
+      and set zoom to Week. Hard-refresh.
+- [ ] **Pass:** Project timeline restores to Week with the task
+      collapsed.
+- [ ] Navigate to the Internal Tools project timeline.
+- [ ] **Pass:** Internal Tools has its OWN state (Month, everything
+      expanded) — Website Redesign's state is not shared.
+
+**Case 7.5 — New rows appear expanded after refresh**
+- [ ] Without interacting with the org timeline, create a new
+      category called "TEMP-Fresh" via the Add picker.
+- [ ] Refresh.
+- [ ] **Pass:** TEMP-Fresh appears expanded (new keys that were
+      never collapsed don't land in the `collapsed` set, so they
+      default to expanded on reload).
+
+**Case 7.6 — localStorage shape sanity**
+- [ ] Browser devtools → Application → Local Storage →
+      `https://larry-pm.com`.
+- [ ] **Pass:** Keys `larry:gantt:portfolio:collapsed`,
+      `larry:gantt:portfolio:zoom`, `larry:gantt:portfolio:outline`
+      exist. Project timelines use `larry:gantt:proj:<uuid>:…`
+      keys. The collapsed value is a JSON array of strings. Zoom is
+      one of `week`/`month`/`quarter`. Outline is a number string.
+
+**(Cleanup)** Delete TEMP-Fresh. Run the localStorage wipe snippet
+from §0 if you want to reset state between later cases.
+
+---
+
+## 8. Bug 8 — Project timeline self-sufficiency
+
+**Was:** Landing directly on a project URL without visiting
+`/workspace/timeline` first rendered the project row in neutral grey
+(NEUTRAL_ROW_COLOUR) until the org cache populated. Category colours
+depended on an org-wide query.
+
+**Case 8.1 — Cold-cache project visit shows real colour**
+- [ ] Log out and back in (or open an incognito window).
+- [ ] Navigate directly to `/workspace/projects/<id>?tab=timeline`
+      for a project that belongs to a coloured category (e.g.
+      Website Redesign under Client Work).
+- [ ] **Pass:** The project row's colour dot matches Client Work's
+      colour on first paint. No grey flash, no wait for a background
+      org-timeline fetch.
+
+**Case 8.2 — Project-scoped subcategories render without org cache**
+- [ ] On the Website Redesign project timeline, right-click the
+      project row → "Add category in this project". Name it
+      "PROJ-CAT".
+- [ ] Log out / back in to fully reset caches, then navigate
+      directly to `/workspace/projects/<id>?tab=timeline` again.
+- [ ] **Pass:** PROJ-CAT row is visible on first paint (came from
+      the project-timeline's own categories slice, not the org
+      cache).
+
+**Case 8.3 — Network sanity**
+- [ ] Devtools Network tab, filter to `timeline`.
+- [ ] **Pass:** Visiting a project page only requires
+      `/api/workspace/projects/<id>/overview` (which includes the
+      timeline internally). Loading succeeds even if
+      `/api/workspace/timeline` is never requested.
+
+**Case 8.4 — Backwards-compat during a partial deploy**
+- [ ] If the API deploy precedes the web deploy (or vice versa),
+      the project timeline should still render — the frontend falls
+      back to the org cache when `timeline.categories` is absent.
+- [ ] **Pass:** Mixed deploy window doesn't break either view. (This
+      is a roll-forward / roll-back safety check; hard to simulate
+      manually — verify via `git diff` review that both paths are
+      guarded.)
+
+**(Cleanup)** Delete PROJ-CAT.
+
+---
+
+## 9. Follow-up: #9 — Hover-aware Add (redundant with Bug 2)
+
+Covered entirely by Bug 2 cases 2.1–2.6. No separate cases.
+
+---
+
+## Regression sweep — stuff that should still work
+
+These are high-blast-radius scenarios that aren't fixes in this PR
+but touch the same code paths. If any of these break, roll back.
+
+- [ ] **R1** — Context menus: right-click category / project / task /
+      subtask show the expected items. "Delete" prompts for confirm.
+- [ ] **R2** — Moving a project to a category via the right-click
+      submenu still works (different code path from DnD).
+- [ ] **R3** — "Remove from timeline" on a task nulls its dates and
+      removes the bar.
+- [ ] **R4** — Archived projects: write actions show the
+      "unarchive first" message.
+- [ ] **R5** — Uncategorised bucket is non-editable: no right-click
+      menu, drops on it are rejected.
+- [ ] **R6** — Category colour picker works (right-click → Change
+      colour → pick a swatch → apply → timeline recolours).
+- [ ] **R7** — Category rename works (right-click → Rename →
+      prompt).
+- [ ] **R8** — The "+ Add item" button shows when the tenant has
+      content AND the empty-state CTA shows when it doesn't.
+- [ ] **R9** — Larry's accept flow (e.g. accept an action that
+      creates a task): the timeline refetches via the
+      `larry:refresh-timeline` window event.
+- [ ] **R10** — Task bars render correctly for each status:
+      not_started / on_track / at_risk / overdue / completed.
+
+---
+
+## Edge cases to poke at
+
+- [ ] A tenant with **zero projects** → empty state, no crashes.
+- [ ] A tenant with **one project, no tasks** → project row shows
+      "(no scheduled tasks)" suffix.
+- [ ] **Very wide outline panel** (~550px) → saved + restored; UI
+      doesn't break the grid below.
+- [ ] **Very narrow outline panel** (~150px) → readable, doesn't
+      clip chevrons.
+- [ ] **Task with dates but no assignee** → bar renders, row shows
+      no avatar.
+- [ ] **Dependency arrows** between tasks still render.
+- [ ] **Delete a category** while some of its rows are collapsed →
+      no localStorage tombstones (the GC pass runs on every tree
+      change).
+
+---
+
+## If something fails
+
+1. Note the exact case number and URL.
+2. Open devtools → Console → copy any error/warning text.
+3. Open devtools → Network → find the failing request, copy its
+   status + response body.
+4. Grab a screenshot of the UI state.
+5. File under PR #141 comment with those four items.
+
+---
+
+## Signoff
+
+- [ ] All Slice 1 cases pass (Bugs 1, 2, 3, 5, 6 — §§1–3, 5, 6)
+- [ ] All Slice 2 cases pass (Bugs 4, 7, 8 — §§4, 7, 8)
+- [ ] Full regression sweep passes (§R1–R10)
+- [ ] Edge cases spot-checked
+- [ ] Signed off by: __________  date: __________

--- a/packages/db/src/migrations/031_task_category_id.sql
+++ b/packages/db/src/migrations/031_task_category_id.sql
@@ -1,7 +1,13 @@
 -- Allow tasks to be associated with a project-scoped category (gantt group/sprint row).
 -- Nullable so existing tasks are unaffected; SET NULL on category delete keeps tasks alive.
+--
+-- FK points at `project_categories`, which is the real category table in this
+-- schema. The earlier version of this migration referenced a non-existent
+-- `categories` table — schema.sql is what the runner actually executes, so
+-- the typo never reached prod, but leaving the standalone file wrong was
+-- misleading for anyone reading the migration history.
 ALTER TABLE tasks
-  ADD COLUMN IF NOT EXISTS category_id UUID REFERENCES categories(id) ON DELETE SET NULL;
+  ADD COLUMN IF NOT EXISTS category_id UUID REFERENCES project_categories(id) ON DELETE SET NULL;
 
 CREATE INDEX IF NOT EXISTS idx_tasks_category ON tasks (tenant_id, category_id)
   WHERE category_id IS NOT NULL;

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -1776,3 +1776,20 @@ CREATE TABLE IF NOT EXISTS larry_org_scan_runs (
   tenant_id    UUID PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
   last_run_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- ── 031_task_category_id.sql ──────────────────────────────────────────────────
+-- Timeline Slice 3 (PR #141 follow-up). Commit c71754c shipped the server
+-- PATCH handler that writes tasks.category_id but the DDL only lived in the
+-- standalone migrations/031_task_category_id.sql file and was never appended
+-- here. schema.sql is the file the migrate runner actually executes, so the
+-- column was never created in any deployed tenant. A `PATCH /v1/tasks/:id`
+-- with {categoryId: ...} returned 500 ("column category_id does not exist")
+-- and the opaque Fastify handler hid the message. Add the column now with
+-- the correct FK (project_categories, not the non-existent categories table
+-- the original migration file pointed at).
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS category_id UUID REFERENCES project_categories(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tasks_category
+  ON tasks (tenant_id, category_id)
+  WHERE category_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Full timeline bug bash — **9 fixes + a schema-drift follow-up**, 6 commits on this branch. Closes every issue from the 2026-04-20 Gantt regression report and unblocks the server path the Bug 1 fix exposed.

> **Note:** Body rewritten after scope expansion from Slice 1 → full slate → Slice 3 schema fix. Individual commits are self-contained, so review commit-by-commit if you want.

### Fix slate

| Slice | Commit | Bug | One-liner |
|-------|--------|-----|-----------|
| 1 | `29635d0` | 1 | Wire `moveTaskToCategory` case into PortfolioGanttClient.handleDragEnd switch (was silently falling through) |
| 1 | `29635d0` | 2 + 9 | `GanttContainer.onHoverChange` + hover-aware Add button routing |
| 1 | `29635d0` | 3 | Auto-expand freshly-appearing keys via `useRef` prev-keys snapshot (superseded by Slice 2's collapsed-set semantics) |
| 1 | `29635d0` | 5 | Memoise `root`, `normalized`, `taskProjectLookup`, `projectStatusById` on `data` |
| 1 | `29635d0` | 6 | Downstream of Bug 5 — stable `root` ref ends re-render cascades |
| 2 | `d170f53` | 4 | `GanttNode.subtask` carries `children`, `buildTaskForest` recursive with cycle guard, `validateDrop` task→task allows arbitrary nesting with `isAncestorTask` guard |
| 2 | `3c583bf` | 7 | Persist collapsed rows + zoom + outlineWidth to `localStorage`, namespaced per timeline (`portfolio` vs `proj:<id>`); flipped state from `expanded` → `collapsed` so new rows auto-expand for free |
| 2 | `fdf0c07` | 8 | `/v1/projects/:id/timeline` returns its own `project + categories + tasks.categoryId`; ProjectGanttClient reads that first, org-cache fallback kept for deploy-window compat |
| — | `ed87ecf` | — | Test sheet (`docs/timeline-bug-bash-2026-04-20.md`) — 408 lines, structured walkthrough |
| 3 | `10342ae` | — | **Schema-drift fix:** append `tasks.category_id` ALTER TABLE to `schema.sql` (migration file was never merged into the runner's source-of-truth). Unblocks the PATCH exposed by the Bug 1 fix. |

### New issue surfaced and fixed (Slice 3)

Playwright testing on the `ailarry-*` preview (not `larry-site-*` — that preview has no env vars and 503s on login; see "Gotchas" below) confirmed **Bugs 1, 2, 7 fully end-to-end**, but Bug 1's PATCH returned opaque 500 from Railway. Turns out commit `c71754c` added `migrations/031_task_category_id.sql` but **never merged the DDL into `schema.sql` — which is what `packages/db/src/migrate.ts` actually runs**. So `tasks.category_id` column doesn't exist in any deployed tenant. The UPDATE failed with "column does not exist" and Fastify's catch-all hid the message. The migration file also FK-referenced a non-existent `categories` table instead of `project_categories` — a red herring at runtime but misleading for readers.

Slice 3 (`10342ae`) appends the correct DDL to `schema.sql` (`ADD COLUMN IF NOT EXISTS`, FK → `project_categories`, partial index `WHERE NOT NULL`) and fixes the standalone migration file for historical clarity. After this deploys, the DnD case completes with 200 instead of 500.

### Testing

- [x] `tsc --noEmit` clean on `apps/web` and `apps/api` (pre-existing `route.test.ts` / missing `mammoth` warnings unchanged)
- [x] `vitest run src/components/workspace/gantt/` — **75 passing** (6 new regression tests added across Slices 1 + 2)
- [x] `npm run build -w @larry/shared` clean
- [x] `npm run build -w @larry/api` clean
- [x] End-to-end verification on `ailarry-git-fix-timeline-slice-1-dnd-h-5c9231-loouuiis-projects.vercel.app` preview:
  - [x] **Bug 2** — hovered a task row, clicked Add item → "New subtask" modal opened directly, picker skipped (`preview-bug2-hover-task-add.png`)
  - [x] **Bug 7** — `larry:gantt:portfolio:{zoom,outline,collapsed}` keys exist; Q zoom survives hard refresh
  - [x] **Bug 1** — PATCH with `{"categoryId":"..."}` fires with correct payload, dnd-kit accessibility status confirms drop recognised (the 500 seen in testing is now patched by Slice 3)
- [ ] Full manual walkthrough using `docs/timeline-bug-bash-2026-04-20.md` against the `ailarry` preview OR prod post-merge. Cases 3 + 4 + 9 need someone to type in the modal; 5 + 6 need human eye on perf/paint; 8 needs the schema+API to deploy.

### Gotchas

- **Use the `ailarry-git-*` preview URL, not `larry-site-git-*`.** The `larry-site` Vercel project has zero env vars in preview scope — its preview 503s on `/api/auth/login`. The `ailarry` project is the one whose production is `www.larry-pm.com` and it has full env-var coverage.
- **Slice 3 needs the migration to run on Railway.** Vercel deploys web; Railway deploys API + runs schema migration. Until Slice 3 rides a Railway deploy, the `tasks.category_id` column is still missing and Bug 1's PATCH will still 500.
- **Post-merge on master, test the full sheet on `larry-pm.com`** (env vars guaranteed, migration applied).

### Files changed

```
apps/api/src/routes/v1/projects.ts                               | +50
apps/web/src/app/dashboard/types.ts                              | +13
apps/web/src/app/workspace/timeline/PortfolioGanttClient.tsx     | +111
apps/web/src/components/workspace/gantt/GanttContainer.tsx       | +70
apps/web/src/components/workspace/gantt/GanttRow.tsx             | +3
apps/web/src/components/workspace/gantt/ProjectGanttClient.tsx   | +32
apps/web/src/components/workspace/gantt/gantt-types.ts           | +4
apps/web/src/components/workspace/gantt/gantt-utils.ts           | +60
apps/web/src/components/workspace/gantt/gantt-utils.test.ts      | +86
docs/timeline-bug-bash-2026-04-20.md                             | +408 (new)
packages/db/src/migrations/031_task_category_id.sql              | +7 / -1
packages/db/src/schema.sql                                       | +17
```

### Follow-ups deferred

- Virtualization for > 200-row timelines (react-window) — biggest remaining perf win, separate PR
- Right-click context menu "Add subtask" on task/subtask rows — UX polish, currently only reachable via hover → Add item
- Cleaner server-side validation: reject `PATCH /v1/tasks/:id` with a `categoryId` that doesn't belong to the task's project (FK prevents invalid UUIDs; semantic validation is a nice-to-have on top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)