### PR TITLE
fix(action-centre): drop stale LLM narrative on Accepted cards (B-005 follow-up)

### DIFF
--- a/apps/web/src/app/workspace/acceptedNarrative.test.ts
+++ b/apps/web/src/app/workspace/acceptedNarrative.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { shouldShowResponseNarrative } from "./acceptedNarrative";
+import type { WorkspaceLarryEvent } from "@/app/dashboard/types";
+
+type EventType = WorkspaceLarryEvent["eventType"];
+
+function evt(eventType: EventType): Pick<WorkspaceLarryEvent, "eventType"> {
+  return { eventType };
+}
+
+describe("shouldShowResponseNarrative (B-005 follow-up)", () => {
+  it("shows the narrative only while the action is still pending", () => {
+    expect(shouldShowResponseNarrative(evt("suggested"))).toBe(true);
+  });
+
+  it("hides the narrative on accepted cards", () => {
+    expect(shouldShowResponseNarrative(evt("accepted"))).toBe(false);
+  });
+
+  it("hides the narrative on auto_executed cards", () => {
+    expect(shouldShowResponseNarrative(evt("auto_executed"))).toBe(false);
+  });
+
+  it("hides the narrative on dismissed cards", () => {
+    expect(shouldShowResponseNarrative(evt("dismissed"))).toBe(false);
+  });
+
+  // Explicit reproduction of the 2026-04-21 observation: user proposed a task
+  // at `high` priority, Modify upgraded it to `critical`, Accept executed.
+  // The narrative still reads "has been created with high priority" because
+  // it is a cached copy of the original LLM reply. Asserting the helper
+  // returns false guarantees the resolved card will not surface that
+  // stale priority word.
+  it("does not surface a stale priority when the executed priority differs from the original", () => {
+    const accepted: Pick<WorkspaceLarryEvent, "eventType"> & {
+      responseMessagePreview: string;
+      payload: { priority: string };
+    } = {
+      eventType: "accepted",
+      responseMessagePreview: "The task has been created with **high** priority.",
+      payload: { priority: "critical" },
+    };
+
+    // The helper is the single gate in both render sites (/workspace/actions
+    // and /workspace/projects/[id]?tab=actions), so this assertion
+    // transitively proves neither Accepted card will show the stale word.
+    expect(shouldShowResponseNarrative(accepted)).toBe(false);
+  });
+});

--- a/apps/web/src/app/workspace/acceptedNarrative.ts
+++ b/apps/web/src/app/workspace/acceptedNarrative.ts
@@ -1,0 +1,15 @@
+import type { WorkspaceLarryEvent } from "@/app/dashboard/types";
+
+/**
+ * B-005 follow-up: once an action has been executed (accepted or auto_executed),
+ * the LLM's pre-modify narrative paragraph (`responseMessagePreview`) can no
+ * longer be trusted as an audit trail — it may reflect the original proposed
+ * priority / assignee / dueDate rather than what actually landed. The
+ * structured `ActionDetailPreview` already renders from the live payload, so
+ * we hide the narrative on resolved cards entirely and rely on that.
+ */
+export function shouldShowResponseNarrative(
+  event: Pick<WorkspaceLarryEvent, "eventType">,
+): boolean {
+  return event.eventType === "suggested";
+}

--- a/apps/web/src/app/workspace/actions/page.tsx
+++ b/apps/web/src/app/workspace/actions/page.tsx
@@ -11,6 +11,7 @@ import { useEmailDrafts } from "@/hooks/useEmailDrafts";
 import { getActionTypeTag, getAllActionTypes } from "@/lib/action-types";
 import { useToast } from "@/components/toast/ToastContext";
 import { ActionDetailPreview } from "@/components/workspace/ActionDetailPreview";
+import { shouldShowResponseNarrative } from "@/app/workspace/acceptedNarrative";
 import { ModifyPanel } from "@/app/workspace/ModifyPanel";
 import { PageState } from "@/components/PageState";
 
