### PR TITLE
fix(db): inline 035 backfill into schema.sql so it actually runs

### DIFF
--- a/packages/db/src/schema.sql
+++ b/packages/db/src/schema.sql
@@ -1855,3 +1855,40 @@ CREATE INDEX IF NOT EXISTS idx_notifications_unread_ui
 CREATE INDEX IF NOT EXISTS idx_notifications_batch
   ON notifications (tenant_id, batch_id)
   WHERE batch_id IS NOT NULL AND channel = 'ui';
+
+-- ── 035_notifications_repair_deep_links.sql ──────────────────────────────────
+-- Existing UI-feed rows were written with deep links pointing at non-existent
+-- web routes (404 on click). Idempotent regex rewrites; scoped to channel='ui'
+-- so legacy email/escalation rows are untouched. Safe to re-run.
+
+UPDATE notifications
+SET deep_link = REGEXP_REPLACE(
+  deep_link,
+  '^/workspace/projects/([^/?#]+)/tasks/([^/?#]+)$',
+  '/workspace/projects/\1?tab=tasks&task=\2'
+)
+WHERE channel = 'ui'
+  AND deep_link ~ '^/workspace/projects/[^/?#]+/tasks/[^/?#]+$';
+
+UPDATE notifications
+SET deep_link = REGEXP_REPLACE(
+  deep_link,
+  '^/workspace/mail/drafts/([^/?#]+)$',
+  '/workspace/email-drafts?draft=\1'
+)
+WHERE channel = 'ui'
+  AND deep_link ~ '^/workspace/mail/drafts/[^/?#]+$';
+
+UPDATE notifications
+SET deep_link = REGEXP_REPLACE(
+  deep_link,
+  '^/workspace/mail/sent/([^/?#]+)$',
+  '/workspace/email-drafts?message=\1'
+)
+WHERE channel = 'ui'
+  AND deep_link ~ '^/workspace/mail/sent/[^/?#]+$';
+
+UPDATE notifications
+SET deep_link = '/workspace/settings/members'
+WHERE channel = 'ui'
+  AND deep_link = '/workspace/members';


### PR DESCRIPTION
## Summary
- The migration runner (`packages/db/src/migrate.ts`) only reads `schema.sql` — the `migrations/` directory is a historical archive whose contents must be appended to `schema.sql` to actually run.
- PR #170 added `migrations/035_*.sql` but didn't inline it, so prod was never touched and old rows still 404.
- Append the same idempotent rewrites here. Runs on next Railway deploy.

## Test plan
- [x] Idempotent: each `UPDATE` regex is anchored and excludes already-rewritten rows via `~` pattern.
- [ ] After Railway deploys, hit feed → all task.created deepLinks contain `?tab=tasks&task=` not `/tasks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)