### PR TITLE
hotfix(db): backfill tasks.labels via ALTER on existing deploys

### DIFF
--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -271,6 +271,13 @@ CREATE TABLE IF NOT EXISTS tasks (
   labels TEXT[] NOT NULL DEFAULT '{}'
 );
 
+-- B-004 hotfix: CREATE TABLE IF NOT EXISTS is a no-op when tasks already
+-- exists in prod, so the labels column from #146 never got added. Use an
+-- explicit ALTER so the column is backfilled on existing deployments before
+-- the GIN index below tries to reference it.
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS labels TEXT[] NOT NULL DEFAULT '{}';
+
 CREATE INDEX IF NOT EXISTS idx_tasks_tenant_project ON tasks (tenant_id, project_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee ON tasks (tenant_id, assignee_user_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_labels ON tasks USING GIN (labels)


### PR DESCRIPTION
## Summary
- Production Railway Api is crash-looping after #146 with `column "labels" does not exist` on the GIN index.
- Root cause: #146 added `labels TEXT[]` only inside `CREATE TABLE IF NOT EXISTS tasks`, which is a no-op when the table already exists. Column never landed → GIN index on the next line blows up every boot.
- This PR adds an explicit `ALTER TABLE tasks ADD COLUMN IF NOT EXISTS labels TEXT[] NOT NULL DEFAULT '{}'` right after the CREATE TABLE block, matching the pattern used throughout schema.sql for every other column bolt-on.

## Test plan
- [ ] Backend CI green
- [ ] Vercel previews green
- [ ] After merge, Railway Api latestDeployment.status flips from CRASHED back to SUCCESS
- [ ] `launch-test-2026@larry-pm.com` can load workspace without API errors