### PR TITLE
fix(notifications): default body to "" so v2 feed inserts succeed

### DIFF
--- a/apps/api/src/lib/notifications/record.test.ts
+++ b/apps/api/src/lib/notifications/record.test.ts
@@ -60,4 +60,22 @@ describe("recordNotification", () => {
     });
     expect(writes[0].params).toContain("batch-1");
   });
+
+  it("passes a non-null body so the legacy NOT NULL constraint passes", async () => {
+    // notifications.body is TEXT NOT NULL in the existing schema
+    // (packages/db/src/schema.sql). If body is ever null/undefined the insert
+    // throws and notifySafe swallows it -> the feed silently stays empty.
+    await recordNotification({
+      db: fakeDb as never,
+      tenantId: "t1",
+      userId: "u1",
+      type: "task.created",
+      payload: { taskId: "t", projectId: "p", title: "x" },
+    });
+    // body is the 4th positional param ($4 in the INSERT)
+    const bodyParam = writes[0].params[3];
+    expect(bodyParam).not.toBeNull();
+    expect(bodyParam).not.toBeUndefined();
+    expect(typeof bodyParam).toBe("string");
+  });
 });

--- a/apps/api/src/lib/notifications/record.ts
+++ b/apps/api/src/lib/notifications/record.ts
@@ -32,7 +32,9 @@ export async function recordNotification(
   const severity = args.severityOverride ?? spec.defaultSeverity;
   const title = spec.renderTitle(args.payload);
   const deepLink = spec.deepLink(args.payload);
-  const body = args.body ?? null;
+  // notifications.body is TEXT NOT NULL (legacy email/escalation rows always set
+  // it). Coerce to "" so UI-feed rows without an explicit body still insert.
+  const body = args.body ?? "";
 
   const [row] = await args.db.queryTenant<{ id: string; created_at: string }>(
     args.tenantId,


### PR DESCRIPTION
## Summary
- Root cause for the empty notification bell in prod: `notifications.body` is `TEXT NOT NULL`, but `recordNotification` was inserting `null`. Every `notifySafe()` call (tasks, emails, invites, larry actions) hit the constraint, the wrapper swallowed the error, the route returned 201 success, and the row was never written.
- Coerce `body` to `""` instead. The UI uses `{n.body && ...}` everywhere, so empty body just renders no second line — matches the design spec.
- Add a regression test that asserts the SQL `body` param is a string (the previous test used a fake DB that didn't enforce NOT NULL, which is how the bug shipped).

## Why this matters
Verified on prod 2026-04-27 with `launch-test-2026@larry-pm.com`: created a task, route returned 201 with `id: 3369b4ca-…`, `/api/workspace/notifications/feed` still returned `{ items: [], unreadCount: 0 }`. The legacy `/api/workspace/notifications` endpoint (which queries all channels) showed zero new `channel='ui'` rows alongside 7 older `channel='system'` rows — confirming the v2 producers silently drop everything.

`NEXT_PUBLIC_NOTIFICATIONS_V2_ENABLED=true` is now set on Vercel Production + Development. Without this fix, flipping the flag does nothing — the feed stays empty so banners never render.

## Test plan
- [x] `vitest run record.test.ts` passes (4 tests, including the new regression)
- [x] `npm run api:build` clean
- [ ] After Railway redeploys, hit `/api/workspace/tasks POST` on prod, expect a `channel='ui'` row to appear in `/api/workspace/notifications/feed`
- [ ] Bell badge increments + banner appears top-right with severity-coloured left border (per design spec)
- [ ] Click banner → deep-links to the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)