### PR TITLE
feat(api): reject cross-project categoryId on PATCH /v1/tasks/:id

### DIFF
--- a/apps/api/src/routes/v1/tasks.ts
+++ b/apps/api/src/routes/v1/tasks.ts
@@ -400,7 +400,7 @@ export const taskRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.patch(
     "/:id",
     { preHandler: [fastify.authenticate, fastify.requireRole(["admin", "pm", "member"])] },
-    async (request) => {
+    async (request, reply) => {
       const params = z.object({ id: z.string().uuid() }).parse(request.params);
       const body = z.object({
         title: z.string().min(1).max(300).optional(),
@@ -452,6 +452,48 @@ export const taskRoutes: FastifyPluginAsync = async (fastify) => {
       const taskProjectState = await loadTaskProjectWriteState(fastify.db, tenantId, params.id);
       if (taskProjectState) {
         assertProjectWritableOrThrow(taskProjectState.projectStatus);
+      }
+
+      // v4 Slice 4 follow-up — semantic validation: a task's categoryId must
+      // resolve (walking up parent_category_id) to a project_id that either
+      // equals the task's own project_id OR is null (org-scoped). Null
+      // categoryId (Uncategorised) is always valid and skips the check.
+      if (body.categoryId !== undefined && body.categoryId !== null && taskProjectState) {
+        const owningRows = await fastify.db.queryTenant<{ projectId: string | null }>(
+          tenantId,
+          `WITH RECURSIVE cat_ancestry AS (
+             SELECT id, parent_category_id, project_id
+               FROM project_categories
+              WHERE tenant_id = $1 AND id = $2
+              UNION ALL
+             SELECT pc.id, pc.parent_category_id, pc.project_id
+               FROM project_categories pc
+               JOIN cat_ancestry ca ON pc.id = ca.parent_category_id
+              WHERE pc.tenant_id = $1
+           )
+           SELECT project_id AS "projectId"
+             FROM cat_ancestry
+            WHERE parent_category_id IS NULL
+            LIMIT 1`,
+          [tenantId, body.categoryId],
+        );
+        if (owningRows.length === 0) {
+          return reply.code(400).send({
+            code: "CATEGORY_PROJECT_MISMATCH",
+            message: "Category not found for this tenant.",
+            expectedProjectId: taskProjectState.projectId,
+            gotProjectId: null,
+          });
+        }
+        const owningProjectId = owningRows[0].projectId;
+        if (owningProjectId !== null && owningProjectId !== taskProjectState.projectId) {
+          return reply.code(400).send({
+            code: "CATEGORY_PROJECT_MISMATCH",
+            message: "Category belongs to a different project than the task.",
+            expectedProjectId: taskProjectState.projectId,
+            gotProjectId: owningProjectId,
+          });
+        }
       }
 
       const setClauses: string[] = ["updated_at = NOW()"];

--- a/apps/api/tests/tasks-category-project-validation.test.ts
+++ b/apps/api/tests/tasks-category-project-validation.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/audit.js", () => ({
+  writeAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+import Fastify from "fastify";
+import sensible from "@fastify/sensible";
+import type { Db } from "@larry/db";
+import { taskRoutes } from "../src/routes/v1/tasks.js";
+
+const TENANT_ID = "11111111-1111-4111-8111-111111111111";
+const USER_ID = "22222222-2222-4222-8222-222222222222";
+const TASK_ID = "33333333-3333-4333-8333-333333333333";
+const PROJECT_ID = "55555555-5555-4555-8555-555555555555";
+const OTHER_PROJECT_ID = "99999999-9999-4999-8999-999999999999";
+const CATEGORY_ID = "44444444-4444-4444-8444-444444444444";
+
+async function buildApp(queryTenant: ReturnType<typeof vi.fn>) {
+  const app = Fastify({ logger: false });
+  app.decorate("db", { queryTenant } as unknown as Db);
+  app.decorate("authenticate", async (req: Parameters<(typeof app)["authenticate"]>[0]) => {
+    (req as typeof req & { user: { tenantId: string; userId: string; role: "pm"; email: string } }).user =
+      { tenantId: TENANT_ID, userId: USER_ID, role: "pm", email: "pm@example.com" };
+  });
+  app.decorate("requireRole", () => async () => undefined);
+  await app.register(sensible);
+  await app.register(taskRoutes, { prefix: "/tasks" });
+  await app.ready();
+  return app;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("PATCH /tasks/:id cross-project categoryId validation", () => {
+  it("rejects a categoryId whose owning project differs from the task's project", async () => {
+    const queryTenant = vi.fn()
+      // project-write-state lookup (writable)
+      .mockResolvedValueOnce([{ taskId: TASK_ID, projectId: PROJECT_ID, projectStatus: "active" }])
+      // categoryId owning-project resolution → returns OTHER_PROJECT_ID (different)
+      .mockResolvedValueOnce([{ projectId: OTHER_PROJECT_ID }]);
+    const app = await buildApp(queryTenant);
+    const res = await app.inject({
+      method: "PATCH", url: `/tasks/${TASK_ID}`,
+      payload: { categoryId: CATEGORY_ID },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.code ?? body.error?.code).toBe("CATEGORY_PROJECT_MISMATCH");
+    expect(body.expectedProjectId ?? body.error?.expectedProjectId).toBe(PROJECT_ID);
+    expect(body.gotProjectId ?? body.error?.gotProjectId).toBe(OTHER_PROJECT_ID);
+  });
+
+  it("accepts a categoryId whose owning project matches the task's project", async () => {
+    const queryTenant = vi.fn()
+      // project-write-state lookup (writable)
+      .mockResolvedValueOnce([{ taskId: TASK_ID, projectId: PROJECT_ID, projectStatus: "active" }])
+      // categoryId owning-project resolution → matches
+      .mockResolvedValueOnce([{ projectId: PROJECT_ID }])
+      // UPDATE returning
+      .mockResolvedValueOnce([{ parentTaskId: null }]);
+    const app = await buildApp(queryTenant);
+    const res = await app.inject({
+      method: "PATCH", url: `/tasks/${TASK_ID}`,
+      payload: { categoryId: CATEGORY_ID },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    expect(res.json().success).toBe(true);
+  });
+
+  it("accepts categoryId: null (Uncategorised) without running the mismatch check", async () => {
+    const queryTenant = vi.fn()
+      // project-write-state lookup (writable)
+      .mockResolvedValueOnce([{ taskId: TASK_ID, projectId: PROJECT_ID, projectStatus: "active" }])
+      // UPDATE returning — no category lookup query in between
+      .mockResolvedValueOnce([{ parentTaskId: null }]);
+    const app = await buildApp(queryTenant);
+    const res = await app.inject({
+      method: "PATCH", url: `/tasks/${TASK_ID}`,
+      payload: { categoryId: null },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    // Critical: categoryId=null must NOT trigger the lookup query.
+    const calls = queryTenant.mock.calls.map((c) => String(c[1]));
+    const lookupCalls = calls.filter((sql) => /project_categories/i.test(sql));
+    expect(lookupCalls).toHaveLength(0);
+  });
+
+  it("rejects categoryId that does not resolve to any row (unknown category)", async () => {
+    const queryTenant = vi.fn()
+      // project-write-state lookup (writable)
+      .mockResolvedValueOnce([{ taskId: TASK_ID, projectId: PROJECT_ID, projectStatus: "active" }])
+      // categoryId owning-project resolution → empty (category missing)
+      .mockResolvedValueOnce([]);
+    const app = await buildApp(queryTenant);
+    const res = await app.inject({
+      method: "PATCH", url: `/tasks/${TASK_ID}`,
+      payload: { categoryId: CATEGORY_ID },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.code ?? body.error?.code).toBe("CATEGORY_PROJECT_MISMATCH");
+  });
+
+  it("allows an org-scoped category (root has project_id = null) regardless of task project", async () => {
+    const queryTenant = vi.fn()
+      // project-write-state lookup (writable)
+      .mockResolvedValueOnce([{ taskId: TASK_ID, projectId: PROJECT_ID, projectStatus: "active" }])
+      // categoryId owning-project resolution → project_id is null (org-scoped)
+      .mockResolvedValueOnce([{ projectId: null }])
+      // UPDATE returning
+      .mockResolvedValueOnce([{ parentTaskId: null }]);
+    const app = await buildApp(queryTenant);
+    const res = await app.inject({
+      method: "PATCH", url: `/tasks/${TASK_ID}`,
+      payload: { categoryId: CATEGORY_ID },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("skips categoryId validation entirely when categoryId is not in the PATCH body", async () => {
+    const queryTenant = vi.fn()
+      // project-write-state lookup (writable)
+      .mockResolvedValueOnce([{ taskId: TASK_ID, projectId: PROJECT_ID, projectStatus: "active" }])
+      // UPDATE returning — no category lookup
+      .mockResolvedValueOnce([{ parentTaskId: null }]);
+    const app = await buildApp(queryTenant);
+    const res = await app.inject({
+      method: "PATCH", url: `/tasks/${TASK_ID}`,
+      payload: { title: "rename only" },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+    const calls = queryTenant.mock.calls.map((c) => String(c[1]));
+    const lookupCalls = calls.filter((sql) => /project_categories/i.test(sql));
+    expect(lookupCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- PATCH `/v1/tasks/:id` now rejects a `categoryId` whose owning project differs from the task's own project. 400 `CATEGORY_PROJECT_MISMATCH` with `{ expectedProjectId, gotProjectId }`.
- `categoryId: null` (Uncategorised) stays always-valid — no lookup runs.
- Walks up `parent_category_id` to resolve the effective owning project, so subcategory targets are checked against their root.
- Org-scoped categories (root has `project_id IS NULL`) remain assignable to any task — intentional per existing data model.
- Does not touch `POST /v1/tasks/:id/move`, which legitimately accepts cross-project moves.

## Why

From PR #141's "Follow-ups deferred" list and the 2026-04-21 handoff (item 5). Without this, a malformed client can PATCH a task's `categoryId` to a category that belongs to a different project in the same tenant: FK passes (the category is a real row), semantic relationship breaks, the timeline then renders the task dangling off the wrong project's tree.

## Test plan

- [x] 6 new tests in `apps/api/tests/tasks-category-project-validation.test.ts` — all 6 pass:
  - rejects cross-project category (400, `code`, `expectedProjectId`, `gotProjectId` asserted)
  - accepts matching category (200)
  - `categoryId: null` skips the lookup entirely (200, asserts no `project_categories` query ran)
  - rejects unknown category (400)
  - accepts org-scoped category with root `project_id IS NULL` (200)
  - body without `categoryId` → no lookup (200)
- [x] Regression: `tasks-parent-task`, `tasks-route-due-date`, `task-document-attachments-routes` all green (11/11).
- [x] `npx tsc -p tsconfig.build.json --noEmit` clean.
- [ ] Post-merge: verify on prod via Playwright MCP with the launch-test tenant — force a cross-project PATCH via devtools and confirm 400 with the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)