### PR TITLE
fix(api): stop /chat/stream quota-reject crash-loop

### DIFF
--- a/apps/api/src/routes/v1/larry.ts
+++ b/apps/api/src/routes/v1/larry.ts
@@ -3756,6 +3756,18 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       });
       const larryMessageId = larryMessageInsert.id;
 
+      // Reserve LLM budget BEFORE writing SSE headers. If reserveTokens throws
+      // LLMQuotaError after headers are flushed, the global 429 JSON error
+      // handler collides with the already-set text/event-stream response and
+      // Fastify raises FST_ERR_REP_INVALID_PAYLOAD_TYPE → headers-already-sent
+      // → uncaught exception, crashing the Api process.
+      const streamConfig = buildIntelligenceConfig(fastify.config);
+      await reserveTokens({
+        tenantId,
+        provider: streamConfig.provider,
+        estimatedTokens: STREAM_CHAT_ESTIMATED_TOKENS,
+      });
+
       // ── SSE headers — must be set before any body writes ─────────────────
       reply.raw.writeHead(200, {
         "Content-Type": "text/event-stream",
@@ -3897,7 +3909,8 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       ];
 
       // ── Intelligence config ───────────────────────────────────────────────
-      const config = buildIntelligenceConfig(fastify.config);
+      // Reuse the config already built before the SSE headers were written.
+      const config = streamConfig;
       const taskLines = snapshot.tasks
         .map(t => `  id:"${t.id}" title:"${t.title}" status:${t.status} risk:${t.riskLevel}${t.dueDate ? ` due:${t.dueDate}` : ""}${t.assigneeName ? ` assignee:${t.assigneeName}` : ""}`)
         .join("\n");
@@ -4032,13 +4045,7 @@ export const larryRoutes: FastifyPluginAsync = async (fastify) => {
       };
 
       // ── Stream ────────────────────────────────────────────────────────────
-      // Reserve budget before opening the stream. If quota is exhausted the
-      // global error handler will return 429 before any SSE frames are sent.
-      await reserveTokens({
-        tenantId,
-        provider: config.provider,
-        estimatedTokens: STREAM_CHAT_ESTIMATED_TOKENS,
-      });
+      // reserveTokens was already called above, before SSE headers were written.
       // Track whether the SDK emitted an error event mid-stream. When it does
       // the client sets the bubble to event.message, and a subsequent recap
       // token would get concatenated onto the error text with no separator


### PR DESCRIPTION
## Summary

- Move `reserveTokens(...)` in `POST /v1/larry/chat/stream` to fire BEFORE the SSE `reply.raw.writeHead(200, ...)` call so that `LLMQuotaError` is caught by the global 429 JSON handler, not thrown into an already-committed `text/event-stream` response.
- Reuse the same `IntelligenceConfig` between the quota reserve and the downstream model call (minor consolidation).

## Why

Observed on prod during the 2026-04-21 E2E verify run:

1. E2E chat request → `/chat/stream`
2. `reply.raw.writeHead(200, { "Content-Type": "text/event-stream", ... })` fires
3. `reserveTokens({ tenantId, provider, estimatedTokens })` throws `LLMQuotaError` (30k/tenant/day hit)
4. Global error handler in `apps/api/src/app.ts:73-86` does `reply.status(429).send({ statusCode: 429, error, message })`
5. Fastify: `FST_ERR_REP_INVALID_PAYLOAD_TYPE: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.` because the stream reply is mid-flight
6. Cascade: `Cannot write headers after they are sent to the client` → uncaught exception → **Node process crash** → Railway auto-restart + schema re-migrate → ~15s downtime per hit
7. Any user hitting the quota took down the Api for every other user

Railway logs from 2026-04-21 01:48 UTC captured the full crash trace.

## Test plan

- [x] `tsc --noEmit` clean on `@larry/api`
- [ ] Deploy preview builds green
- [ ] After merge: trigger the quota path (busy tenant) and verify it returns 429 JSON without crashing the Api worker
- [ ] Confirm normal chat stream path still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)