@@ -828,10 +829,12 @@ export default function WorkspaceActionsPage() {
                         <p className="mt-1 text-[12px]" style={{ color: "var(--text-muted)" }}>
                           {getEventMeta(event)} | {formatRelativeTime(event.executedAt ?? event.createdAt)}
                         </p>
-                        {/* Hide Larry's pre-modify chat summary on modified events
-                            — B-005: the summary was generated against the original
-                            payload and misrepresents what was actually executed. */}
-                        {event.responseMessagePreview && !wasModified && (
+                        {/* B-005 follow-up: drop the LLM narrative on resolved cards entirely.
+                            The structured `ActionDetailPreview` above renders from the live
+                            payload, so it remains correct after Modify + Accept. The narrative
+                            is a snapshot of the pre-modify LLM reply and may surface a stale
+                            priority / assignee / dueDate word. See `shouldShowResponseNarrative`. */}
+                        {shouldShowResponseNarrative(event) && event.responseMessagePreview && (
                           <p className="mt-2 line-clamp-2 text-[12px] leading-5" style={{ color: "var(--text-2)" }}>
                             {event.responseMessagePreview}
                           </p>

--- a/apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx
+++ b/apps/web/src/app/workspace/projects/[projectId]/ProjectWorkspaceView.tsx
@@ -47,6 +47,7 @@ import { ProjectGanttClient } from "@/components/workspace/gantt/ProjectGanttCli
 import { getActionTypeTag, getAllActionTypes } from "@/lib/action-types";
 import { useToast } from "@/components/toast/ToastContext";
 import { ActionDetailPreview } from "@/components/workspace/ActionDetailPreview";
+import { shouldShowResponseNarrative } from "@/app/workspace/acceptedNarrative";
 import { ModifyPanel } from "@/app/workspace/ModifyPanel";
 import { ActionBellDropdown } from "./overview/ActionBellDropdown";
 import { ProjectOverviewTab } from "./overview/ProjectOverviewTab";
@@ -1482,7 +1483,10 @@ function ProjectActionCentreTab({
                       <p className="mt-1 text-[12px]" style={{ color: "var(--text-muted)" }}>
                         {getEventMeta(event)} | {formatRelativeTime(event.executedAt ?? event.createdAt)}
                       </p>
-                      {event.responseMessagePreview && (
+                      {/* B-005 follow-up: drop the LLM narrative on resolved cards — see
+                          `shouldShowResponseNarrative`. The structured `ActionDetailPreview`
+                          above renders from the live payload and is the audit trail. */}
+                      {shouldShowResponseNarrative(event) && event.responseMessagePreview && (
                         <p className="mt-2 line-clamp-2 text-[12px] leading-5" style={{ color: "var(--text-2)" }}>
                           {event.responseMessagePreview}
                         </p>


### PR DESCRIPTION
## Summary
- On resolved action cards, `responseMessagePreview` is a frozen copy of the pre-Modify LLM reply and can surface a stale priority / assignee / dueDate word. The structured `ActionDetailPreview` already renders from the live payload — that is the correct audit trail.
- Extract `shouldShowResponseNarrative(event)` (suggested-only) and gate both render sites: `/workspace/actions` and the resolved map in `/workspace/projects/[projectId]?tab=actions`.
- 5 vitest cases including the explicit stale-priority reproduction.

## Context
Observed on 2026-04-21 E2E verify: Accepted Create Task card's structured summary read `critical priority · due 2026-04-25 · → Launch Test`, but the paragraph underneath still read "has been created with **high** priority". Handoff task 4 of `handoff-larry-e2e-verify-2026-04-21.md`.

## Test plan
- [x] `vitest run src/app/workspace/acceptedNarrative.test.ts` → 5/5 green
- [ ] Post-merge: confirm on prod that the Accepted card in the Modify Test 2026-04-18 project no longer shows a priority paragraph
- [x] `tsc --noEmit` clean on the edited files (pre-existing errors elsewhere unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)