### PR TITLE
fix(gantt): unwrap { task } envelope in EditTaskModal

### DIFF
--- a/apps/web/src/components/workspace/gantt/EditTaskModal.test.tsx
+++ b/apps/web/src/components/workspace/gantt/EditTaskModal.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { EditTaskModal } from "./EditTaskModal";
+
+function mockTaskFetch(taskBody: unknown, membersBody: unknown = { members: [] }) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/api/workspace/members")) {
+      return Promise.resolve(new Response(JSON.stringify(membersBody), { status: 200 }));
+    }
+    return Promise.resolve(new Response(JSON.stringify(taskBody), { status: 200 }));
+  });
+}
+
+describe("EditTaskModal task GET response handling", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    cleanup();
+  });
+
+  // Regression: route returns `{ task, comments }` envelope but the
+  // modal previously cast the body straight to TaskDetail, leaving
+  // `title` undefined and crashing on `title.trim()` when the user
+  // clicked a Gantt bar.
+  it("populates the title input when the API returns a { task } envelope", async () => {
+    mockTaskFetch({
+      task: {
+        id: "t1",
+        projectId: "p1",
+        parentTaskId: null,
+        title: "Ship Gantt fix",
+        description: null,
+        status: "in_progress",
+        priority: "high",
+        assigneeUserId: null,
+        progressPercent: 0,
+        startDate: null,
+        dueDate: null,
+      },
+      comments: [],
+    });
+
+    render(
+      <EditTaskModal
+        taskId="t1"
+        projectId="p1"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    const titleInput = (await waitFor(() =>
+      screen.getByPlaceholderText(/task title/i),
+    )) as HTMLInputElement;
+    expect(titleInput.value).toBe("Ship Gantt fix");
+  });
+
+  it("still works if the API returns the raw task object (legacy shape)", async () => {
+    mockTaskFetch({
+      id: "t1",
+      projectId: "p1",
+      parentTaskId: null,
+      title: "Legacy shape",
+      description: null,
+      status: "not_started",
+      priority: "medium",
+      assigneeUserId: null,
+      progressPercent: 0,
+      startDate: null,
+      dueDate: null,
+    });
+
+    render(
+      <EditTaskModal
+        taskId="t1"
+        projectId="p1"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    const titleInput = (await waitFor(() =>
+      screen.getByPlaceholderText(/task title/i),
+    )) as HTMLInputElement;
+    expect(titleInput.value).toBe("Legacy shape");
+  });
+
+  it("surfaces an error instead of crashing when the response is malformed", async () => {
+    mockTaskFetch({ task: null });
+
+    render(
+      <EditTaskModal
+        taskId="t1"
+        projectId="p1"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/task response missing required fields/i)).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/components/workspace/gantt/EditTaskModal.tsx
+++ b/apps/web/src/components/workspace/gantt/EditTaskModal.tsx
@@ -93,13 +93,17 @@ export function EditTaskModal({ taskId, onClose, onSaved, onDeleted }: Props) {
           fetch("/api/workspace/members"),
         ]);
         if (!taskRes.ok) throw new Error(`HTTP ${taskRes.status}`);
-        const task = await taskRes.json() as TaskDetail;
+        const payload = await taskRes.json() as { task?: TaskDetail } | TaskDetail;
+        const task = (payload as { task?: TaskDetail }).task ?? (payload as TaskDetail);
+        if (!task || typeof task.title !== "string") {
+          throw new Error("Task response missing required fields");
+        }
 
         if (!cancelled) {
           orig.current = task;
           setTitle(task.title);
-          setPriority(task.priority);
-          setStatus(task.status);
+          setPriority(task.priority ?? "medium");
+          setStatus(task.status ?? "not_started");
           setStartDate(task.startDate ?? "");
           setDueDate(task.dueDate ?? "");
           setAssigneeUserId(task.assigneeUserId ?? "");


### PR DESCRIPTION
## Summary
- Clicking a Gantt bar crashed with `Cannot read properties of undefined (reading 'trim')` because `EditTaskModal` cast the `/api/workspace/tasks/[id]` GET body straight to `TaskDetail`, but the route actually returns `{ task, comments }`. `task.title` was `undefined`, then `title.trim()` threw on render.
- Unwrap `payload.task` (with a fallback to the raw object for legacy callers) and throw a clear error if the shape is malformed. Matches the pattern already used in `TaskDetailDrawer.tsx`.
- Default `priority`/`status` so future API omissions degrade instead of crashing.

## Test plan
- [x] New `EditTaskModal.test.tsx` covers enveloped, legacy raw, and malformed responses (3/3 pass locally)
- [ ] CI green
- [ ] Manual: click a task bar in `/workspace/timeline` on the preview deploy — modal opens, title populates, save round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)