### PR TITLE
fix(web/api): harden Task Center against sub-request 500s (B-006)

### DIFF
--- a/apps/api/src/routes/v1/reporting.ts
+++ b/apps/api/src/routes/v1/reporting.ts
@@ -104,7 +104,11 @@ export const reportingRoutes: FastifyPluginAsync = async (fastify) => {
         generatedAt: new Date().toISOString(),
       };
 
-      await insertProjectRiskSnapshotOncePerDay(fastify, tenantId, params.id, avgRiskScore, riskLevel);
+      try {
+        await insertProjectRiskSnapshotOncePerDay(fastify, tenantId, params.id, avgRiskScore, riskLevel);
+      } catch (err) {
+        fastify.log.warn({ err, projectId: params.id }, "failed to write risk snapshot");
+      }
 
       return response;
     }
@@ -194,14 +198,18 @@ export const reportingRoutes: FastifyPluginAsync = async (fastify) => {
         })(),
       };
 
-      await insertReportSnapshotOncePerDay(
-        fastify,
-        tenantId,
-        params.id,
-        "outcomes",
-        outcome as Record<string, unknown>,
-        request.user.userId
-      );
+      try {
+        await insertReportSnapshotOncePerDay(
+          fastify,
+          tenantId,
+          params.id,
+          "outcomes",
+          outcome as Record<string, unknown>,
+          request.user.userId
+        );
+      } catch (err) {
+        fastify.log.warn({ err, projectId: params.id }, "failed to write outcomes snapshot");
+      }
 
       return outcome;
     }
@@ -259,14 +267,18 @@ export const reportingRoutes: FastifyPluginAsync = async (fastify) => {
         narrative: `Updated ${updatedThisWeek.length} tasks this week. ${highRisk.length} tasks are currently high risk and need intervention.`,
       };
 
-      await insertReportSnapshotOncePerDay(
-        fastify,
-        tenantId,
-        params.id,
-        "weekly_summary",
-        summary as Record<string, unknown>,
-        request.user.userId
-      );
+      try {
+        await insertReportSnapshotOncePerDay(
+          fastify,
+          tenantId,
+          params.id,
+          "weekly_summary",
+          summary as Record<string, unknown>,
+          request.user.userId
+        );
+      } catch (err) {
+        fastify.log.warn({ err, projectId: params.id }, "failed to write weekly summary snapshot");
+      }
 
       return summary;
     }

--- a/apps/web/src/app/api/workspace/projects/[id]/overview/route.test.ts
+++ b/apps/web/src/app/api/workspace/projects/[id]/overview/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock session + proxy before importing the route.
+vi.mock("@/lib/auth", () => ({
+  getSession: vi.fn(async () => ({ userId: "u1", tenantId: "t1", role: "member" })),
+}));
+
+const mockProxy = vi.fn();
+vi.mock("@/lib/workspace-proxy", () => ({
+  proxyApiRequest: (...args: unknown[]) => mockProxy(...args),
+  persistSession: vi.fn(async () => {}),
+}));
+
+import { GET } from "./route";
+
+const PROJECT_ID = "fe0afe7a-cacc-43c4-bdd9-7f7105a054a3";
+
+function ok<T>(body: T, status = 200) {
+  return { status, body };
+}
+
+function okProjectList() {
+  return ok({ items: [{ id: PROJECT_ID, name: "Modify Test" }] });
+}
+
+function makeReq() {
+  return new Request(`http://localhost/api/workspace/projects/${PROJECT_ID}/overview`);
+}
+
+function ctx() {
+  return { params: Promise.resolve({ id: PROJECT_ID }) };
+}
+
+describe("GET /api/workspace/projects/:id/overview — B-006 hardening", () => {
+  beforeEach(() => {
+    mockProxy.mockReset();
+  });
+
+  it("returns project with empty tasks and no error when tasks endpoint 500s", async () => {
+    mockProxy.mockImplementation((_session, path: string) => {
+      if (path === "/v1/projects?status=all") return okProjectList();
+      if (path.startsWith("/v1/tasks")) return ok({ error: "Internal Server Error", message: "An unexpected error occurred." }, 500);
+      if (path.endsWith("/timeline")) return ok({ tasks: [], dependencies: [] });
+      if (path.endsWith("/health")) return ok({});
+      if (path.endsWith("/outcomes")) return ok({});
+      if (path.startsWith("/v1/meetings")) return ok({ items: [] });
+      throw new Error(`unexpected proxy call: ${path}`);
+    });
+
+    const res = await GET(makeReq(), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.project).toBeTruthy();
+    expect(body.project.id).toBe(PROJECT_ID);
+    expect(body.tasks).toEqual([]);
+    expect(body.error).toBeUndefined();
+  });
+
+  it("still returns non-blocking response when health/outcomes/meetings 500", async () => {
+    mockProxy.mockImplementation((_session, path: string) => {
+      if (path === "/v1/projects?status=all") return okProjectList();
+      if (path.startsWith("/v1/tasks")) return ok({ items: [{ id: "t1", title: "Task" }] });
+      if (path.endsWith("/timeline")) return ok({ items: [] }, 500);
+      if (path.endsWith("/health")) return ok({ error: "boom" }, 500);
+      if (path.endsWith("/outcomes")) return ok({ error: "boom" }, 500);
+      if (path.startsWith("/v1/meetings")) return ok({ error: "boom" }, 500);
+      throw new Error(`unexpected proxy call: ${path}`);
+    });
+
+    const res = await GET(makeReq(), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tasks).toHaveLength(1);
+    expect(body.timeline).toBeNull();
+    expect(body.health).toBeNull();
+    expect(body.outcomes).toBeNull();
+    expect(body.meetings).toEqual([]);
+    expect(body.error).toBeUndefined();
+  });
+
+  it("surfaces a fatal error only when the projects endpoint itself fails", async () => {
+    mockProxy.mockImplementation((_session, path: string) => {
+      if (path === "/v1/projects?status=all") return ok({ error: "Unauthorized" }, 401);
+      return ok({});
+    });
+
+    const res = await GET(makeReq(), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.project).toBeNull();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 404 when the project id is not in the list", async () => {
+    mockProxy.mockImplementation((_session, path: string) => {
+      if (path === "/v1/projects?status=all") return ok({ items: [{ id: "different-id" }] });
+      return ok({ items: [] });
+    });
+
+    const res = await GET(makeReq(), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("Project not found.");
+  });
+});

--- a/apps/web/src/app/api/workspace/projects/[id]/overview/route.ts
+++ b/apps/web/src/app/api/workspace/projects/[id]/overview/route.ts
@@ -94,17 +94,19 @@ export async function GET(
     );
   }
 
