### PR TITLE
fix(larry): allow unassign + disambiguate duplicate project names

### DIFF
--- a/apps/web/src/app/workspace/larry/page.tsx
+++ b/apps/web/src/app/workspace/larry/page.tsx
@@ -37,6 +37,7 @@ import { PageState } from "@/components/PageState";
 interface WorkspaceProject {
   id: string;
   name: string;
+  updatedAt?: string | null;
 }
 
 /* ─── Helpers ────────────────────────────────────────────────────── */
@@ -298,6 +299,32 @@ export default function AskLarryPage() {
     () => new Map(projects.map((project) => [project.id, project.name])),
     [projects]
   );
+
+  // B-011: if two projects share a display name (common after test imports
+  // or merges), the user can't tell them apart in the selector. Append a
+  // disambiguation suffix — updatedAt date preferred, short ID fallback —
+  // only to the duplicates, so unique-name projects stay clean.
+  const projectSelectLabels = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const p of projects) {
+      const key = (p.name ?? "").trim().toLowerCase();
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    const labels = new Map<string, string>();
+    for (const p of projects) {
+      const key = (p.name ?? "").trim().toLowerCase();
+      if ((counts.get(key) ?? 0) <= 1) {
+        labels.set(p.id, p.name);
+      } else {
+        const suffix =
+          typeof p.updatedAt === "string" && p.updatedAt
+            ? p.updatedAt.slice(0, 10)
+            : p.id.slice(0, 6);
+        labels.set(p.id, `${p.name} · ${suffix}`);
+      }
+    }
+    return labels;
+  }, [projects]);
 
   const activeConversation = useMemo(
     () => conversations.find((c) => c.id === selectedConversationId) ?? null,
@@ -770,7 +797,7 @@ export default function AskLarryPage() {
                       >
                         <option value="">Global workspace</option>
                         {projects.map((project) => (
-                          <option key={project.id} value={project.id}>{project.name}</option>
+                          <option key={project.id} value={project.id}>{projectSelectLabels.get(project.id) ?? project.name}</option>
                         ))}
                         <option value="__new__">＋ New project</option>
                       </select>

--- a/packages/ai/src/chat.ts
+++ b/packages/ai/src/chat.ts
@@ -146,7 +146,7 @@ Only reference tasks, people, and dates from the project context. Never invent I
 - flag_task_risk — flag a task's risk level
 - create_task — create a new task
 - change_deadline — change a task's due date
-- change_task_owner — reassign a task
+- change_task_owner — reassign or unassign a task (pass newOwnerName: null to clear the owner)
 - draft_email — draft an email to a team member
 
 **Read-only:**
@@ -411,11 +411,11 @@ export async function* streamLarryChat(input: {
     }),
 
     change_task_owner: tool({
-      description: "Reassign a task to a different owner. Will be queued in the Action Centre for approval.",
+      description: "Reassign or unassign a task. Will be queued in the Action Centre for approval. Pass null for newOwnerName to unassign the task entirely.",
       inputSchema: z.object({
         taskId: z.string().describe("Task UUID from project context"),
         taskTitle: z.string().describe("Task title"),
-        newOwnerName: z.string().describe("New owner's display name"),
+        newOwnerName: z.string().nullable().describe("New owner's display name (must be on the project team), or null to unassign the task"),
         reasoning: z.string().describe("One sentence: why reassign this task"),
         displayText: z.string().describe("Short imperative shown in the UI"),
       }),

--- a/packages/db/src/larry-executor.ts
+++ b/packages/db/src/larry-executor.ts
@@ -100,7 +100,8 @@ interface DeadlineChangePayload {
 interface OwnerChangePayload {
   taskId: string;
   taskTitle: string;
-  newOwnerName: string;
+  // null / empty string → unassign the task entirely (B-009).
+  newOwnerName: string | null;
 }
 
 interface ScopeChangePayload {
@@ -909,9 +910,19 @@ export async function executeOwnerChange(
   tenantId: string,
   payload: OwnerChangePayload
 ): Promise<Record<string, unknown>> {
-  const newOwnerId = await resolveUserByName(db, tenantId, payload.newOwnerName);
-  if (!newOwnerId) {
-    throw new Error(`executeOwnerChange: user "${payload.newOwnerName}" not found in tenant ${tenantId}`);
+  // B-009: null / empty newOwnerName is the unassign path. Only resolve when
+  // the caller actually named someone.
+  const wantsUnassign =
+    payload.newOwnerName === null ||
+    payload.newOwnerName === undefined ||
+    payload.newOwnerName.trim() === "";
+
+  let newOwnerId: string | null = null;
+  if (!wantsUnassign) {
+    newOwnerId = await resolveUserByName(db, tenantId, payload.newOwnerName as string);
+    if (!newOwnerId) {
+      throw new Error(`executeOwnerChange: user "${payload.newOwnerName}" not found in tenant ${tenantId}`);
+    }
   }
 
   const rows = await db.queryTenant<Record<string, unknown>>(
@@ -928,7 +939,7 @@ export async function executeOwnerChange(
   const task = rows[0];
   await logActivity(db, tenantId, task.project_id as string, payload.taskId, {
     action: "owner_change",
-    newOwnerName: payload.newOwnerName,
+    newOwnerName: wantsUnassign ? null : payload.newOwnerName,
     newOwnerId,
     triggeredBy: "larry",
   });


### PR DESCRIPTION
## Summary
- **B-009**: `change_task_owner` now accepts `newOwnerName: null` to clear the assignee; executor skips `resolveUserByName` on the unassign path and writes NULL
- **B-011**: Project `<select>` disambiguates duplicate names by appending `· YYYY-MM-DD` (updatedAt) or short id, only when a name collides case-insensitively

## Test plan
- [ ] Ask Larry "unassign the onboarding task" — verify assignee cleared, no 500
- [ ] Create a second project with the same name — verify dropdown shows disambiguator on both; unique projects unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)