### PR TITLE
fix(notifications): collapse duplicate Content-Type so markRead stops 415-ing

### DIFF
--- a/apps/web/src/lib/workspace-proxy.ts
+++ b/apps/web/src/lib/workspace-proxy.ts
@@ -99,17 +99,24 @@ export async function proxyApiRequest(
   }
 
   const timeoutMs = options.timeoutMs ?? 12_000;
-  const perform = async (accessToken: string): Promise<Response> =>
-    fetch(`${baseUrl}${path}`, {
+  const perform = async (accessToken: string): Promise<Response> => {
+    // Build headers via Headers so case-insensitive duplicates collapse.
+    // Spreading two plain objects with `content-type` and `Content-Type`
+    // sends both to undici, which appends them as `application/json,
+    // application/json` — Fastify's parser then 415s. Use Headers.set so
+    // each name has exactly one value regardless of caller casing.
+    const headers = new Headers(init.headers as HeadersInit | undefined);
+    headers.set("Authorization", `Bearer ${accessToken}`);
+    if (init.body && !headers.has("content-type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    return fetch(`${baseUrl}${path}`, {
       ...init,
       cache: "no-store",
-      headers: {
-        ...(init.headers ?? {}),
-        Authorization: `Bearer ${accessToken}`,
-        ...(init.body ? { "Content-Type": "application/json" } : {}),
-      },
+      headers,
       signal: init.signal ?? AbortSignal.timeout(timeoutMs),
     });
+  };
 
   let response: Response;
   try {


### PR DESCRIPTION
## Summary
- Discovered while validating PR #169/#171 on prod: every \`POST /v1/notifications/read\` returned **415 Unsupported Media Type**, so clicking a bell row never actually marked it read and the unread count never decremented.
- Root cause: \`workspace-proxy.ts\` spread two plain objects — caller's \`{ "content-type": "application/json" }\` plus proxy's conditional \`{ "Content-Type": "application/json" }\`. JS treats those as distinct keys, undici appends them, header value becomes \`application/json, application/json\`, Fastify's content-type-parser doesn't match → 415.
- Fix: build headers via the \`Headers\` API so case-insensitive duplicates collapse to one value. Only default JSON if caller didn't set a content type.

## Reproduction (pre-fix)
\`\`\`
$ curl -b cookies.txt -X POST https://www.larry-pm.com/api/workspace/notifications/read \
    -H 'content-type: application/json' \
    -H "x-csrf-token: \$CSRF" \
    -d '{"all":true}'
{"statusCode":415,"error":"Unsupported Media Type","message":"Unsupported Media Type"}
HTTP 415
\`\`\`

## Test plan
- [x] \`api:build\` clean.
- [ ] Repeat the curl reproduction post-deploy → expect 200 + read_at set.
- [ ] Click any bell row → unread count decrements + row goes from bold to regular weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)