### PR TITLE
fix(notifications): point deep links at routes that actually exist

### DIFF
--- a/apps/api/src/lib/notifications/record.test.ts
+++ b/apps/api/src/lib/notifications/record.test.ts
@@ -33,7 +33,7 @@ describe("recordNotification", () => {
     expect(writes[0].params).toContain("task.created");
     expect(writes[0].params).toContain("success");
     expect(n.id).toBe("00000000-0000-0000-0000-000000000001");
-    expect(n.deepLink).toBe("/workspace/projects/proj-1/tasks/task-1");
+    expect(n.deepLink).toBe("/workspace/projects/proj-1?tab=tasks&task=task-1");
     expect(n.title).toBe("Task created: Deck");
   });
 

--- a/packages/shared/src/notifications/registry.test.ts
+++ b/packages/shared/src/notifications/registry.test.ts
@@ -17,6 +17,23 @@ const ALL_TYPES: NotificationType[] = [
   "action.failed",
 ];
 
+// Known good route prefixes that exist on the web app. If a deep link does not
+// start with one of these, it will 404 in the browser. These prefixes are
+// verified against the apps/web/src/app/workspace directory.
+const KNOWN_ROUTE_PREFIXES = [
+  "/workspace/projects/", // dynamic [projectId]
+  "/workspace/email-drafts",
+  "/workspace/settings/members",
+  "/workspace/actions",
+  "/workspace/notifications",
+];
+
+function deepLinkPrefix(url: string): string {
+  // Strip query string and fragment so we can match against route prefixes.
+  const path = url.split("?")[0]!.split("#")[0]!;
+  return path;
+}
+
 describe("NOTIFICATION_REGISTRY", () => {
   it("has a spec for every NotificationType", () => {
     for (const t of ALL_TYPES) {
@@ -24,16 +41,56 @@ describe("NOTIFICATION_REGISTRY", () => {
     }
   });
 
-  it("email.drafted deep-links to the draft", () => {
-    const spec = NOTIFICATION_REGISTRY["email.drafted"];
-    expect(spec.deepLink({ draftId: "abc" })).toBe("/workspace/mail/drafts/abc");
+  it("every deep link resolves to a known web route prefix", () => {
+    // Sample payloads cover all parameterised deep-link shapes.
+    const samplePayloads: Record<NotificationType, Record<string, unknown>> = {
+      "task.created": { taskId: "t1", projectId: "p1", title: "x" },
+      "task.updated": { taskId: "t1", projectId: "p1", title: "x" },
+      "task.deleted": { projectId: "p1", title: "x" },
+      "email.drafted": { draftId: "d1", recipient: "x@y.com" },
+      "email.sent": { messageId: "m1", recipient: "x@y.com" },
+      "email.failed": { draftId: "d1", recipient: "x@y.com" },
+      "invite.sent": { email: "x@y.com" },
+      "invite.accepted": { email: "x@y.com" },
+      "scan.completed": { changeCount: 3 },
+      "scan.failed": {},
+      "action.executed": { actionId: "a1", label: "x" },
+      "action.failed": { actionId: "a1", label: "x" },
+    };
+
+    for (const t of ALL_TYPES) {
+      const url = NOTIFICATION_REGISTRY[t]!.deepLink(samplePayloads[t]);
+      const path = deepLinkPrefix(url);
+      const matched = KNOWN_ROUTE_PREFIXES.some((p) => path.startsWith(p));
+      expect(matched, `${t} → ${url} does not match a known route prefix`).toBe(
+        true
+      );
+    }
   });
 
-  it("task.created deep-links to the task in its project", () => {
+  it("task.created deep-links via the project page with task query param", () => {
     const spec = NOTIFICATION_REGISTRY["task.created"];
     expect(spec.deepLink({ taskId: "t1", projectId: "p1" })).toBe(
-      "/workspace/projects/p1/tasks/t1"
+      "/workspace/projects/p1?tab=tasks&task=t1"
     );
+  });
+
+  it("email.drafted deep-links to email-drafts list (with draft query when provided)", () => {
+    const spec = NOTIFICATION_REGISTRY["email.drafted"];
+    expect(spec.deepLink({ draftId: "abc" })).toBe(
+      "/workspace/email-drafts?draft=abc"
+    );
+    // Still resolves when payload omits draftId.
+    expect(spec.deepLink({})).toBe("/workspace/email-drafts");
+  });
+
+  it("invite.* deep-links to the settings members page", () => {
+    expect(NOTIFICATION_REGISTRY["invite.sent"]!.deepLink({ email: "x" })).toBe(
+      "/workspace/settings/members"
+    );
+    expect(
+      NOTIFICATION_REGISTRY["invite.accepted"]!.deepLink({ email: "x" })
+    ).toBe("/workspace/settings/members");
   });
 
   it("renderTitle uses payload", () => {

--- a/packages/shared/src/notifications/registry.ts
+++ b/packages/shared/src/notifications/registry.ts
@@ -10,44 +10,48 @@ export const NOTIFICATION_REGISTRY: Record<NotificationType, NotificationSpec> =
   "task.created": {
     defaultSeverity: "success",
     deepLink: (p: { taskId: string; projectId: string }) =>
-      `/workspace/projects/${p.projectId}/tasks/${p.taskId}`,
+      `/workspace/projects/${p.projectId}?tab=tasks&task=${p.taskId}`,
     renderTitle: (p: { title: string }) => `Task created: ${p.title}`,
   },
   "task.updated": {
     defaultSeverity: "info",
     deepLink: (p: { taskId: string; projectId: string }) =>
-      `/workspace/projects/${p.projectId}/tasks/${p.taskId}`,
+      `/workspace/projects/${p.projectId}?tab=tasks&task=${p.taskId}`,
     renderTitle: (p: { title: string }) => `Task updated: ${p.title}`,
   },
   "task.deleted": {
     defaultSeverity: "warning",
-    deepLink: (p: { projectId: string }) => `/workspace/projects/${p.projectId}`,
+    deepLink: (p: { projectId: string }) =>
+      `/workspace/projects/${p.projectId}?tab=tasks`,
     renderTitle: (p: { title: string }) => `Task deleted: ${p.title}`,
   },
   "email.drafted": {
     defaultSeverity: "success",
-    deepLink: (p: { draftId: string }) => `/workspace/mail/drafts/${p.draftId}`,
+    deepLink: (p: { draftId?: string }) =>
+      p.draftId ? `/workspace/email-drafts?draft=${p.draftId}` : `/workspace/email-drafts`,
     renderTitle: (p: { recipient: string }) => `Email drafted for ${p.recipient}`,
   },
   "email.sent": {
     defaultSeverity: "success",
-    deepLink: (p: { messageId: string }) => `/workspace/mail/sent/${p.messageId}`,
+    deepLink: (p: { messageId?: string }) =>
+      p.messageId ? `/workspace/email-drafts?message=${p.messageId}` : `/workspace/email-drafts`,
     renderTitle: (p: { recipient: string }) => `Email sent to ${p.recipient}`,
   },
   "email.failed": {
     defaultSeverity: "error",
-    deepLink: (p: { draftId: string }) => `/workspace/mail/drafts/${p.draftId}`,
+    deepLink: (p: { draftId?: string }) =>
+      p.draftId ? `/workspace/email-drafts?draft=${p.draftId}` : `/workspace/email-drafts`,
     renderTitle: (p: { recipient: string }) =>
       `Email failed to send to ${p.recipient}`,
   },
   "invite.sent": {
     defaultSeverity: "success",
-    deepLink: () => `/workspace/members`,
+    deepLink: () => `/workspace/settings/members`,
     renderTitle: (p: { email: string }) => `Invite sent to ${p.email}`,
   },
   "invite.accepted": {
     defaultSeverity: "success",
-    deepLink: () => `/workspace/members`,
+    deepLink: () => `/workspace/settings/members`,
     renderTitle: (p: { email: string }) => `${p.email} joined the workspace`,
   },
   "scan.completed": {


### PR DESCRIPTION
## Summary
- 6 of 12 `NotificationType` deep links pointed at routes that don't exist on the web app — clicking a notification row 404'd. Fixed.
- Routes audited against `apps/web/src/app/workspace/**`:

| Type | Was (404'd) | Now |
|---|---|---|
| `task.created` / `task.updated` | `/workspace/projects/{p}/tasks/{t}` | `/workspace/projects/{p}?tab=tasks&task={t}` |
| `task.deleted` | `/workspace/projects/{p}` | `/workspace/projects/{p}?tab=tasks` |
| `email.drafted` / `email.failed` | `/workspace/mail/drafts/{d}` | `/workspace/email-drafts?draft={d}` |
| `email.sent` | `/workspace/mail/sent/{m}` | `/workspace/email-drafts?message={m}` |
| `invite.sent` / `invite.accepted` | `/workspace/members` | `/workspace/settings/members` |

- The task path uses the `?tab=tasks&task={id}` convention already produced elsewhere in `ProjectWorkspaceView.tsx:657` (which `useSearchParams().get("task")` consumes at line 1527).

## Why it shipped broken
The existing registry test asserted the BROKEN strings (`expect(spec.deepLink({...})).toBe("/workspace/mail/drafts/abc")`) — it validated string format, not route existence. Updated both old assertions and added a new test that walks every `NotificationType` and checks the deep link starts with one of the known route prefixes scraped from the workspace directory. That guard would've caught all 6 broken links before merge.

## Test plan
- [x] `vitest run src/notifications/registry.test.ts` — 6 tests pass
- [x] `npm run api:build` — clean (registry is in `@larry/shared`, consumed by api at runtime)
- [ ] After Railway redeploys, hit the bell on prod, click a `task.created` row → lands on the project page with that task focused (not 404)
- [ ] Same for `email.drafted` (lands on email-drafts) and `invite.accepted` (lands on settings/members)

🤖 Generated with [Claude Code](https://claude.com/claude-code)