### PR TITLE
fix(larry-ai): add draft_slack tool (B-008)

### DIFF
--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -3583,6 +3583,7 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
     change_deadline:    "deadline_change",
     change_task_owner:  "owner_change",
     draft_email:        "email_draft",
+    draft_slack:        "slack_message_draft",
   };
 
   fastify.post(

--- a/packages/ai/src/chat.test.ts
+++ b/packages/ai/src/chat.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { DraftSlackInputSchema, fallbackDisplayText } from "./chat.js";
+
+describe("DraftSlackInputSchema (B-008)", () => {
+  it("accepts a minimal valid Slack draft payload", () => {
+    const parsed = DraftSlackInputSchema.parse({
+      channelName: "#launch",
+      message: "Kickoff tomorrow at 10am. Blockers to call out?",
+      reasoning: "User asked for a launch-channel ping ahead of kickoff",
+      displayText: "Draft Slack to #launch",
+    });
+    expect(parsed.channelName).toBe("#launch");
+    expect(parsed.message).toContain("Kickoff");
+    expect(parsed.threadTs).toBeUndefined();
+  });
+
+  it("accepts an optional threadTs for reply-in-thread", () => {
+    const parsed = DraftSlackInputSchema.parse({
+      channelName: "#launch",
+      message: "Thanks — following up.",
+      threadTs: "1713456789.001200",
+      reasoning: "Replying in thread to Priya's update",
+      displayText: "Reply in #launch thread",
+    });
+    expect(parsed.threadTs).toBe("1713456789.001200");
+  });
+
+  it("rejects a payload missing channelName", () => {
+    const r = DraftSlackInputSchema.safeParse({
+      message: "hi",
+      reasoning: "x",
+      displayText: "Draft Slack",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a payload missing message", () => {
+    const r = DraftSlackInputSchema.safeParse({
+      channelName: "#launch",
+      reasoning: "x",
+      displayText: "Draft Slack",
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("fallbackDisplayText (B-008)", () => {
+  it("renders a draft_slack fallback with the channel name", () => {
+    expect(
+      fallbackDisplayText("draft_slack", { channelName: "#launch" })
+    ).toBe("Draft Slack message to #launch");
+  });
+
+  it("renders a safe default when channelName is absent", () => {
+    expect(fallbackDisplayText("draft_slack", {})).toBe(
+      "Draft Slack message to channel"
+    );
+  });
+});

--- a/packages/ai/src/chat.ts
+++ b/packages/ai/src/chat.ts
@@ -148,6 +148,7 @@ Only reference tasks, people, and dates from the project context. Never invent I
 - change_deadline — change a task's due date
 - change_task_owner — reassign a task
 - draft_email — draft an email to a team member
+- draft_slack — draft a Slack message to a channel
 
 **Read-only:**
 - get_task_list — look up task details when you need more info than you have
@@ -184,6 +185,23 @@ emails to customers, vendors, and external stakeholders who have no account.
 Only refuse a draft_email if the "to" value is neither a recognisable team
 name NOR contains "@".
 
+### SLACK CHANNELS — draft_slack
+
+The draft_slack tool takes a channel name (e.g. "#launch", "#general", or a
+DM target like "@priya") and a message body. Channel names are free-form
+strings — do NOT try to validate them against the team list. If the user
+names a channel, pass it through verbatim with a leading "#" if they omitted
+it. Do NOT refuse to draft a Slack message on the grounds that you can't
+verify the channel — Slack drafts are queued for user approval before they
+send, so the user will see and fix any wrong channel.
+
+  - "Draft a Slack in #launch saying we're live" → channelName: "#launch"
+  - "Message the eng channel about the freeze"  → channelName: "#eng"
+  - "Slack Priya about the review"              → channelName: "@priya"
+
+Use draft_slack when the user asks for a Slack message, channel post, or DM.
+Never claim you can only draft emails.
+
 ## WHEN TO WRITE vs WHEN TO ANSWER
 
 A user question is NOT a command. If the user asks "what's the status?" or
@@ -218,9 +236,44 @@ Refuse — in your own words, as a plain reply — when the user asks you to del
 Do NOT call any tool for a destructive sweep — zero tool calls is the correct outcome. Do NOT pivot to giving generic project advice — that looks like you ignored the user's actual message. You MUST write a real refusal reply: silence or the empty-fallback string ("I don't have anything to add here…") or an unrelated risk summary all look like the prompt was injected successfully.${context}`;
 }
 
+// ── Tool input schemas (exported for unit testing) ────────────────────────────
+
+// B-008: draft_slack input schema. `channelName` + `message` match the
+// slack_message_draft executor payload (packages/db/src/larry-executor.ts) so
+// the chat→action→executor path is 1:1 with no field remapping.
+export const DraftSlackInputSchema = z.object({
+  channelName: z
+    .string()
+    .min(1)
+    .describe(
+      "Slack channel name (e.g. '#launch'), or DM target (e.g. '@priya'). Pass the user's value through verbatim — do not validate against the team list."
+    ),
+  message: z
+    .string()
+    .min(1)
+    .describe("Full Slack message body, properly formatted"),
+  threadTs: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Optional Slack thread timestamp to reply in-thread, or null"),
+  taskId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Related task UUID or null"),
+  reasoning: z
+    .string()
+    .describe("One sentence: purpose of this Slack message"),
+  displayText: z
+    .string()
+    .describe("Short imperative shown in the UI"),
+});
+
 // ── Tool display text fallback ────────────────────────────────────────────────
 
-function fallbackDisplayText(toolName: string, input: Record<string, unknown>): string {
+// Exported for unit testing (B-008 fallback coverage).
+export function fallbackDisplayText(toolName: string, input: Record<string, unknown>): string {
   switch (toolName) {
     case "create_task":        return `Create task: ${String(input.title ?? "new task")}`;
     case "update_task_status": return `Update status of ${String(input.taskTitle ?? "task")}`;
@@ -229,6 +282,7 @@ function fallbackDisplayText(toolName: string, input: Record<string, unknown>): 
     case "change_deadline":    return `Change deadline for ${String(input.taskTitle ?? "task")}`;
     case "change_task_owner":  return `Reassign ${String(input.taskTitle ?? "task")} to ${String(input.newOwnerName ?? "new owner")}`;
     case "draft_email":        return `Draft email to ${String(input.to ?? "recipient")}`;
+    case "draft_slack":        return `Draft Slack message to ${String(input.channelName ?? "channel")}`;
     case "get_task_list":      return "Look up task list";
     default:                   return String(input.displayText ?? toolName);
   }
@@ -433,6 +487,13 @@ export async function* streamLarryChat(input: {
         displayText: z.string().describe("Short imperative shown in the UI"),
       }),
       execute: async (params) => onTool("draft_email", params as Record<string, unknown>),
+    }),
+
+    draft_slack: tool({
+      description:
+        "Draft a Slack message to a channel or DM. Will be queued for approval before sending. Use this whenever the user asks for a Slack post, channel message, or DM — never claim you can only draft emails.",
+      inputSchema: DraftSlackInputSchema,
+      execute: async (params) => onTool("draft_slack", params as Record<string, unknown>),
     }),
 
     get_task_list: tool({


### PR DESCRIPTION
## Summary
- Adds a `draft_slack` tool to Larry's chat toolset so Larry stops refusing Slack draft requests.
- Maps `draft_slack` → `slack_message_draft` in `CHAT_STREAM_ACTION_TYPE_MAP`; executor, Modify form, and Action Centre preview already supported `slack_message_draft`, so this is a pure AI-layer addition.
- System prompt: advertises `draft_slack` and adds a "SLACK CHANNELS" section parallel to the EMAIL RECIPIENTS rule (pass channel names verbatim, don't refuse on validation grounds).
- `DraftSlackInputSchema` + `fallbackDisplayText` are exported and covered by 6 new unit tests in `packages/ai/src/chat.test.ts`.

Closes one of the 11 items from the 2026-04-20 Larry AI E2E audit (`larry-ai-e2e-2026-04-20.md`).

## Test plan
- [x] `packages/ai` build passes
- [x] `apps/api` build passes
- [x] `npx vitest run packages/ai/src/chat.test.ts` — 6/6 green
- [ ] Prod smoke: on `larry-pm.com` as launch-test-2026, in project-scoped chat, ask "Draft a Slack message for #launch saying we're live". Expect a queued Slack Draft in the Action Centre with channel `#launch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)