-  const error = tasksResult.status >= 500
-    ? extractError(tasksResult.body) ?? "Failed to load project tasks."
-    : undefined;
-
+  // Sub-request failures (tasks, timeline, health, outcomes, meetings) degrade
+  // silently so the project page still renders. Previously a 500 from tasks
+  // (or any endpoint that raised an unhandled error) would set a blocking
+  // `error` field, crashing the whole workspace — including Task Center on
+  // projects where tasks themselves were fine. Fatal errors (project not
+  // found / unauthorized) are handled above and still short-circuit.
   return NextResponse.json({
     project,
-    tasks: extractItems<WorkspaceTask>(tasksResult.body),
+    tasks: tasksResult.status < 400 ? extractItems<WorkspaceTask>(tasksResult.body) : [],
     timeline: timelineResult.status < 400 ? extractObject<WorkspaceTimeline>(timelineResult.body) : null,
     health: healthResult.status < 400 ? extractObject<WorkspaceHealth>(healthResult.body) : null,
     outcomes: outcomesResult.status < 400 ? extractObject<WorkspaceOutcomes>(outcomesResult.body) : null,
-    meetings: extractItems<WorkspaceMeeting>(meetingsResult.body),
-    error,
+    meetings: meetingsResult.status < 400 ? extractItems<WorkspaceMeeting>(meetingsResult.body) : [],
+    error: undefined,
   });
 }


### PR DESCRIPTION
## Summary

Closes B-006 from the 2026-04-20 AI E2E audit: the Task Center tab crashed with a generic "An unexpected error occurred" on projects that had pending actions.

## Root cause

The Next.js overview route (`/api/workspace/projects/:id/overview`) fans six requests out to the Fastify API in parallel: `projects`, `tasks`, `timeline`, `health`, `outcomes`, `meetings`. It was only tolerant of failure on four of them (timeline, health, outcomes, meetings). A tasks sub-request returning `>= 500` set a blocking top-level `error` field, which `PageState` read and rendered as a full-tab error panel — hiding the Task Center entirely.

On the API side, the `health` and `outcomes` routes both call `insertProjectRiskSnapshotOncePerDay` / `insertReportSnapshotOncePerDay` after returning their computed payload. Any snapshot INSERT failure (unique-constraint race, transient DB error, etc.) escalated to the Fastify 500 handler and produced the exact "An unexpected error occurred" string the user saw.

## Changes

- `apps/web/.../overview/route.ts` — sub-request failures now degrade silently to empty/null. Only project-level fatal errors (not found / unauthorized) still short-circuit with a blocking `error`.
- `apps/api/.../reporting.ts` — wrap risk + report snapshot writes in `try/catch` at three call sites (`/health`, `/outcomes`, `/weekly-summary`). Warn-level log keeps failures observable.
- `apps/web/.../overview/route.test.ts` — new regression tests covering tasks-500, non-tasks-500, projects 401, and project-not-found.

## Test plan

- [x] `npx vitest run src/app/api/workspace/projects/[id]/overview/route.test.ts` — 4/4 pass
- [ ] Deploy to prod, load `/workspace/projects/fe0afe7a-cacc-43c4-bdd9-7f7105a054a3`, click Task center tab — should render empty/populated list instead of the error panel
- [ ] Confirm existing project workspaces still load normally (baseline regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)