### PR TITLE
fix(chat): B-007 enumerate captured + dropped fields in action confirmations

### DIFF
--- a/packages/ai/src/chat.test.ts
+++ b/packages/ai/src/chat.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildChatSystemPrompt } from "./chat.js";
+
+describe("buildChatSystemPrompt — action confirmations (B-007)", () => {
+  it("forces Larry to enumerate every captured create_task field in the confirmation reply", () => {
+    const prompt = buildChatSystemPrompt(null);
+    expect(prompt).toMatch(/CONFIRMING ACTIONS/);
+    // All six fields that the audit found Larry silently dropping must be
+    // explicitly named in the confirmation template.
+    for (const field of ["title", "priority", "startDate", "dueDate", "assigneeName", "labels"]) {
+      expect(prompt).toContain(field);
+    }
+  });
+
+  it("requires Larry to flag any field the user asked for that couldn't be captured", () => {
+    const prompt = buildChatSystemPrompt(null);
+    // Silent drops were the worst failure mode in the audit. The prompt must
+    // make explicit that Larry says when a requested field was dropped, not
+    // just when it was captured.
+    expect(prompt).toMatch(/silently dropping/i);
+    expect(prompt).toMatch(/couldn't (include|capture)/i);
+  });
+
+  it("provides a concrete example confirmation with every field", () => {
+    const prompt = buildChatSystemPrompt(null);
+    // A single worked example in the prompt is more reliable than a rule the
+    // model has to synthesise. Must include all six audit fields in one line.
+    expect(prompt).toMatch(/Queued .* priority.* starts .* due .* assigned to .* labels/s);
+  });
+});

--- a/packages/ai/src/chat.ts
+++ b/packages/ai/src/chat.ts
@@ -152,6 +152,23 @@ Only reference tasks, people, and dates from the project context. Never invent I
 **Read-only:**
 - get_task_list — look up task details when you need more info than you have
 
+## CONFIRMING ACTIONS — ENUMERATE EVERY CAPTURED AND DROPPED FIELD
+
+After you call an action tool, your reply MUST name every field the user mentioned — both the ones you captured in the tool call and any you couldn't include.
+
+For create_task specifically, walk through **title, priority, startDate, dueDate, assigneeName, and labels** in that order. Include a field only if the user mentioned it; omit the ones they didn't. Format it as one short sentence, e.g.:
+
+  "Queued **Fix onboarding** — high priority, starts 2026-04-21, due 2026-04-25, assigned to Anton, labels qa + launch."
+
+If the user mentioned something you couldn't capture (name not on the team, field the tool doesn't support, ambiguous date), say so in the same reply. Examples:
+
+  "…assigned to Anton. I didn't add the 'backend' label because create_task doesn't accept labels yet — want me to add a comment instead?"
+  "…high priority. I didn't set an owner because Marcus isn't on this project — should I use Joel, or add Marcus first?"
+
+The worst failure mode is silently dropping a field. The user asked for it; if you can't do it, say so. If you did do it, confirm the exact value so the user can catch a misparse before approving in the Action Centre.
+
+The same rule applies to every other action tool: after calling the tool, name every argument you set in plain English, and flag anything the user asked for that you couldn't include.
+
 ## NAMING PEOPLE — ALWAYS VERIFY BEFORE USING
 
 The project context includes a team list with every member's display name.


### PR DESCRIPTION
## Summary

Audit found Larry silently dropping fields from chat confirmations. User asked for 6 fields on create_task (title, priority, start, due, assignee, labels); reply named only priority + due + assignee. Silent drops are indistinguishable from accepted-but-unmentioned values, so users can't catch a misparse before approving in the Action Centre.

## Fix

Prompt-level. New **CONFIRMING ACTIONS** section in the chat system prompt requires Larry to:

1. Enumerate every `create_task` field in fixed order (title / priority / startDate / dueDate / assigneeName / labels) when the user mentioned it
2. State explicitly when a requested field couldn't be captured (name off-team, tool doesn't support, ambiguous date)
3. Extend the same pattern to every other action tool

Includes a worked example confirmation in the prompt so the model has a concrete template. Three invariant tests in `chat.test.ts` guard against future prompt refactors dropping the directive.

## Note on conflict with PR #147

This PR also touches `packages/ai/src/chat.test.ts`. PR #147 (B-010) creates the same file with different tests. Whichever lands second will need to merge both test suites into the file — trivial concat.

## Test plan

- [x] `npx vitest run src/chat.test.ts` passes (3/3)
- [ ] After deploy: in project chat, say "create task Fix onboarding, high priority, due 2026-04-25, start 2026-04-21, assign to Anton, label qa" → reply enumerates all 5 captured fields + 1 label
- [ ] Say "create task Do X, assign to Marcus" (Marcus not on team) → reply flags "didn't set owner because Marcus isn't on this project"

🤖 Generated with [Claude Code](https://claude.com/claude-code)