### PR TITLE
fix(workspace/larry): dedupe selector when duplicate projects share a date (B-011 regression)

### DIFF
--- a/apps/web/src/app/workspace/larry/page.tsx
+++ b/apps/web/src/app/workspace/larry/page.tsx
@@ -33,6 +33,7 @@ function getLarryErrorMessage(code?: string): string {
 import { ChatInput, type AttachedFile } from "@/components/larry/ChatInput";
 import { useSmartScroll } from "@/hooks/useSmartScroll";
 import { PageState } from "@/components/PageState";
+import { buildProjectSelectLabels } from "./projectSelectLabels";
 
 interface WorkspaceProject {
   id: string;
@@ -300,31 +301,10 @@ export default function AskLarryPage() {
     [projects]
   );
 
-  // B-011: if two projects share a display name (common after test imports
-  // or merges), the user can't tell them apart in the selector. Append a
-  // disambiguation suffix — updatedAt date preferred, short ID fallback —
-  // only to the duplicates, so unique-name projects stay clean.
-  const projectSelectLabels = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const p of projects) {
-      const key = (p.name ?? "").trim().toLowerCase();
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-    const labels = new Map<string, string>();
-    for (const p of projects) {
-      const key = (p.name ?? "").trim().toLowerCase();
-      if ((counts.get(key) ?? 0) <= 1) {
-        labels.set(p.id, p.name);
-      } else {
-        const suffix =
-          typeof p.updatedAt === "string" && p.updatedAt
-            ? p.updatedAt.slice(0, 10)
-            : p.id.slice(0, 6);
-        labels.set(p.id, `${p.name} · ${suffix}`);
-      }
-    }
-    return labels;
-  }, [projects]);
+  const projectSelectLabels = useMemo(
+    () => buildProjectSelectLabels(projects),
+    [projects],
+  );
 
   const activeConversation = useMemo(
     () => conversations.find((c) => c.id === selectedConversationId) ?? null,

--- a/apps/web/src/app/workspace/larry/projectSelectLabels.test.ts
+++ b/apps/web/src/app/workspace/larry/projectSelectLabels.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { buildProjectSelectLabels } from "./projectSelectLabels";
+
+describe("buildProjectSelectLabels (B-011)", () => {
+  it("leaves unique project names untouched", () => {
+    const labels = buildProjectSelectLabels([
+      { id: "aaaaaa-1", name: "Alpha", updatedAt: "2026-04-18T10:00:00Z" },
+      { id: "bbbbbb-2", name: "Beta", updatedAt: "2026-04-18T10:00:00Z" },
+    ]);
+    expect(labels.get("aaaaaa-1")).toBe("Alpha");
+    expect(labels.get("bbbbbb-2")).toBe("Beta");
+  });
+
+  it("suffixes duplicate names with the updatedAt date", () => {
+    const labels = buildProjectSelectLabels([
+      { id: "aaa111", name: "Verify child", updatedAt: "2026-04-18T10:00:00Z" },
+      { id: "bbb222", name: "Verify child", updatedAt: "2026-04-15T08:00:00Z" },
+    ]);
+    expect(labels.get("aaa111")).toBe("Verify child · 2026-04-18");
+    expect(labels.get("bbb222")).toBe("Verify child · 2026-04-15");
+  });
+
+  it("escalates to date + short id when duplicates share a date", () => {
+    const labels = buildProjectSelectLabels([
+      { id: "0400604c-2df6-431c-afa2-da3f4d86ef2e", name: "Verify-109 child — EDITED", updatedAt: "2026-04-18T10:00:00Z" },
+      { id: "67c42816-6e03-4712-8b60-e7da409ca426", name: "Verify-109 child — EDITED", updatedAt: "2026-04-18T11:00:00Z" },
+      { id: "2cd6648b-7eae-42e9-8dfb-b2c05e0ea0cf", name: "Verify-109 child — EDITED", updatedAt: "2026-04-18T12:00:00Z" },
+    ]);
+    const out = [...labels.values()];
+    // All three must be distinct — this is the regression #149 missed.
+    expect(new Set(out).size).toBe(3);
+    for (const label of out) {
+      expect(label.startsWith("Verify-109 child — EDITED · 2026-04-18 · ")).toBe(true);
+    }
+    expect(labels.get("0400604c-2df6-431c-afa2-da3f4d86ef2e")).toContain("040060");
+    expect(labels.get("67c42816-6e03-4712-8b60-e7da409ca426")).toContain("67c428");
+    expect(labels.get("2cd6648b-7eae-42e9-8dfb-b2c05e0ea0cf")).toContain("2cd664");
+  });
+
+  it("falls back to short id when updatedAt is missing for duplicates", () => {
+    const labels = buildProjectSelectLabels([
+      { id: "aaaaaaaa", name: "Dup", updatedAt: null },
+      { id: "bbbbbbbb", name: "Dup", updatedAt: undefined },
+    ]);
+    expect(labels.get("aaaaaaaa")).toBe("Dup · aaaaaa");
+    expect(labels.get("bbbbbbbb")).toBe("Dup · bbbbbb");
+  });
+
+  it("name comparison is case/whitespace-insensitive", () => {
+    const labels = buildProjectSelectLabels([
+      { id: "x1", name: "Alpha", updatedAt: "2026-04-18T10:00:00Z" },
+      { id: "x2", name: " alpha ", updatedAt: "2026-04-15T08:00:00Z" },
+    ]);
+    // Both end up with suffixes since they collide under the normalised key.
+    expect(labels.get("x1")).toBe("Alpha · 2026-04-18");
+    expect(labels.get("x2")).toBe(" alpha  · 2026-04-15");
+  });
+});

--- a/apps/web/src/app/workspace/larry/projectSelectLabels.ts
+++ b/apps/web/src/app/workspace/larry/projectSelectLabels.ts
@@ -1,0 +1,62 @@
+// B-011: helper for the Fresh conversation / project selector.
+// Extracted from page.tsx so the dedupe logic is unit-testable.
+//
+// Rules:
+//   - Unique project names render as-is
+//   - Duplicate names get a ` · <suffix>` tag
+//   - Prefer the updatedAt date (YYYY-MM-DD) as the suffix
+//   - If the (name, date) pair STILL collides — seeded test data often
+//     shares both — escalate to `<date> · <shortId>` (or just shortId when
+//     updatedAt is missing) so every duplicate gets a visually distinct
+//     label
+
+export type LabelledProject = {
+  id: string;
+  name: string;
+  updatedAt?: string | null;
+};
+
+export function buildProjectSelectLabels<T extends LabelledProject>(
+  projects: ReadonlyArray<T>,
+): Map<string, string> {
+  const nameCounts = new Map<string, number>();
+  for (const p of projects) {
+    const key = (p.name ?? "").trim().toLowerCase();
+    nameCounts.set(key, (nameCounts.get(key) ?? 0) + 1);
+  }
+
+  const dateKey = (p: T) =>
+    `${(p.name ?? "").trim().toLowerCase()}::${
+      typeof p.updatedAt === "string" && p.updatedAt ? p.updatedAt.slice(0, 10) : ""
+    }`;
+
+  const dateCounts = new Map<string, number>();
+  for (const p of projects) {
+    const key = (p.name ?? "").trim().toLowerCase();
+    if ((nameCounts.get(key) ?? 0) > 1) {
+      const dk = dateKey(p);
+      dateCounts.set(dk, (dateCounts.get(dk) ?? 0) + 1);
+    }
+  }
+
+  const labels = new Map<string, string>();
+  for (const p of projects) {
+    const key = (p.name ?? "").trim().toLowerCase();
+    if ((nameCounts.get(key) ?? 0) <= 1) {
+      labels.set(p.id, p.name);
+      continue;
+    }
+    const datePart =
+      typeof p.updatedAt === "string" && p.updatedAt ? p.updatedAt.slice(0, 10) : "";
+    const shortId = p.id.slice(0, 6);
+    const dk = dateKey(p);
+    const needsIdSuffix = !datePart || (dateCounts.get(dk) ?? 0) > 1;
+    const suffix = needsIdSuffix
+      ? datePart
+        ? `${datePart} · ${shortId}`
+        : shortId
+      : datePart;
+    labels.set(p.id, `${p.name} · ${suffix}`);
+  }
+  return labels;
+}


### PR DESCRIPTION
## Summary

- PR #149 added a `· <updatedAt date>` suffix to duplicate-named project options in the Fresh-conversation selector. When duplicate projects also share an updatedAt date (common on seeded/test tenants), labels stayed visually identical — confirmed on prod 2026-04-21.
- Extract the dedupe rule into a pure helper (`projectSelectLabels.ts`) so it is unit-testable.
- Escalate the suffix to `<date> · <shortId>` when the (name, date) pair still collides.
- Add vitest coverage for unique names, single-date duplicates, same-date triple collisions, missing updatedAt, and case/whitespace normalisation.

## Why this matters

On the verify tenant the selector showed three separate `Verify-109 child — EDITED · 2026-04-18` rows — user cannot tell them apart → wrong conversation could be opened. This would be embarrassing in a customer demo.

## Test plan

- [x] `vitest run projectSelectLabels.test.ts` — 5/5 pass
- [ ] Preview deploy renders three distinct labels for the three `Verify-109 child — EDITED` test projects on launch-test-2026's tenant
- [ ] Unique-name projects unchanged (no suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)