### PR TITLE
feat(web): landing page redesign — Situation Room (light mode)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 import "@/styles/landing-v3.css";
 import { LandingNavbar } from "@/components/landing-v3/Navbar";
 import { HeroHead } from "@/components/landing-v3/HeroHead";
-import { SituationRoom, DropPanel } from "@/components/landing-v3/SituationRoom";
+import { SituationRoom } from "@/components/landing-v3/SituationRoom";
 import { WhatLarryDoes } from "@/components/landing-v3/WhatLarryDoes";
 import { BeforeAfter } from "@/components/landing-v3/BeforeAfter";
 import { CTA } from "@/components/landing-v3/CTA";
@@ -26,13 +26,12 @@ export default function Home() {
         style={{
           maxWidth: 1240,
           minHeight: "calc(100vh - 68px)",
-          padding: "56px 28px 40px",
-          gridTemplateRows: "auto 1fr auto",
+          padding: "28px 28px 40px",
+          gridTemplateRows: "auto 1fr",
         }}
       >
         <HeroHead />
         <SituationRoom />
-        <DropPanel />
       </main>
       <WhatLarryDoes />
       <BeforeAfter />

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,38 +1,43 @@
-import { HeroSection } from "@/components/sections/HeroSection";
-import { MissionSection } from "@/components/sections/MissionSection";
-import { LogoBar } from "@/components/sections/LogoBar";
-import { ClientLogos } from "@/components/sections/ClientLogos";
-import { ComparisonSection } from "@/components/sections/ComparisonSection";
-import { FeaturesSection } from "@/components/sections/FeaturesSection";
-import { VibeSection } from "@/components/sections/VibeSection";
-import { TemplatesSection } from "@/components/sections/TemplatesSection";
-import { ROISection } from "@/components/sections/ROISection";
-import { WhoItsForSection } from "@/components/sections/WhoItsForSection";
-import { CTASection } from "@/components/sections/CTASection";
-import { Navbar } from "@/components/layout/Navbar";
-import { Footer } from "@/components/layout/Footer";
-import { WelcomeSplash } from "@/components/ui/WelcomeSplash";
-import { LandingRoot } from "@/components/layout/LandingRoot";
+import "@/styles/landing-v3.css";
+import { LandingNavbar } from "@/components/landing-v3/Navbar";
+import { HeroHead } from "@/components/landing-v3/HeroHead";
+import { SituationRoom, DropPanel } from "@/components/landing-v3/SituationRoom";
+import { WhatLarryDoes } from "@/components/landing-v3/WhatLarryDoes";
+import { BeforeAfter } from "@/components/landing-v3/BeforeAfter";
+import { CTA } from "@/components/landing-v3/CTA";
+import { LandingFooter } from "@/components/landing-v3/Footer";
 
 export default function Home() {
   return (
-    <LandingRoot>
-      <WelcomeSplash />
-      <Navbar />
-      <main>
-        <HeroSection />
-        <MissionSection />
-        <LogoBar />
-        <ClientLogos />
-        <ComparisonSection />
-        <FeaturesSection />
-        <VibeSection />
-        <TemplatesSection />
-        <ROISection />
-        <WhoItsForSection />
-        <CTASection />
+    <div
+      className="min-h-screen"
+      style={{
+        background: "var(--page-bg)",
+        color: "var(--text-1)",
+        backgroundImage: `
+          radial-gradient(ellipse 80% 40% at 50% -5%, rgba(139,92,246,0.09), transparent 70%),
+          radial-gradient(ellipse 60% 30% at 50% 100%, rgba(108,68,246,0.05), transparent 70%)
+        `,
+      }}
+    >
+      <LandingNavbar />
+      <main
+        className="relative mx-auto grid gap-8"
+        style={{
+          maxWidth: 1240,
+          minHeight: "calc(100vh - 68px)",
+          padding: "56px 28px 40px",
+          gridTemplateRows: "auto 1fr auto",
+        }}
+      >
+        <HeroHead />
+        <SituationRoom />
+        <DropPanel />
       </main>
-      <Footer />
-    </LandingRoot>
+      <WhatLarryDoes />
+      <BeforeAfter />
+      <CTA />
+      <LandingFooter />
+    </div>
   );
 }

--- a/apps/web/src/components/landing-v3/BeforeAfter.tsx
+++ b/apps/web/src/components/landing-v3/BeforeAfter.tsx
@@ -1,0 +1,50 @@
+export function BeforeAfter() {
+  return (
+    <section className="lv3-page">
+      <div className="lv3-contrast">
+        <div>
+          <span className="lv3-sec-label">Before / After</span>
+          <h3 className="lv3-contrast__kill">
+            One hour on Monday morning, <em>without Larry</em> and with.
+          </h3>
+        </div>
+        <div className="lv3-ba">
+          <div className="lv3-ba__row">
+            <div className="lv3-ba__lbl">Before</div>
+            <div className="lv3-ba__txt">
+              <span className="lv3-ba__strike">
+                Scroll three Slack channels for blockers. DM four owners.
+                Copy-paste into Monday.
+              </span>
+            </div>
+          </div>
+          <div className="lv3-ba__row">
+            <div className="lv3-ba__lbl">Before</div>
+            <div className="lv3-ba__txt">
+              <span className="lv3-ba__strike">
+                Read Friday&apos;s meeting notes. Create four tasks by hand.
+                Assign, date, describe.
+              </span>
+            </div>
+          </div>
+          <div className="lv3-ba__row">
+            <div className="lv3-ba__lbl">Before</div>
+            <div className="lv3-ba__txt">
+              <span className="lv3-ba__strike">
+                Draft the standup email. Redraft. Send. Field replies. Update
+                the tracker.
+              </span>
+            </div>
+          </div>
+          <div className="lv3-ba__row lv3-ba__row--larry">
+            <div className="lv3-ba__lbl">With Larry</div>
+            <div className="lv3-ba__txt">
+              Open the workspace. Six actions are already executed. Three are
+              waiting for your nod. Accept.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing-v3/CTA.tsx
+++ b/apps/web/src/components/landing-v3/CTA.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useOverlayTrigger } from "@/components/ui/LiquidOverlay";
+
+export function CTA() {
+  const onWaitlist = useOverlayTrigger("waitlist");
+  const onIntro = useOverlayTrigger("intro");
+
+  return (
+    <section className="lv3-cta" id="cta">
+      <div className="lv3-cta__inner">
+        <h2 className="lv3-cta__h">
+          Stop <em>managing</em> work.
+          <br />
+          Start delivering it.
+        </h2>
+        <p className="lv3-cta__p">
+          Invite-only beta, shaped around your team&apos;s first three weeks.
+          Direct line to the founders.
+        </p>
+        <div className="lv3-cta__row">
+          <button
+            type="button"
+            onClick={onWaitlist}
+            className="lv3-cta__btn lv3-cta__btn--primary"
+          >
+            Request early access →
+          </button>
+          <button
+            type="button"
+            onClick={onIntro}
+            className="lv3-cta__btn lv3-cta__btn--ghost"
+          >
+            Book a 20-min intro
+          </button>
+        </div>
+        <div className="lv3-cta__fine">
+          Priority onboarding · No migration · Reversible by default
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing-v3/Footer.tsx
+++ b/apps/web/src/components/landing-v3/Footer.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import Link from "next/link";
 
 export function LandingFooter() {
   const year = new Date().getFullYear();
@@ -10,8 +9,6 @@ export function LandingFooter() {
         <span>© {year} Larry. Making projects run themselves.</span>
       </div>
       <nav className="lv3-footer__nav">
-        <Link href="/privacy">Privacy</Link>
-        <Link href="/terms">Terms</Link>
         <a href="mailto:hello@larry-pm.com">hello@larry-pm.com</a>
       </nav>
     </footer>

--- a/apps/web/src/components/landing-v3/Footer.tsx
+++ b/apps/web/src/components/landing-v3/Footer.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export function LandingFooter() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="lv3-footer">
+      <div className="lv3-footer__brand">
+        <Image src="/Larryfulllogo.png" alt="Larry" width={88} height={20} />
+        <span>© {year} Larry. Making projects run themselves.</span>
+      </div>
+      <nav className="lv3-footer__nav">
+        <Link href="/privacy">Privacy</Link>
+        <Link href="/terms">Terms</Link>
+        <a href="mailto:hello@larry-pm.com">hello@larry-pm.com</a>
+      </nav>
+    </footer>
+  );
+}

--- a/apps/web/src/components/landing-v3/HeroHead.tsx
+++ b/apps/web/src/components/landing-v3/HeroHead.tsx
@@ -1,0 +1,45 @@
+export function HeroHead() {
+  return (
+    <div className="mx-auto w-full max-w-[900px] text-center">
+      <span
+        className="inline-flex items-center gap-2.5 rounded-full border bg-white px-4 py-1.5 font-mono uppercase"
+        style={{
+          borderColor: "var(--border)",
+          fontSize: "10px",
+          fontWeight: 500,
+          letterSpacing: "0.18em",
+          color: "var(--text-2)",
+        }}
+      >
+        <span className="hero-eyebrow-dot" />
+        Larry · Execution live
+      </span>
+
+      <h1
+        className="mx-auto mt-5 max-w-[16ch] font-extrabold"
+        style={{
+          fontSize: "clamp(2.75rem, 7.2vw, 5.75rem)",
+          lineHeight: 0.98,
+          letterSpacing: "-0.045em",
+          color: "var(--text-1)",
+        }}
+      >
+        Making projects <span className="hero-italic">run themselves.</span>
+      </h1>
+
+      <p
+        className="mx-auto mt-6 max-w-[580px]"
+        style={{
+          fontSize: "17px",
+          lineHeight: 1.55,
+          color: "var(--text-2)",
+          letterSpacing: "-0.005em",
+        }}
+      >
+        Larry listens across your stack, decides what needs to happen, drafts
+        it in your voice, and ships it. Watch a live minute of execution below
+        — or drop in a signal and see Larry act in real time.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing-v3/HeroHead.tsx
+++ b/apps/web/src/components/landing-v3/HeroHead.tsx
@@ -1,22 +1,8 @@
 export function HeroHead() {
   return (
     <div className="mx-auto w-full max-w-[900px] text-center">
-      <span
-        className="inline-flex items-center gap-2.5 rounded-full border bg-white px-4 py-1.5 font-mono uppercase"
-        style={{
-          borderColor: "var(--border)",
-          fontSize: "10px",
-          fontWeight: 500,
-          letterSpacing: "0.18em",
-          color: "var(--text-2)",
-        }}
-      >
-        <span className="hero-eyebrow-dot" />
-        Larry · Execution live
-      </span>
-
       <h1
-        className="mx-auto mt-5 max-w-[16ch] font-extrabold"
+        className="mx-auto max-w-[16ch] font-extrabold"
         style={{
           fontSize: "clamp(2.75rem, 7.2vw, 5.75rem)",
           lineHeight: 0.98,

--- a/apps/web/src/components/landing-v3/Navbar.tsx
+++ b/apps/web/src/components/landing-v3/Navbar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useOverlayTrigger } from "@/components/ui/LiquidOverlay";
+
+export function LandingNavbar() {
+  const onWaitlist = useOverlayTrigger("waitlist");
+
+  return (
+    <nav
+      className="sticky top-0 z-50 border-b"
+      style={{
+        padding: "18px 28px",
+        background: "rgba(242,243,255,0.88)",
+        borderColor: "rgba(240,237,250,0.6)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+      }}
+    >
+      <div className="mx-auto flex max-w-[1240px] items-center justify-between">
+        <Link href="/" aria-label="Larry" className="inline-flex items-center">
+          <Image
+            src="/Larryfulllogo.png"
+            alt="Larry"
+            width={120}
+            height={28}
+            priority
+            className="h-7 w-auto"
+          />
+        </Link>
+
+        <div className="flex items-center gap-2.5">
+          <a
+            href="#what"
+            className="hidden px-3.5 py-2 text-[13px] text-[var(--text-2)] transition-colors hover:text-[var(--text-1)] sm:inline-flex"
+          >
+            What Larry does
+          </a>
+          <Link
+            href="/login"
+            className="hidden px-3.5 py-2 text-[13px] text-[var(--text-2)] transition-colors hover:text-[var(--text-1)] sm:inline-flex"
+          >
+            Sign in
+          </Link>
+          <button
+            type="button"
+            onClick={onWaitlist}
+            className="inline-flex items-center gap-1.5 rounded-full border border-[var(--text-1)] bg-[var(--text-1)] px-4.5 py-2 text-[13px] font-medium text-white transition-all duration-200 hover:border-[var(--brand)] hover:bg-[var(--brand)]"
+            style={{ letterSpacing: "-0.005em", padding: "9px 18px" }}
+          >
+            Get early access
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/landing-v3/SituationRoom.tsx
+++ b/apps/web/src/components/landing-v3/SituationRoom.tsx
@@ -1,0 +1,612 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef } from "react";
+
+type SignalSrc = "slack" | "email" | "meeting" | "calendar" | "scan";
+
+type ActionKind =
+  | "risk_flag"
+  | "reminder_send"
+  | "task_create"
+  | "status_update"
+  | "deadline_change"
+  | "email_draft"
+  | "slack_message_draft"
+  | "project_note_send";
+
+type Tone = "suggested" | "accepted" | "auto";
+
+type Beat = {
+  src: SignalSrc;
+  project: string;
+  signal: string;
+  action: {
+    kind: ActionKind;
+    tone: Tone;
+    toneLabel: string;
+    display: string;
+    reason: string;
+    meta: string;
+  };
+};
+
+const ICON: Record<SignalSrc, string> = {
+  slack: `<svg viewBox="0 0 20 20" fill="currentColor"><path d="M4.5 12.5a1.5 1.5 0 1 1 0-3h1.5v3H4.5Zm3.75 0a1.5 1.5 0 0 1 3 0v3.75a1.5 1.5 0 0 1-3 0V12.5ZM8.25 4.5a1.5 1.5 0 0 1 3 0v4.5h-3V4.5ZM15.5 8.25a1.5 1.5 0 0 1 0-3h.25a1.5 1.5 0 0 1 0 3H15.5ZM15.5 11.75a1.5 1.5 0 0 1 3 0v.25a1.5 1.5 0 0 1-3 0v-.25Zm-3.75 3.75a1.5 1.5 0 0 1-3 0V15a1.5 1.5 0 0 1 3 0v.5Z"/></svg>`,
+  email: `<svg viewBox="0 0 20 20" fill="none"><rect x="2.5" y="5" width="15" height="11" rx="2" stroke="currentColor" stroke-width="1.4"/><path d="M3 6l7 5 7-5" stroke="currentColor" stroke-width="1.4"/></svg>`,
+  meeting: `<svg viewBox="0 0 20 20" fill="none"><rect x="2.5" y="5" width="11" height="10" rx="2" stroke="currentColor" stroke-width="1.4"/><path d="M14 9l4-2v6l-4-2V9Z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/></svg>`,
+  calendar: `<svg viewBox="0 0 20 20" fill="none"><rect x="3" y="4.5" width="14" height="12" rx="2" stroke="currentColor" stroke-width="1.4"/><path d="M3 8h14M7 3v3M13 3v3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>`,
+  scan: `<svg viewBox="0 0 20 20" fill="none"><circle cx="9" cy="9" r="5.5" stroke="currentColor" stroke-width="1.4"/><path d="M13 13l4 4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>`,
+};
+
+const KIND: Record<ActionKind, { label: string; color: string }> = {
+  risk_flag: { label: "Risk Flag", color: "#dc2626" },
+  reminder_send: { label: "Reminder", color: "#b45309" },
+  task_create: { label: "Create Task", color: "#6c44f6" },
+  status_update: { label: "Status Update", color: "#0891b2" },
+  deadline_change: { label: "Deadline Change", color: "#c2410c" },
+  email_draft: { label: "Email Draft", color: "#4f46e5" },
+  slack_message_draft: { label: "Slack Draft", color: "#be185d" },
+  project_note_send: { label: "Project Note", color: "#0f766e" },
+};
+
+const BEATS: Beat[] = [
+  {
+    src: "slack",
+    project: "Platform migration",
+    signal: `#eng-q3 · "vendor SLA confirm still not back — cutover is Thursday"`,
+    action: {
+      kind: "risk_flag",
+      tone: "suggested",
+      toneLabel: "Pending approval",
+      display: `Flag "Migration dry-run" as at-risk and notify the portfolio owner.`,
+      reason:
+        "Vendor SLA confirmation is 3 days overdue; production cutover can't start without it.",
+      meta: "Risk flag · requested by Larry · 2s ago",
+    },
+  },
+  {
+    src: "email",
+    project: "Onboarding v4",
+    signal: `hello@acme → "Can we get a Loom of the 4-screen flow before Fri?"`,
+    action: {
+      kind: "email_draft",
+      tone: "suggested",
+      toneLabel: "Pending approval",
+      display: "Drafted reply to Priya with Loom attached and Friday EOD delivery.",
+      reason:
+        "Standard external follow-up. Larry pulled the latest Loom from the project channel.",
+      meta: "Email draft · awaits send · 4s ago",
+    },
+  },
+  {
+    src: "meeting",
+    project: "Q3 programme",
+    signal: `Tues stand-up transcript · "Marcus said he's blocked on design review"`,
+    action: {
+      kind: "task_create",
+      tone: "auto",
+      toneLabel: "Auto executed",
+      display: `Added subtask "Design review unblock" owned by @lena, due Thu.`,
+      reason:
+        "Speaker attribution + explicit blocker → owner-mapped via prior review cadence.",
+      meta: "Create task · executed by Larry · just now",
+    },
+  },
+  {
+    src: "calendar",
+    project: "Launch · GA",
+    signal: `invite · "Launch comms sync · Thu 15:00" moved to Fri 09:00`,
+    action: {
+      kind: "deadline_change",
+      tone: "auto",
+      toneLabel: "Auto executed",
+      display: `Shifted "Comms calendar" milestone to Fri and re-stacked dependents.`,
+      reason:
+        "Cascades: 3 tasks moved, 1 owner re-notified. No external stakeholder impact.",
+      meta: "Deadline change · executed by Larry · just now",
+    },
+  },
+  {
+    src: "scan",
+    project: "Platform migration",
+    signal:
+      "scheduled scan · 6/6 cutover runbook checks green in Slack between 14:02–14:18",
+    action: {
+      kind: "status_update",
+      tone: "accepted",
+      toneLabel: "Accepted",
+      display: `Moved "Staging cutover" to Completed. Rolled up Infra to 80%.`,
+      reason: "All six checks green in #ops-cutover. No open blockers in linked chat.",
+      meta: "Status update · accepted by Mo · 1m ago",
+    },
+  },
+  {
+    src: "slack",
+    project: "Onboarding v4",
+    signal: `DM · "@marcus any update on the 4-screen collapse? deadline Fri."`,
+    action: {
+      kind: "reminder_send",
+      tone: "suggested",
+      toneLabel: "Pending approval",
+      display: `Send gentle nudge to @marcus on "Collapse to 4 screens."`,
+      reason: "Due in 48h. Last activity was Thursday's mock review; no commits since.",
+      meta: "Reminder · in your voice · 3s ago",
+    },
+  },
+  {
+    src: "email",
+    project: "Q3 programme",
+    signal: `exec@acme → "Give me the blockers this week in two lines."`,
+    action: {
+      kind: "project_note_send",
+      tone: "auto",
+      toneLabel: "Auto executed",
+      display: "Sent 2-line blockers digest to the exec thread.",
+      reason:
+        "Exec-threshold request. Two blockers pulled from action ledger + linked owners.",
+      meta: "Project note · executed by Larry · just now",
+    },
+  },
+];
+
+const DROP_MAP: Record<"slack" | "email" | "meeting" | "calendar", number> = {
+  slack: 5,
+  email: 1,
+  meeting: 2,
+  calendar: 3,
+};
+
+const SRC_LABEL: Record<SignalSrc, string> = {
+  slack: "Slack",
+  email: "Email",
+  meeting: "Meeting",
+  calendar: "Calendar",
+  scan: "Scan",
+};
+
+export function SituationRoom() {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const stackRef = useRef<HTMLDivElement>(null);
+  const sealRef = useRef<HTMLDivElement>(null);
+  const boltsRef = useRef<SVGSVGElement>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const statSigRef = useRef<HTMLSpanElement>(null);
+  const statActRef = useRef<HTMLSpanElement>(null);
+  const statPendRef = useRef<HTMLSpanElement>(null);
+
+  // Imperative beat-engine state, kept out of React render cycle.
+  const runtimeRef = useRef({
+    beatIdx: 0,
+    actionsTaken: 0,
+    pendingCount: 0,
+    autoTimer: null as ReturnType<typeof setTimeout> | null,
+    visible: true,
+    running: false,
+  });
+
+  useEffect(() => {
+    const runtime = runtimeRef.current;
+    const STAGE = stageRef.current!;
+    const TRACK = trackRef.current!;
+    const STACK = stackRef.current!;
+    const SEAL = sealRef.current!;
+    const BOLTS = boltsRef.current!;
+    const STATUS = statusRef.current!;
+    const LABEL = labelRef.current!;
+    const STAT_SIG = statSigRef.current!;
+    const STAT_ACT = statActRef.current!;
+    const STAT_PEND = statPendRef.current!;
+
+    const timers = new Set<ReturnType<typeof setTimeout>>();
+    const schedule = (fn: () => void, ms: number) => {
+      const id = setTimeout(() => {
+        timers.delete(id);
+        fn();
+      }, ms);
+      timers.add(id);
+      return id;
+    };
+
+    const hexLighten = (h: string, pct: number) => {
+      const m = /^#?([0-9a-f]{6})$/i.exec(h);
+      if (!m) return h;
+      const r = parseInt(m[1].slice(0, 2), 16);
+      const g = parseInt(m[1].slice(2, 4), 16);
+      const b = parseInt(m[1].slice(4, 6), 16);
+      const x = (c: number) => Math.round(c + (255 - c) * (pct / 100));
+      return `rgb(${x(r)},${x(g)},${x(b)})`;
+    };
+
+    const hexDarken = (h: string, pct: number) => {
+      const m = /^#?([0-9a-f]{6})$/i.exec(h);
+      if (!m) return h;
+      const r = parseInt(m[1].slice(0, 2), 16);
+      const g = parseInt(m[1].slice(2, 4), 16);
+      const b = parseInt(m[1].slice(4, 6), 16);
+      const x = (c: number) => Math.round(c * (1 - pct / 100));
+      return `rgb(${x(r)},${x(g)},${x(b)})`;
+    };
+
+    const el = (h: string) => {
+      const t = document.createElement("template");
+      t.innerHTML = h.trim();
+      return t.content.firstElementChild as HTMLElement;
+    };
+
+    const formatSignal = (b: Beat) => {
+      const L = SRC_LABEL[b.src];
+      return `<div class="lv3-signal lv3-signal--${b.src}"><div class="lv3-signal__ico">${ICON[b.src]}</div><div class="lv3-signal__body"><div class="lv3-signal__src">${L} · ${b.project}</div><div class="lv3-signal__txt">${b.signal}</div></div></div>`;
+    };
+
+    const formatAction = (b: Beat) => {
+      const k = KIND[b.action.kind];
+      const kindBg = hexLighten(k.color, 88);
+      const kindFg = hexDarken(k.color, 10);
+      const kindBorder = hexLighten(k.color, 65);
+      return `<div class="lv3-act"><div class="lv3-act__head"><span class="lv3-act__proj"><svg viewBox="0 0 14 14" fill="none"><path d="M2 4a1 1 0 0 1 1-1h3l1 1h4a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4Z" stroke="currentColor" stroke-width="1.2"/></svg>${b.project}</span><span class="lv3-act__tone lv3-act__tone--${b.action.tone}">${b.action.toneLabel}</span><span class="lv3-act__kind" style="background:${kindBg};color:${kindFg};border:1px solid ${kindBorder}">${k.label}</span></div><div class="lv3-act__display">${b.action.display}</div><div class="lv3-act__reason">${b.action.reason}</div><div class="lv3-act__meta">${b.action.meta}</div></div>`;
+    };
+
+    const ensureGrad = (w: number) => {
+      if (BOLTS.querySelector("#lv3-bolt-grad")) return;
+      const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+      defs.innerHTML = `<linearGradient id="lv3-bolt-grad" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="${w}" y2="0"><stop offset="0" stop-color="#8b5cf6" stop-opacity="0"/><stop offset="0.5" stop-color="#6c44f6" stop-opacity="0.9"/><stop offset="1" stop-color="#6c44f6" stop-opacity="0.2"/></linearGradient>`;
+      BOLTS.appendChild(defs);
+    };
+
+    const fireBolt = (fromEl: HTMLElement) => {
+      const sr = STAGE.getBoundingClientRect();
+      const fr = fromEl.getBoundingClientRect();
+      const sealR = SEAL.getBoundingClientRect();
+      const ax = fr.right - sr.left;
+      const ay = fr.top + fr.height / 2 - sr.top;
+      const bx = sealR.left + sealR.width / 2 - sr.left;
+      const by = sealR.top + sealR.height / 2 - sr.top;
+      const d = `M ${ax},${ay} C ${(ax + bx) / 2},${ay} ${(ax + bx) / 2},${by} ${bx},${by}`;
+      BOLTS.setAttribute("width", String(sr.width));
+      BOLTS.setAttribute("height", String(sr.height));
+      BOLTS.setAttribute("viewBox", `0 0 ${sr.width} ${sr.height}`);
+      ensureGrad(sr.width);
+      const existing = BOLTS.querySelectorAll("path");
+      if (existing.length > 3) {
+        existing.forEach((n, i) => {
+          if (i < existing.length - 2) n.remove();
+        });
+      }
+      const p = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      p.setAttribute("d", d);
+      p.setAttribute("fill", "none");
+      p.setAttribute("stroke", "url(#lv3-bolt-grad)");
+      p.setAttribute("stroke-width", "1.4");
+      p.setAttribute("stroke-linecap", "round");
+      BOLTS.appendChild(p);
+      const len = p.getTotalLength();
+      p.style.strokeDasharray = String(len);
+      p.style.strokeDashoffset = String(len);
+      p.animate(
+        [{ strokeDashoffset: len }, { strokeDashoffset: 0 }],
+        { duration: 600, easing: "cubic-bezier(.22,1,.36,1)", fill: "forwards" }
+      );
+      schedule(() => {
+        p.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 500, fill: "forwards" });
+        schedule(() => {
+          if (p.parentNode) p.remove();
+        }, 550);
+      }, 550);
+      schedule(firePulse, 540);
+    };
+
+    const firePulse = () => {
+      const p = document.createElement("div");
+      p.className = "lv3-pulse lv3-pulse--fire";
+      SEAL.parentElement!.appendChild(p);
+      schedule(() => p.remove(), 1500);
+    };
+
+    const setStatus = (t: string, active = true) => {
+      LABEL.textContent = t;
+      STATUS.classList.toggle("is-active", active);
+    };
+
+    const repositionSignals = () => {
+      Array.from(TRACK.children).forEach((s, i) => {
+        (s as HTMLElement).style.top = i * 70 + "px";
+      });
+    };
+
+    const runBeat = (b: Beat) => {
+      const sig = el(formatSignal(b));
+      TRACK.prepend(sig);
+      requestAnimationFrame(() => {
+        sig.classList.add("is-in");
+        repositionSignals();
+      });
+      while (TRACK.children.length > 6) {
+        const old = TRACK.lastElementChild as HTMLElement | null;
+        if (!old) break;
+        old.classList.add("is-absorb");
+        schedule(() => old.remove(), 900);
+      }
+
+      schedule(() => {
+        setStatus("Parsing " + b.src + " signal");
+        sig.classList.add("is-absorb");
+        fireBolt(sig);
+        SEAL.classList.add("is-thinking");
+        schedule(() => SEAL.classList.remove("is-thinking"), 1200);
+      }, 900);
+
+      schedule(
+        () => setStatus("Drafting " + KIND[b.action.kind].label.toLowerCase()),
+        1600
+      );
+
+      schedule(() => {
+        const a = el(formatAction(b));
+        STACK.prepend(a);
+        requestAnimationFrame(() => a.classList.add("is-in"));
+        sig.remove();
+        while (STACK.children.length > 4) {
+          const o = STACK.lastElementChild as HTMLElement | null;
+          if (!o) break;
+          o.style.transition = "opacity .6s, transform .6s";
+          o.style.opacity = "0";
+          o.style.transform = "translateY(20px) scale(0.96)";
+          schedule(() => o.remove(), 650);
+        }
+        runtime.actionsTaken += 1;
+        STAT_ACT.textContent = String(runtime.actionsTaken);
+        if (b.action.tone === "suggested") {
+          runtime.pendingCount += 1;
+          STAT_PEND.textContent = String(runtime.pendingCount);
+        }
+        if (b.action.tone === "auto" || b.action.tone === "accepted") {
+          schedule(() => a.classList.add("is-complete"), 1200);
+        }
+        setStatus("Listening", false);
+      }, 2200);
+    };
+
+    const scheduleNext = (delay: number) => {
+      if (runtime.autoTimer) {
+        clearTimeout(runtime.autoTimer);
+        runtime.autoTimer = null;
+      }
+      if (!runtime.visible) return;
+      runtime.autoTimer = setTimeout(tick, delay);
+    };
+
+    const tick = () => {
+      runtime.autoTimer = null;
+      if (runtime.running || !runtime.visible || document.hidden) {
+        scheduleNext(1500);
+        return;
+      }
+      runtime.running = true;
+      runBeat(BEATS[runtime.beatIdx % BEATS.length]);
+      runtime.beatIdx += 1;
+      schedule(() => {
+        runtime.running = false;
+        scheduleNext(1000);
+      }, 2400);
+    };
+
+    // Drop handler exposed via window-scoped custom event so chip buttons can call into us.
+    const onDrop = (evt: Event) => {
+      const which = (evt as CustomEvent<"slack" | "email" | "meeting" | "calendar">).detail;
+      const idx = DROP_MAP[which];
+      if (idx == null) return;
+      if (runtime.running) return;
+      if (runtime.autoTimer) {
+        clearTimeout(runtime.autoTimer);
+        runtime.autoTimer = null;
+      }
+      runtime.running = true;
+      runBeat(BEATS[idx]);
+      schedule(() => {
+        runtime.running = false;
+        scheduleNext(1200);
+      }, 2400);
+    };
+    window.addEventListener("lv3:drop", onDrop as EventListener);
+
+    // Statistics ticker.
+    let n = 42;
+    const statInterval = setInterval(() => {
+      if (document.hidden) return;
+      n += Math.round((Math.random() - 0.5) * 6);
+      n = Math.max(28, Math.min(68, n));
+      STAT_SIG.textContent = String(n);
+    }, 1800);
+
+    // IntersectionObserver gates auto-play to on-screen visibility.
+    const io = new IntersectionObserver(
+      (entries) =>
+        entries.forEach((entry) => {
+          runtime.visible = entry.isIntersecting;
+          if (!runtime.visible) {
+            if (runtime.autoTimer) {
+              clearTimeout(runtime.autoTimer);
+              runtime.autoTimer = null;
+            }
+          } else if (!runtime.autoTimer && !runtime.running && runtime.beatIdx > 0) {
+            scheduleNext(1500);
+          }
+        }),
+      { threshold: 0.1 }
+    );
+    io.observe(STAGE);
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        if (runtime.autoTimer) {
+          clearTimeout(runtime.autoTimer);
+          runtime.autoTimer = null;
+        }
+      } else if (
+        runtime.visible &&
+        !runtime.running &&
+        !runtime.autoTimer &&
+        runtime.beatIdx > 0
+      ) {
+        scheduleNext(1200);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    // Kick it off.
+    schedule(() => {
+      setStatus("Listening", false);
+      tick();
+    }, 700);
+
+    return () => {
+      timers.forEach((id) => clearTimeout(id));
+      timers.clear();
+      if (runtime.autoTimer) clearTimeout(runtime.autoTimer);
+      runtime.autoTimer = null;
+      clearInterval(statInterval);
+      io.disconnect();
+      window.removeEventListener("lv3:drop", onDrop as EventListener);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return (
+    <section className="lv3-room" aria-label="Larry situation room — live">
+      <div className="lv3-room__chrome">
+        <div className="lv3-room__chrome-left">
+          <span className="lv3-room__seal">
+            <Image src="/Larry_logos.png" alt="" width={20} height={20} />
+          </span>
+          <span className="lv3-room__live">Situation room</span>
+          <span className="lv3-room__ws">Workspace · Acme · 14 projects</span>
+        </div>
+        <div className="lv3-room__chrome-right">
+          <span className="lv3-room__stat">
+            Signals/min <b ref={statSigRef}>—</b>
+          </span>
+          <span className="lv3-room__stat">
+            Actions taken <b ref={statActRef}>0</b>
+          </span>
+          <span className="lv3-room__stat">
+            Pending review <b ref={statPendRef}>0</b>
+          </span>
+        </div>
+      </div>
+
+      <div className="lv3-stage" ref={stageRef}>
+        <div className="lv3-col lv3-col--signals">
+          <div className="lv3-col__head">Signals in</div>
+          <div className="lv3-signal-track" ref={trackRef} />
+        </div>
+
+        <div className="lv3-col lv3-col--core">
+          <div className="lv3-core-wrap">
+            <div className="lv3-ring lv3-ring--r4" />
+            <div className="lv3-ring lv3-ring--r3" />
+            <div className="lv3-ring lv3-ring--r2" />
+            <div className="lv3-ring lv3-ring--r1" />
+            <div className="lv3-seal" ref={sealRef}>
+              <Image src="/Larry_logos.png" alt="Larry" width={60} height={60} />
+            </div>
+            <div className="lv3-core-status" ref={statusRef}>
+              <span className="lv3-core-status__dots">
+                <i />
+                <i />
+                <i />
+              </span>
+              <span ref={labelRef}>Listening</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="lv3-col lv3-col--actions">
+          <div className="lv3-col__head">Actions out</div>
+          <div className="lv3-act-stack" ref={stackRef} />
+        </div>
+
+        <svg className="lv3-bolts" ref={boltsRef} xmlns="http://www.w3.org/2000/svg" />
+      </div>
+    </section>
+  );
+}
+
+export function DropPanel() {
+  const dispatch = (which: "slack" | "email" | "meeting" | "calendar") => {
+    window.dispatchEvent(new CustomEvent("lv3:drop", { detail: which }));
+  };
+
+  const chips: {
+    key: "slack" | "email" | "meeting" | "calendar";
+    label: string;
+    svg: React.ReactNode;
+  }[] = [
+    {
+      key: "slack",
+      label: "Slack thread",
+      svg: (
+        <svg viewBox="0 0 20 20" fill="currentColor">
+          <path d="M4.5 12.5a1.5 1.5 0 1 1 0-3h1.5v3H4.5Zm3.75 0a1.5 1.5 0 0 1 3 0v3.75a1.5 1.5 0 0 1-3 0V12.5ZM8.25 4.5a1.5 1.5 0 0 1 3 0v4.5h-3V4.5ZM15.5 8.25a1.5 1.5 0 0 1 0-3h.25a1.5 1.5 0 0 1 0 3H15.5ZM15.5 11.75a1.5 1.5 0 0 1 3 0v.25a1.5 1.5 0 0 1-3 0v-.25Zm-3.75 3.75a1.5 1.5 0 0 1-3 0V15a1.5 1.5 0 0 1 3 0v.5Z" />
+        </svg>
+      ),
+    },
+    {
+      key: "email",
+      label: "Email",
+      svg: (
+        <svg viewBox="0 0 20 20" fill="none">
+          <rect x="2.5" y="5" width="15" height="11" rx="2" stroke="currentColor" strokeWidth="1.4" />
+          <path d="M3 6l7 5 7-5" stroke="currentColor" strokeWidth="1.4" />
+        </svg>
+      ),
+    },
+    {
+      key: "meeting",
+      label: "Meeting transcript",
+      svg: (
+        <svg viewBox="0 0 20 20" fill="none">
+          <rect x="2.5" y="5" width="11" height="10" rx="2" stroke="currentColor" strokeWidth="1.4" />
+          <path d="M14 9l4-2v6l-4-2V9Z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+        </svg>
+      ),
+    },
+    {
+      key: "calendar",
+      label: "Calendar invite",
+      svg: (
+        <svg viewBox="0 0 20 20" fill="none">
+          <rect x="3" y="4.5" width="14" height="12" rx="2" stroke="currentColor" strokeWidth="1.4" />
+          <path d="M3 8h14M7 3v3M13 3v3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+        </svg>
+      ),
+    },
+  ];
+
+  return (
+    <div className="lv3-drop">
+      <div className="lv3-drop__intro">
+        <h3>Drop in a signal. Watch Larry act.</h3>
+        <p>
+          Pick a source and Larry will parse it, draft the right action, and
+          execute — live, in the room above.
+        </p>
+      </div>
+      <div className="lv3-drop__chips">
+        {chips.map((c) => (
+          <button
+            key={c.key}
+            type="button"
+            className={`lv3-chip lv3-chip--${c.key}`}
+            onClick={() => dispatch(c.key)}
+          >
+            {c.svg}
+            {c.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing-v3/SituationRoom.tsx
+++ b/apps/web/src/components/landing-v3/SituationRoom.tsx
@@ -536,11 +536,13 @@ export function SituationRoom() {
 
         <svg className="lv3-bolts" ref={boltsRef} xmlns="http://www.w3.org/2000/svg" />
       </div>
+
+      <DropPanel />
     </section>
   );
 }
 
-export function DropPanel() {
+function DropPanel() {
   const dispatch = (which: "slack" | "email" | "meeting" | "calendar") => {
     window.dispatchEvent(new CustomEvent("lv3:drop", { detail: which }));
   };

--- a/apps/web/src/components/landing-v3/SituationRoom.tsx
+++ b/apps/web/src/components/landing-v3/SituationRoom.tsx
@@ -323,9 +323,12 @@ export function SituationRoom() {
         sig.classList.add("is-in");
         repositionSignals();
       });
-      while (TRACK.children.length > 6) {
-        const old = TRACK.lastElementChild as HTMLElement | null;
-        if (!old) break;
+      const trackOverflow = TRACK.children.length - 6;
+      for (let i = 0; i < trackOverflow; i++) {
+        const idx = TRACK.children.length - 1 - i;
+        const old = TRACK.children[idx] as HTMLElement | undefined;
+        if (!old || old.dataset.leaving === "1") continue;
+        old.dataset.leaving = "1";
         old.classList.add("is-absorb");
         schedule(() => old.remove(), 900);
       }
@@ -348,9 +351,12 @@ export function SituationRoom() {
         STACK.prepend(a);
         requestAnimationFrame(() => a.classList.add("is-in"));
         sig.remove();
-        while (STACK.children.length > 4) {
-          const o = STACK.lastElementChild as HTMLElement | null;
-          if (!o) break;
+        const stackOverflow = STACK.children.length - 4;
+        for (let i = 0; i < stackOverflow; i++) {
+          const idx = STACK.children.length - 1 - i;
+          const o = STACK.children[idx] as HTMLElement | undefined;
+          if (!o || o.dataset.leaving === "1") continue;
+          o.dataset.leaving = "1";
           o.style.transition = "opacity .6s, transform .6s";
           o.style.opacity = "0";
           o.style.transform = "translateY(20px) scale(0.96)";

--- a/apps/web/src/components/landing-v3/WhatLarryDoes.tsx
+++ b/apps/web/src/components/landing-v3/WhatLarryDoes.tsx
@@ -1,0 +1,72 @@
+export function WhatLarryDoes() {
+  const tiles = [
+    {
+      num: "01 / Listen",
+      title: "Every channel, parsed in context",
+      blurb:
+        "Larry watches Slack, email, calendar, meeting transcripts and scheduled scans — with full memory of who's on what and what's due when.",
+      demo: (
+        <>
+          <span className="lv3-demo__k">08:14</span> slack.#eng-q3 → &quot;vendor SLA gap flagged&quot;
+          <br />
+          <span className="lv3-demo__k">08:14</span> match → project &quot;Platform migration&quot;
+          <br />
+          <span className="lv3-demo__k">08:14</span> risk surface → production cutover
+        </>
+      ),
+    },
+    {
+      num: "02 / Decide",
+      title: "Drafts the action, states the why",
+      blurb:
+        "19 action types — from reminders and status updates to email and Slack drafts, timeline re-cuts, and blocker escalations. Nothing fires without reasoning.",
+      demo: (
+        <>
+          <span className="lv3-demo__k">action</span> risk_flag
+          <br />
+          <span className="lv3-demo__k">reason</span> SLA confirm 3d overdue
+          <br />
+          <span className="lv3-demo__k">impact</span> cutover +2d if unresolved by Wed
+        </>
+      ),
+    },
+    {
+      num: "03 / Execute",
+      title: "Sends, assigns, updates — in your voice",
+      blurb:
+        "Drafts route to you for one-tap accept when stakes are high; low-stakes updates auto-execute and show up in the ledger. Always reversible.",
+      demo: (
+        <>
+          <span className="lv3-demo__k">sent</span> @priya — nudge on 4-screen collapse
+          <br />
+          <span className="lv3-demo__k">moved</span> Staging cutover → Completed
+          <br />
+          <span className="lv3-demo__k">queued</span> exec summary for Fri 16:00
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <section className="lv3-page lv3-does" id="what">
+      <span className="lv3-sec-label">What Larry actually does</span>
+      <h2 className="lv3-does__title">
+        Not a chat. Not a gantt. An <em>operations engine</em> that runs
+        between your tools.
+      </h2>
+      <p className="lv3-does__sub">
+        Three responsibilities. Always on. Always in your voice.
+      </p>
+      <div className="lv3-does__grid">
+        {tiles.map((t) => (
+          <div key={t.num} className="lv3-tile">
+            <span className="lv3-tile__num">{t.num}</span>
+            <h3 className="lv3-tile__h">{t.title}</h3>
+            <p className="lv3-tile__p">{t.blurb}</p>
+            <div className="lv3-demo">{t.demo}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/styles/landing-v3.css
+++ b/apps/web/src/styles/landing-v3.css
@@ -1,0 +1,804 @@
+/* ═══════════════════════════════════════════════════════════════════
+   Larry — Landing v3 (Situation Room)
+   Light mode. Ported from the Claude Design bundle, all dark colours
+   converted to the Larry token palette in globals.css.
+   ══════════════════════════════════════════════════════════════════ */
+
+.lv3-page {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+.lv3-sec-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.lv3-sec-label::before {
+  content: "";
+  width: 22px;
+  height: 1px;
+  background: var(--border-2);
+}
+
+/* ─── Hero head ─── */
+.hero-eyebrow-dot {
+  position: relative;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--pm-green);
+}
+.hero-eyebrow-dot::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 1px solid var(--pm-green);
+  animation: lv3-ping 1.8s ease-out infinite;
+}
+@keyframes lv3-ping {
+  0%   { opacity: 1; transform: scale(0.6); }
+  100% { opacity: 0; transform: scale(1.8); }
+}
+
+.hero-italic {
+  font-style: italic;
+  font-weight: 300;
+  color: var(--brand);
+  position: relative;
+}
+.hero-italic::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.06em;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--brand);
+  transform-origin: left;
+  animation: lv3-draw 800ms 600ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes lv3-draw {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+}
+
+/* ─── Situation Room shell ─── */
+.lv3-room {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 60px rgba(17,23,44,0.06), 0 4px 12px rgba(17,23,44,0.04);
+  min-height: 560px;
+}
+
+.lv3-room__chrome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.lv3-room__chrome-left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.lv3-room__seal {
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  background: var(--brand);
+  display: grid;
+  place-items: center;
+  padding: 2px;
+}
+.lv3-room__seal img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: brightness(0) invert(1);
+}
+.lv3-room__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-2);
+}
+.lv3-room__live::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--pm-green);
+  box-shadow: 0 0 6px rgba(106,184,106,0.5);
+}
+.lv3-room__ws { color: var(--text-muted); }
+.lv3-room__chrome-right {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+.lv3-room__stat b {
+  color: var(--text-1);
+  font-weight: 600;
+}
+
+/* ─── 3-column stage ─── */
+.lv3-stage {
+  position: relative;
+  display: grid;
+  grid-template-columns: 260px 1fr 340px;
+  gap: 0;
+  min-height: 520px;
+}
+.lv3-col__head {
+  padding: 16px 20px 10px;
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-disabled);
+}
+
+/* LEFT — signals */
+.lv3-col--signals {
+  position: relative;
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--border-subtle);
+}
+.lv3-signal-track {
+  position: absolute;
+  inset: 46px 0 0 0;
+  overflow: hidden;
+}
+.lv3-signal {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 3px rgba(17,23,44,0.04);
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 12px;
+  color: var(--text-1);
+  line-height: 1.4;
+  transform: translateX(-110%);
+  transition:
+    transform 0.8s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.6s,
+    top 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.lv3-signal.is-in { transform: translateX(0); }
+.lv3-signal.is-absorb {
+  transform: translateX(360px) scale(0.3);
+  opacity: 0;
+  transition:
+    transform 1s cubic-bezier(0.65, 0, 0.35, 1),
+    opacity 0.8s;
+}
+.lv3-signal__ico {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-2);
+}
+.lv3-signal__ico svg { width: 13px; height: 13px; }
+.lv3-signal__body { min-width: 0; flex: 1; }
+.lv3-signal__src {
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-disabled);
+}
+.lv3-signal__txt {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--text-1);
+  line-height: 1.4;
+}
+.lv3-signal--slack .lv3-signal__ico    { color: #be185d; background: #fdf2f8; }
+.lv3-signal--email .lv3-signal__ico    { color: var(--brand); background: #f0eeff; }
+.lv3-signal--meeting .lv3-signal__ico  { color: #0369a1; background: #e0f2fe; }
+.lv3-signal--calendar .lv3-signal__ico { color: var(--pm-green); background: var(--pm-green-light); }
+.lv3-signal--scan .lv3-signal__ico     { color: #b45309; background: var(--pm-orange-light); }
+
+/* CENTER — Larry core */
+.lv3-col--core {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0;
+}
+.lv3-core-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.lv3-ring {
+  position: absolute;
+  border-radius: 50%;
+  border: 1px solid rgba(108, 68, 246, 0.22);
+  pointer-events: none;
+}
+.lv3-ring--r1 { width: 120px; height: 120px; }
+.lv3-ring--r2 { width: 200px; height: 200px; border-color: rgba(108,68,246,0.16); }
+.lv3-ring--r3 { width: 300px; height: 300px; border-color: rgba(108,68,246,0.1); }
+.lv3-ring--r4 {
+  width: 420px;
+  height: 420px;
+  border-color: rgba(108,68,246,0.06);
+  border-style: dashed;
+}
+.lv3-ring::after {
+  content: "";
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--brand);
+  top: -2px;
+  left: calc(50% - 2px);
+  box-shadow: 0 0 6px rgba(108,68,246,0.5);
+}
+.lv3-ring--r4::after { display: none; }
+
+.lv3-pulse {
+  position: absolute;
+  border-radius: 50%;
+  border: 1.5px solid var(--brand);
+  opacity: 0;
+  pointer-events: none;
+}
+.lv3-pulse--fire { animation: lv3-pulse-out 1.4s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
+@keyframes lv3-pulse-out {
+  0%   { width: 80px; height: 80px; opacity: 0.8; border-width: 2px; left: calc(50% - 40px); top: calc(50% - 40px); }
+  100% { width: 520px; height: 520px; opacity: 0; border-width: 0.5px; left: calc(50% - 260px); top: calc(50% - 260px); }
+}
+
+.lv3-seal {
+  position: relative;
+  width: 88px;
+  height: 88px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, #7c5af8 0%, #5a35d6 100%);
+  display: grid;
+  place-items: center;
+  padding: 14px;
+  box-shadow:
+    0 0 0 1px rgba(108,68,246,0.2),
+    0 20px 48px rgba(108,68,246,0.35),
+    inset 0 1px 0 rgba(255,255,255,0.25);
+  z-index: 2;
+  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.lv3-seal.is-thinking { animation: lv3-seal-pulse 1.2s ease-in-out; }
+@keyframes lv3-seal-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.08); }
+}
+.lv3-seal img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: brightness(0) invert(1);
+}
+
+.lv3-core-status {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: opacity 0.3s;
+}
+.lv3-core-status__dots { display: inline-flex; gap: 3px; }
+.lv3-core-status__dots i {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--brand);
+  opacity: 0.3;
+}
+.lv3-core-status.is-active .lv3-core-status__dots i { animation: lv3-dot 1.2s infinite; }
+.lv3-core-status.is-active .lv3-core-status__dots i:nth-child(2) { animation-delay: 0.2s; }
+.lv3-core-status.is-active .lv3-core-status__dots i:nth-child(3) { animation-delay: 0.4s; }
+@keyframes lv3-dot {
+  0%, 100% { opacity: 0.3; }
+  50%      { opacity: 1; }
+}
+
+/* RIGHT — action cards (LIGHT) */
+.lv3-col--actions {
+  position: relative;
+  border-left: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--surface);
+}
+.lv3-act-stack {
+  position: absolute;
+  inset: 46px 14px 14px;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 10px;
+  overflow: hidden;
+}
+.lv3-act {
+  padding: 12px 13px;
+  border-radius: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 3px rgba(17,23,44,0.04);
+  transform: translateX(110%) scale(0.96);
+  opacity: 0;
+  transition:
+    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.5s,
+    border-color 0.4s;
+}
+.lv3-act.is-in { transform: translateX(0) scale(1); opacity: 1; }
+.lv3-act__head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.lv3-act__proj {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 9999px;
+  border: 1px solid var(--border-2);
+  background: var(--surface-2);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-2);
+}
+.lv3-act__proj svg { width: 11px; height: 11px; opacity: 0.7; }
+.lv3-act__tone {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border-radius: 9999px;
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.lv3-act__tone--suggested {
+  background: var(--pm-orange-light);
+  color: #8a6b00;
+  border: 1px solid #e4ce8c;
+}
+.lv3-act__tone--accepted {
+  background: var(--pm-green-light);
+  color: var(--status-done-text);
+  border: 1px solid #a9d6a9;
+}
+.lv3-act__tone--auto {
+  background: #e0ecfd;
+  color: #1a3f70;
+  border: 1px solid #9dbde8;
+}
+.lv3-act__kind {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 9.5px;
+  font-weight: 600;
+}
+.lv3-act__display {
+  margin-top: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-1);
+  line-height: 1.4;
+}
+.lv3-act__reason {
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--text-2);
+  line-height: 1.45;
+}
+.lv3-act__meta {
+  margin-top: 8px;
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-disabled);
+}
+.lv3-act.is-complete { border-color: #a9d6a9; }
+.lv3-act.is-complete .lv3-act__tone--suggested {
+  background: var(--pm-green-light);
+  color: var(--status-done-text);
+  border-color: #a9d6a9;
+}
+.lv3-act.is-complete .lv3-act__tone--suggested::after { content: " ✓"; }
+
+.lv3-bolts {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ─── Drop panel (light) ─── */
+.lv3-drop {
+  position: relative;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+  border-radius: 18px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 3px rgba(17,23,44,0.04);
+  flex-wrap: wrap;
+}
+.lv3-drop__intro h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text-1);
+}
+.lv3-drop__intro p {
+  margin: 4px 0 0;
+  font-size: 12.5px;
+  color: var(--text-2);
+}
+.lv3-drop__chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.lv3-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border-radius: 9999px;
+  background: var(--surface);
+  border: 1px solid var(--border-2);
+  font-size: 12.5px;
+  color: var(--text-1);
+  cursor: pointer;
+  transition: all 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.lv3-chip svg { width: 13px; height: 13px; }
+.lv3-chip:hover {
+  background: var(--brand);
+  border-color: var(--brand);
+  transform: translateY(-1px);
+  color: #fff;
+}
+.lv3-chip:hover svg { color: #fff !important; }
+.lv3-chip--slack svg    { color: #be185d; }
+.lv3-chip--email svg    { color: var(--brand); }
+.lv3-chip--meeting svg  { color: #0369a1; }
+.lv3-chip--calendar svg { color: var(--pm-green); }
+
+/* ─── What Larry does — 3 tiles (light) ─── */
+.lv3-does {
+  padding: 160px 0 40px;
+  text-align: center;
+}
+.lv3-does__title {
+  margin: 18px auto 0;
+  max-width: 18ch;
+  font-size: clamp(2rem, 4.5vw, 3.25rem);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  color: var(--text-1);
+}
+.lv3-does__title em {
+  color: var(--brand);
+  font-style: italic;
+  font-weight: 300;
+}
+.lv3-does__sub {
+  margin: 18px auto 0;
+  max-width: 540px;
+  font-size: 15px;
+  color: var(--text-2);
+  line-height: 1.55;
+}
+.lv3-does__grid {
+  margin-top: 64px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--border);
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+.lv3-tile {
+  padding: 32px 28px;
+  text-align: left;
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 280px;
+}
+.lv3-tile__num {
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--brand);
+  text-transform: uppercase;
+}
+.lv3-tile__h {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  color: var(--text-1);
+}
+.lv3-tile__p {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--text-2);
+  line-height: 1.55;
+}
+.lv3-demo {
+  margin-top: auto;
+  padding: 12px;
+  border-radius: 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--brand-hover, #5b38d4);
+  line-height: 1.5;
+}
+.lv3-demo__k { color: var(--text-muted); }
+
+/* ─── Before/After contrast (light) ─── */
+.lv3-contrast {
+  margin: 120px 0 0;
+  padding: 72px 56px;
+  border-radius: 24px;
+  background:
+    radial-gradient(ellipse 60% 50% at 50% 0%, rgba(108,68,246,0.08), transparent 65%),
+    var(--surface);
+  border: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  align-items: center;
+}
+.lv3-contrast__kill {
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  color: var(--text-1);
+  margin: 18px 0 0;
+}
+.lv3-contrast__kill em {
+  color: var(--brand);
+  font-style: italic;
+  font-weight: 300;
+}
+.lv3-ba {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.lv3-ba__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.lv3-ba__lbl {
+  flex-shrink: 0;
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  width: 66px;
+  padding-top: 2px;
+}
+.lv3-ba__txt {
+  font-size: 13.5px;
+  color: var(--text-2);
+  line-height: 1.55;
+}
+.lv3-ba__row--larry {
+  background: #f0eeff;
+  border-color: rgba(108,68,246,0.25);
+}
+.lv3-ba__row--larry .lv3-ba__lbl { color: var(--brand); }
+.lv3-ba__row--larry .lv3-ba__txt { color: var(--text-1); font-weight: 500; }
+.lv3-ba__strike {
+  text-decoration: line-through;
+  text-decoration-color: var(--text-muted);
+  color: var(--text-muted);
+}
+
+/* ─── Final CTA (light) ─── */
+.lv3-cta {
+  margin: 120px 0 0;
+  padding: 96px 24px 112px;
+  text-align: center;
+  position: relative;
+}
+.lv3-cta::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(ellipse 40% 50% at 50% 50%, rgba(108,68,246,0.08), transparent 70%);
+}
+.lv3-cta__inner {
+  position: relative;
+  max-width: 720px;
+  margin: 0 auto;
+}
+.lv3-cta__h {
+  font-size: clamp(2.5rem, 5.5vw, 4rem);
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  line-height: 1;
+  color: var(--text-1);
+  margin: 0;
+}
+.lv3-cta__h em {
+  color: var(--brand);
+  font-style: italic;
+  font-weight: 300;
+}
+.lv3-cta__p {
+  margin: 24px auto 0;
+  max-width: 480px;
+  font-size: 15px;
+  color: var(--text-2);
+  line-height: 1.55;
+}
+.lv3-cta__row {
+  margin-top: 36px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.lv3-cta__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 28px;
+  border-radius: 9999px;
+  font-size: 14.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  border: 1px solid transparent;
+  font-family: inherit;
+}
+.lv3-cta__btn--primary {
+  background: var(--text-1);
+  color: #fff;
+  border-color: var(--text-1);
+}
+.lv3-cta__btn--primary:hover {
+  background: var(--brand);
+  color: #fff;
+  border-color: var(--brand);
+  transform: scale(1.01);
+}
+.lv3-cta__btn--ghost {
+  background: transparent;
+  color: var(--text-1);
+  border-color: var(--border-2);
+}
+.lv3-cta__btn--ghost:hover { border-color: var(--text-1); }
+.lv3-cta__fine {
+  margin-top: 20px;
+  font-family: var(--font-mono, "Geist Mono", ui-monospace, monospace);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* ─── Footer (light) ─── */
+.lv3-footer {
+  max-width: 1240px;
+  margin: 80px auto 0;
+  padding: 40px 28px 48px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.lv3-footer__brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.lv3-footer__brand img { height: 20px; opacity: 0.85; }
+.lv3-footer__nav {
+  display: flex;
+  gap: 22px;
+}
+.lv3-footer__nav a { color: inherit; text-decoration: none; }
+.lv3-footer__nav a:hover { color: var(--text-1); }
+
+/* ─── Responsive ─── */
+@media (max-width: 1020px) {
+  .lv3-stage { grid-template-columns: 1fr; }
+  .lv3-col--signals,
+  .lv3-col--actions {
+    border: none;
+    border-bottom: 1px solid var(--border);
+  }
+  .lv3-col--core { min-height: 260px; }
+  .lv3-contrast {
+    grid-template-columns: 1fr;
+    padding: 48px 24px;
+  }
+  .lv3-does__grid { grid-template-columns: 1fr; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hero-eyebrow-dot::after,
+  .hero-italic::after,
+  .lv3-pulse--fire,
+  .lv3-seal.is-thinking,
+  .lv3-core-status.is-active .lv3-core-status__dots i {
+    animation: none !important;
+  }
+}

--- a/apps/web/src/styles/landing-v3.css
+++ b/apps/web/src/styles/landing-v3.css
@@ -28,26 +28,6 @@
 }
 
 /* ─── Hero head ─── */
-.hero-eyebrow-dot {
-  position: relative;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--pm-green);
-}
-.hero-eyebrow-dot::after {
-  content: "";
-  position: absolute;
-  inset: -4px;
-  border-radius: 50%;
-  border: 1px solid var(--pm-green);
-  animation: lv3-ping 1.8s ease-out infinite;
-}
-@keyframes lv3-ping {
-  0%   { opacity: 1; transform: scale(0.6); }
-  100% { opacity: 0; transform: scale(1.8); }
-}
-
 .hero-italic {
   font-style: italic;
   font-weight: 300;
@@ -463,23 +443,24 @@
   z-index: 1;
 }
 
-/* ─── Drop panel (light) ─── */
+/* ─── Drop panel (integrated footer of the Situation Room card) ─── */
 .lv3-drop {
   position: relative;
   display: flex;
-  gap: 14px;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  padding: 18px 22px;
-  border-radius: 18px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  box-shadow: 0 1px 3px rgba(17,23,44,0.04);
-  flex-wrap: wrap;
+  gap: 12px;
+  padding: 20px 22px 22px;
+  border-top: 1px solid var(--border);
+  background: var(--surface-2);
+  text-align: center;
+}
+.lv3-drop__intro {
+  max-width: 520px;
 }
 .lv3-drop__intro h3 {
   margin: 0;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 500;
   letter-spacing: -0.01em;
   color: var(--text-1);
@@ -493,6 +474,7 @@
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+  justify-content: center;
 }
 .lv3-chip {
   display: inline-flex;
@@ -794,7 +776,6 @@
   .lv3-does__grid { grid-template-columns: 1fr; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .hero-eyebrow-dot::after,
   .hero-italic::after,
   .lv3-pulse--fire,
   .lv3-seal.is-thinking,


### PR DESCRIPTION
## Summary
- Replaces the 11-section marketing landing with a focused 7-section "Situation Room" design: signals (Slack / email / meeting / calendar / scan) stream in from the left, flow through an animated Larry core, and emerge as executed action cards on the right. Auto-plays on mount and via IntersectionObserver, with 4 interactive drop-signal chips for user-initiated beats.
- Adapted from the Claude Design bundle's dark v3 to Larry's **light mode** — all colors derive from existing design tokens (`--page-bg`, `--surface`, `--text-1/2`, `--brand` #6c44f6). No dark surfaces anywhere.
- Preserves the existing Waitlist / Intro overlay system via `useOverlayTrigger` — no auth, pricing, or overlay code touched. Pricing / careers pages left on the old Navbar+Footer intentionally (scope is landing only).

## Implementation notes
- New components under `apps/web/src/components/landing-v3/`: `Navbar`, `HeroHead`, `SituationRoom` (+ `DropPanel`), `WhatLarryDoes`, `BeforeAfter`, `CTA`, `Footer`.
- All animation logic lives in a single `useEffect` in `SituationRoom.tsx` with tracked-timer cleanup, `visibilitychange` + `IntersectionObserver` pause/resume, and `prefers-reduced-motion` fallback.
- `DropPanel` → `SituationRoom` signaling via `window.dispatchEvent(new CustomEvent('lv3:drop'))` — imperative engine, not React state.
- Dynamic per-action-kind colors via new `hexLighten` / `hexDarken` helpers (converted from the original dark-mode hex-alpha scheme).

## Test plan
- [ ] `/` renders without console errors on desktop and mobile
- [ ] Situation Room auto-plays on load; status label cycles through beats
- [ ] Clicking the 4 drop-signal chips fires immediate beats with the mapped action
- [ ] Animations pause on tab hide and when scrolled off-screen; resume on return
- [ ] `prefers-reduced-motion: reduce` disables bolt/pulse animation
- [ ] Waitlist + Intro buttons (Navbar and CTA) open the existing overlays
- [ ] `vercel-build` passes; landing route is statically prerendered
- [ ] Lighthouse mobile still >= prior baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)