### PR TITLE
fix(action-centre): B-003/B-004/B-005 structured cards, labels, fresh summary

### DIFF
--- a/apps/api/src/lib/larry-ledger.ts
+++ b/apps/api/src/lib/larry-ledger.ts
@@ -70,6 +70,9 @@ const EVENT_SUMMARY_SELECT = `
          e.execution_mode AS "executionMode",
          e.source_kind AS "sourceKind",
          e.source_record_id AS "sourceRecordId",
+         e.modified_at AS "modifiedAt",
+         e.modified_by_user_id AS "modifiedByUserId",
+         COALESCE(NULLIF(modified.display_name, ''), SPLIT_PART(modified.email, '@', 1)) AS "modifiedByName",
          c.title AS "conversationTitle",
          LEFT(request_message.content, 160) AS "requestMessagePreview",
          LEFT(response_message.content, 160) AS "responseMessagePreview"
@@ -93,7 +96,9 @@ const EVENT_SUMMARY_SELECT = `
     LEFT JOIN users dismissed
       ON dismissed.id = e.dismissed_by_user_id
     LEFT JOIN users executor
-      ON executor.id = e.executed_by_user_id`;
+      ON executor.id = e.executed_by_user_id
+    LEFT JOIN users modified
+      ON modified.id = e.modified_by_user_id`;
 
 export async function listLarryConversationPreviews(
   db: Db,

--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -445,6 +445,83 @@ function isCalendarActionType(
   return actionType === "calendar_event_create" || actionType === "calendar_event_update";
 }
 
+/**
+ * Regenerate the short imperative that renders as the action card header when
+ * a user modifies a pending suggestion (B-005). The shape mirrors the
+ * `displayText` strings Larry emits at suggestion time in
+ * `packages/ai/src/chat.ts` so completed cards read consistently regardless
+ * of whether the user accepted as-is or modified first.
+ *
+ * Falls back to the prior displayText for action types we don't synthesise
+ * here — losing accuracy on those is less harmful than a blank header.
+ */
+function rebuildDisplayText(
+  actionType: string,
+  payload: Record<string, unknown>,
+  fallback: string,
+): string {
+  const str = (key: string): string | null => {
+    const v = payload[key];
+    return typeof v === "string" && v.trim() !== "" ? v.trim() : null;
+  };
+  switch (actionType) {
+    case "task_create": {
+      const title = str("title");
+      return title ? `Create task: ${title}` : fallback;
+    }
+    case "email_draft": {
+      const subject = str("subject");
+      const to = str("to");
+      if (subject && to) return `Email ${to}: ${subject}`;
+      if (subject) return `Email: ${subject}`;
+      if (to) return `Email ${to}`;
+      return fallback;
+    }
+    case "slack_message_draft": {
+      const channel = str("channelName");
+      return channel ? `Slack ${channel}` : fallback;
+    }
+    case "deadline_change": {
+      const task = str("taskTitle");
+      const when = str("newDeadline");
+      if (task && when) return `Move "${task}" deadline to ${when}`;
+      return fallback;
+    }
+    case "owner_change": {
+      const task = str("taskTitle");
+      const owner = str("newOwnerName");
+      if (task && owner) return `Reassign "${task}" to ${owner}`;
+      if (task) return `Unassign "${task}"`;
+      return fallback;
+    }
+    case "status_update": {
+      const task = str("taskTitle");
+      const status = str("newStatus");
+      if (task && status) return `Set "${task}" to ${status}`;
+      return fallback;
+    }
+    case "risk_flag": {
+      const task = str("taskTitle");
+      const level = str("riskLevel");
+      if (task && level) return `Flag "${task}" risk as ${level}`;
+      return fallback;
+    }
+    case "scope_change": {
+      const task = str("taskTitle");
+      return task ? `Update scope of "${task}"` : fallback;
+    }
+    case "project_create": {
+      const name = str("name");
+      return name ? `Create project: ${name}` : fallback;
+    }
+    case "project_note_send": {
+      return "Send project note";
+    }
+    default:
+      return fallback;
+  }
+}
+
 export const larryRoutes: FastifyPluginAsync = async (fastify) => {
   async function assertProjectAccessOrThrow(input: {
     tenantId: string;
@@ -2092,6 +2169,16 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
         payloadPatch
       );
 
+      // B-005: regenerate displayText from the modified payload so completed
+      // cards reflect what was actually executed, not Larry's pre-modify
+      // "Create task: <old title>" line. Falls back to the original displayText
+      // when the payload doesn't drive a synthesisable header.
+      const nextDisplayText = rebuildDisplayText(
+        event.actionType,
+        nextPayload,
+        event.displayText,
+      );
+
       // Persist the edit first. If the user is only saving (not executing), we're done.
       // If they're also executing, we run the executor; on executor failure we intentionally
       // leave the edited payload in place so the user can retry Accept without re-editing.
@@ -2100,13 +2187,14 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
         `UPDATE larry_events
             SET previous_payload    = COALESCE(previous_payload, payload),
                 payload             = $3::jsonb,
+                display_text        = $5,
                 modified_by_user_id = $4,
                 modified_at         = NOW()
           WHERE tenant_id = $1
             AND id        = $2
             AND event_type = 'suggested'
         RETURNING id`,
-        [tenantId, id, JSON.stringify(nextPayload), actorUserId]
+        [tenantId, id, JSON.stringify(nextPayload), actorUserId, nextDisplayText]
       );
       if (updatedRows.length === 0) {
         // Lost the race — another tab resolved the event between our fetch and UPDATE.
@@ -2135,7 +2223,7 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       // Execute the edited action. Retry-with-resolution mirrors the /accept handler
       // for the common hallucinated/stale taskId case; calendar and slack actions
       // are not modifiable per the spec, so this simpler path is sufficient.
-      const executePayload = { ...nextPayload, displayText: event.displayText };
+      const executePayload = { ...nextPayload, displayText: nextDisplayText };
       let entity: unknown;
       try {
         entity = await executeAction(

--- a/apps/api/src/routes/v1/tasks.ts
+++ b/apps/api/src/routes/v1/tasks.ts
@@ -79,6 +79,7 @@ export const taskRoutes: FastifyPluginAsync = async (fastify) => {
                         tasks.start_date::text as "startDate",
                         tasks.due_date::text as "dueDate",
                         tasks.category_id as "categoryId",
+                        tasks.labels as "labels",
                         tasks.created_at as "createdAt",
                         tasks.updated_at as "updatedAt"
                  FROM tasks

--- a/apps/web/src/app/dashboard/types.ts
+++ b/apps/web/src/app/dashboard/types.ts
@@ -77,6 +77,7 @@ export interface WorkspaceTask {
   assigneeName?: string | null;
   progressPercent?: number;
   riskLevel?: string;
+  labels?: string[];
   updatedAt?: string | null;
 }
 
@@ -318,6 +319,9 @@ export interface WorkspaceLarryEvent {
   conversationTitle?: string | null;
   requestMessagePreview?: string | null;
   responseMessagePreview?: string | null;
+  modifiedAt?: string | null;
+  modifiedByUserId?: string | null;
+  modifiedByName?: string | null;
 }
 
 export interface WorkspaceConversationPreview {

--- a/apps/web/src/app/workspace/ModifyPanelFields.tsx
+++ b/apps/web/src/app/workspace/ModifyPanelFields.tsx
@@ -21,6 +21,74 @@ function str(v: unknown): string {
   return typeof v === "string" ? v : "";
 }
 
+function toLabels(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string" && x.trim() !== "");
+}
+
+function LabelsInput({
+  value,
+  onChange,
+}: {
+  value: string[];
+  onChange: (labels: string[]) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="flex flex-wrap gap-1.5">
+        {value.length === 0 ? (
+          <span className="text-xs text-neutral-400">No labels yet</span>
+        ) : (
+          value.map((label, i) => (
+            <span
+              key={`${label}-${i}`}
+              className="inline-flex items-center gap-1 rounded-full border border-neutral-300 bg-neutral-50 px-2 py-0.5 text-xs text-neutral-700"
+            >
+              {label}
+              <button
+                type="button"
+                aria-label={`Remove label ${label}`}
+                onClick={() => onChange(value.filter((_, idx) => idx !== i))}
+                className="text-neutral-400 hover:text-neutral-600"
+              >
+                ×
+              </button>
+            </span>
+          ))
+        )}
+      </div>
+      <input
+        type="text"
+        placeholder="Add a label and press Enter"
+        className={INPUT_CLASS}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter" && e.key !== ",") return;
+          e.preventDefault();
+          const input = e.currentTarget;
+          const next = input.value.trim();
+          if (!next) return;
+          if (value.some((x) => x.toLowerCase() === next.toLowerCase())) {
+            input.value = "";
+            return;
+          }
+          onChange([...value, next]);
+          input.value = "";
+        }}
+        onBlur={(e) => {
+          const next = e.currentTarget.value.trim();
+          if (!next) return;
+          if (value.some((x) => x.toLowerCase() === next.toLowerCase())) {
+            e.currentTarget.value = "";
+            return;
+          }
+          onChange([...value, next]);
+          e.currentTarget.value = "";
+        }}
+      />
+    </div>
+  );
+}
+
 function TeamSelect({
   value,
   onChange,
@@ -112,6 +180,13 @@ function CreateTaskFields({ snapshot, payload, onPatch }: FieldsProps) {
             placeholder="(unassigned)"
           />
         </label>
+      </div>
+      <div className={LABEL_CLASS}>
+        <span className={SPAN_CLASS}>Labels</span>
+        <LabelsInput
+          value={toLabels(payload.labels)}
+          onChange={(labels) => onPatch({ labels })}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/app/workspace/actions/page.tsx
+++ b/apps/web/src/app/workspace/actions/page.tsx
@@ -780,6 +780,7 @@ export default function WorkspaceActionsPage() {
               ) : (
                 filteredActivity.map((event) => {
                   const completedByLarry = event.executedByKind === "larry" && event.payload?._selfExecutable === true;
+                  const wasModified = Boolean(event.modifiedAt);
                   return (
                   <div
                     key={event.id}
@@ -810,6 +811,15 @@ export default function WorkspaceActionsPage() {
                               Completed by Larry
                             </span>
                           )}
+                          {wasModified && (
+                            <span
+                              className="inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold"
+                              style={{ background: "#fef3c7", color: "#92400e", borderColor: "#fde68a" }}
+                              title={event.modifiedByName ? `Modified by ${event.modifiedByName}` : "Modified before execution"}
+                            >
+                              Modified
+                            </span>
+                          )}
                         </div>
                         <p className="mt-3 text-[14px] font-semibold" style={{ color: "var(--text-1)" }}>
                           {event.displayText}
@@ -818,7 +828,10 @@ export default function WorkspaceActionsPage() {
                         <p className="mt-1 text-[12px]" style={{ color: "var(--text-muted)" }}>
                           {getEventMeta(event)} | {formatRelativeTime(event.executedAt ?? event.createdAt)}
                         </p>
-                        {event.responseMessagePreview && (
+                        {/* Hide Larry's pre-modify chat summary on modified events
+                            — B-005: the summary was generated against the original
+                            payload and misrepresents what was actually executed. */}
+                        {event.responseMessagePreview && !wasModified && (
                           <p className="mt-2 line-clamp-2 text-[12px] leading-5" style={{ color: "var(--text-2)" }}>
                             {event.responseMessagePreview}
                           </p>

--- a/apps/web/src/components/workspace/ActionDetailPreview.tsx
+++ b/apps/web/src/components/workspace/ActionDetailPreview.tsx
@@ -9,6 +9,7 @@ import { TimelineSuggestionPreview } from "./TimelineSuggestionPreview";
  * Collapsible action detail preview.
  * Shows a 1-2 line description that expands on click to reveal:
  * - Full description text
+ * - For task_create: structured key/value panel (priority, dates, assignee, labels)
  * - For email_draft: To, Subject, and Body
  * - For slack_message_draft: Channel and Message
  * - For project_note_send: Note content
@@ -26,11 +27,20 @@ export function ActionDetailPreview({ event }: { event: WorkspaceLarryEvent }) {
   const isEmailDraft = event.actionType === "email_draft";
   const isSlackDraft = event.actionType === "slack_message_draft";
   const isProjectNote = event.actionType === "project_note_send";
-  const hasContent = isEmailDraft || isSlackDraft || isProjectNote;
+  const isTaskCreate = event.actionType === "task_create";
+  const hasContent = isEmailDraft || isSlackDraft || isProjectNote || isTaskCreate;
 
   if (!description && !hasContent) return null;
 
-  const previewText = description
+  // For task_create cards, favour the structured key/value summary as the
+  // preview line rather than a truncated description. Reviewers need to see
+  // priority, dates, and assignee at a glance without having to expand.
+  // (B-003.)
+  const taskCreatePreviewLine = isTaskCreate ? buildTaskCreateSummary(payload) : null;
+
+  const previewText = taskCreatePreviewLine
+    ? taskCreatePreviewLine
+    : description
     ? description.length > 140
       ? description.slice(0, 140) + "..."
       : description
@@ -120,6 +130,81 @@ export function ActionDetailPreview({ event }: { event: WorkspaceLarryEvent }) {
               {typeof payload.content === "string" ? payload.content : "No content"}
             </div>
           )}
+          {isTaskCreate && <TaskCreateDetail payload={payload} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildTaskCreateSummary(payload: Record<string, unknown>): string | null {
+  const bits: string[] = [];
+  const priority = typeof payload.priority === "string" ? payload.priority : null;
+  if (priority) bits.push(`${priority} priority`);
+  if (typeof payload.dueDate === "string" && payload.dueDate) bits.push(`due ${payload.dueDate}`);
+  else if (typeof payload.startDate === "string" && payload.startDate) bits.push(`starts ${payload.startDate}`);
+  const assignee = typeof payload.assigneeName === "string" && payload.assigneeName.trim()
+    ? payload.assigneeName.trim()
+    : null;
+  if (assignee) bits.push(`→ ${assignee}`);
+  else bits.push("→ unassigned");
+  const labels = Array.isArray(payload.labels)
+    ? payload.labels.filter((x): x is string => typeof x === "string" && x.trim() !== "")
+    : [];
+  if (labels.length > 0) bits.push(`labels: ${labels.join(", ")}`);
+  return bits.length > 0 ? bits.join(" · ") : null;
+}
+
+function TaskCreateDetail({ payload }: { payload: Record<string, unknown> }) {
+  const priority = typeof payload.priority === "string" ? payload.priority : "medium";
+  const startDate = typeof payload.startDate === "string" && payload.startDate ? payload.startDate : "—";
+  const dueDate = typeof payload.dueDate === "string" && payload.dueDate ? payload.dueDate : "—";
+  const assignee = typeof payload.assigneeName === "string" && payload.assigneeName.trim()
+    ? payload.assigneeName.trim()
+    : "(unassigned)";
+  const labels = Array.isArray(payload.labels)
+    ? payload.labels.filter((x): x is string => typeof x === "string" && x.trim() !== "")
+    : [];
+  const description = typeof payload.description === "string" && payload.description.trim()
+    ? payload.description.trim()
+    : null;
+
+  return (
+    <div className="space-y-2">
+      <dl className="grid grid-cols-[88px_1fr] gap-x-3 gap-y-1 text-[11px]" style={{ color: "var(--text-muted)" }}>
+        <dt className="font-semibold">Priority</dt>
+        <dd style={{ color: "var(--text-1)" }}>{priority}</dd>
+        <dt className="font-semibold">Start</dt>
+        <dd style={{ color: "var(--text-1)" }}>{startDate}</dd>
+        <dt className="font-semibold">Due</dt>
+        <dd style={{ color: "var(--text-1)" }}>{dueDate}</dd>
+        <dt className="font-semibold">Assignee</dt>
+        <dd style={{ color: "var(--text-1)" }}>{assignee}</dd>
+        <dt className="font-semibold">Labels</dt>
+        <dd style={{ color: "var(--text-1)" }}>
+          {labels.length === 0 ? (
+            <span style={{ color: "var(--text-muted)" }}>—</span>
+          ) : (
+            <span className="flex flex-wrap gap-1">
+              {labels.map((label) => (
+                <span
+                  key={label}
+                  className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium"
+                  style={{ borderColor: "var(--border)", background: "var(--surface-2)", color: "var(--text-2)" }}
+                >
+                  {label}
+                </span>
+              ))}
+            </span>
+          )}
+        </dd>
+      </dl>
+      {description && (
+        <div
+          className="border-t pt-2 text-[12px] leading-5"
+          style={{ borderColor: "var(--border)", color: "var(--text-1)", whiteSpace: "pre-wrap" }}
+        >
+          {description}
         </div>
       )}
     </div>

--- a/packages/ai/src/chat.ts
+++ b/packages/ai/src/chat.ts
@@ -352,6 +352,7 @@ export async function* streamLarryChat(input: {
         dueDate: z.string().nullable().optional().describe("Due date in YYYY-MM-DD format or null"),
         assigneeName: z.string().nullable().optional().describe("Assignee display name or null"),
         priority: z.enum(["low", "medium", "high", "critical"]).describe("Task priority"),
+        labels: z.array(z.string()).nullable().optional().describe("Short free-form tags the user mentioned (e.g. 'qa', 'launch'). Pass [] when none were requested — never invent labels."),
         reasoning: z.string().describe("One sentence: why create this task now"),
         displayText: z.string().describe("Short imperative for the UI, e.g. 'Create task: Design login'"),
       }),

--- a/packages/db/src/larry-event-modifications.ts
+++ b/packages/db/src/larry-event-modifications.ts
@@ -22,7 +22,7 @@ export type ModifiableActionType =
   | "slack_message_draft";
 
 const FIELDS_BY_ACTION_TYPE: Record<string, readonly string[]> = {
-  task_create:              ["title", "description", "startDate", "dueDate", "assigneeName", "priority"],
+  task_create:              ["title", "description", "startDate", "dueDate", "assigneeName", "priority", "labels"],
   status_update:            ["newStatus", "newRiskLevel"],
   risk_flag:                ["riskLevel"],
   deadline_change:          ["newDeadline"],

--- a/packages/db/src/larry-executor.ts
+++ b/packages/db/src/larry-executor.ts
@@ -63,12 +63,32 @@ interface TaskCreatePayload {
   assigneeName: string | null;
   priority: "low" | "medium" | "high" | "critical";
   /**
+   * Free-form string tags applied to the task. Deduped + trimmed by the
+   * executor; never null-coerces into a literal "null" entry. See B-004.
+   */
+  labels?: string[] | null;
+  /**
    * Optional UUID of the project_memory_entries row that triggered this task.
    * When set and valid, the executor copies that entry's source_kind +
    * source_record_id onto the new task so the UI can link back to the
    * originating email/Slack thread (#92).
    */
   sourceMemoryEntryId?: string | null;
+}
+
+function normalizeLabels(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed.toLowerCase())) continue;
+    seen.add(trimmed.toLowerCase());
+    out.push(trimmed);
+  }
+  return out;
 }
 
 interface StatusUpdatePayload {
@@ -775,14 +795,16 @@ export async function executeTaskCreate(
     }
   }
 
+  const labels = normalizeLabels(payload.labels);
+
   const rows = await db.queryTenant<Record<string, unknown>>(
     tenantId,
     `INSERT INTO tasks
-       (tenant_id, project_id, title, description, status, priority, assignee_user_id, start_date, due_date, source_kind, source_record_id)
-     VALUES ($1, $2, $3, $4, 'not_started', $5, $6, $7, $8, $9, $10)
+       (tenant_id, project_id, title, description, status, priority, assignee_user_id, start_date, due_date, source_kind, source_record_id, labels)
+     VALUES ($1, $2, $3, $4, 'not_started', $5, $6, $7, $8, $9, $10, $11)
      RETURNING id, tenant_id, project_id, title, description, status, priority,
                assignee_user_id, progress_percent, risk_score, risk_level, start_date, due_date,
-               source_kind, source_record_id, created_at`,
+               source_kind, source_record_id, labels, created_at`,
     [
       tenantId,
       projectId,
@@ -794,6 +816,7 @@ export async function executeTaskCreate(
       payload.dueDate ?? null,
       sourceKind,
       sourceRecordId,
+      labels,
     ]
   );
   const task = rows[0];

--- a/packages/db/src/migrations/032_task_labels.sql
+++ b/packages/db/src/migrations/032_task_labels.sql
@@ -1,0 +1,9 @@
+-- B-004: Capture user-provided task labels through create_task.
+-- Small, additive column; existing tasks default to an empty array so no
+-- backfill is needed.
+
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS labels TEXT[] NOT NULL DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS idx_tasks_labels ON tasks USING GIN (labels)
+  WHERE cardinality(labels) > 0;

--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -267,11 +267,14 @@ CREATE TABLE IF NOT EXISTS tasks (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   assigned_to_larry BOOLEAN NOT NULL DEFAULT FALSE,
   completed_by_larry BOOLEAN NOT NULL DEFAULT FALSE,
-  larry_document_id UUID REFERENCES larry_documents(id) ON DELETE SET NULL
+  larry_document_id UUID REFERENCES larry_documents(id) ON DELETE SET NULL,
+  labels TEXT[] NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_tenant_project ON tasks (tenant_id, project_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee ON tasks (tenant_id, assignee_user_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_labels ON tasks USING GIN (labels)
+  WHERE cardinality(labels) > 0;
 
 CREATE TABLE IF NOT EXISTS task_dependencies (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -241,6 +241,9 @@ export interface LarryEventSummary {
   conversationTitle?: string | null;
   requestMessagePreview?: string | null;
   responseMessagePreview?: string | null;
+  modifiedAt?: string | null;
+  modifiedByUserId?: string | null;
+  modifiedByName?: string | null;
 }
 
 export interface LarryMessageRecord {


### PR DESCRIPTION
## Summary

Three Action Centre bugs from the 2026-04-20 E2E audit (`larry-ai-e2e-2026-04-20.md`) shipped together because they share the card rendering pipeline.

- **B-003** — task_create cards now render a structured summary + detail panel (priority · due · assignee · labels) instead of just a description blob. Matches existing treatment of email/slack/project_note.
- **B-004** — free-form labels captured end-to-end: migration 032 adds `tasks.labels TEXT[]` + partial GIN index, AI tool schema grows a labels field with strong anti-hallucination docs, executor normalises (trim + case-insensitive dedupe), Modify panel gets pill input, labels surface on cards.
- **B-005** — modify/save regenerates `display_text` from the edited payload via `rebuildDisplayText` (covers 10 action types, falls back to original for unsupported). UI surfaces a Modified badge and suppresses the stale pre-modify `responseMessagePreview` so the completed card reflects what actually ran.

## Files

- Migration: `packages/db/src/migrations/032_task_labels.sql` + `schema.sql`
- AI: `packages/ai/src/chat.ts` (create_task labels param)
- Executor: `packages/db/src/larry-executor.ts` (normalize + INSERT + RETURNING)
- API: `apps/api/src/routes/v1/larry.ts` (rebuildDisplayText + UPDATE display_text), `larry-ledger.ts` (SELECT modified_at/modifiedByName), `tasks.ts` (SELECT labels)
- Shared types: `packages/shared/src/index.ts`, `apps/web/src/app/dashboard/types.ts`
- UI: `ActionDetailPreview.tsx` (TaskCreateDetail), `ModifyPanelFields.tsx` (LabelsInput), `actions/page.tsx` (Modified badge + suppressed preview)

## Test plan

- [ ] Railway deploys + migration 032 runs cleanly (`tasks.labels TEXT[]` exists)
- [ ] Chat "create a task called Fix onboarding, high priority, due 2026-04-25, assign to Anton, label qa" → task_create suggestion has labels=["qa"]
- [ ] Modify the suggestion → add "launch" label → save → Action card shows `high priority · due 2026-04-25 · → Anton · labels: qa, launch`
- [ ] Modify + execute → completed card shows regenerated title (`Create task: Fix onboarding`), Modified badge present, stale responseMessagePreview suppressed
- [ ] SELECT labels FROM tasks WHERE title = 'Fix onboarding' returns `{qa,launch}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)