### PR TITLE
fix(worker): default notifySafe body to "" (same bug as #168)

### DIFF
--- a/apps/worker/src/notifications.ts
+++ b/apps/worker/src/notifications.ts
@@ -35,7 +35,10 @@ export async function notifySafe(args: SafeArgs): Promise<void> {
         args.tenantId,
         args.userId,
         title,
-        args.body ?? null,
+        // notifications.body is TEXT NOT NULL — coerce to "" so callers
+        // that only provide a title (scan.completed, scan.failed, etc.)
+        // don't trip the constraint and get silently dropped.
+        args.body ?? "",
         JSON.stringify({ payload: args.payload }),
         args.type,
         severity,


### PR DESCRIPTION
## Summary
The worker has a duplicate \`notifySafe\` at \`apps/worker/src/notifications.ts\`. PR #168 fixed the same bug in \`apps/api/src/lib/notifications/record.ts\` but missed this copy. So worker-emitted events (\`scan.completed\`, \`scan.failed\`) still silently fail the NOT NULL constraint and never land in the bell.

Same one-line fix.

## Follow-up
Two parallel implementations of \`recordNotification\` is fragile — each new column or fix needs to be applied twice. Issue worth filing: dedupe into a single \`@larry/notifications\` helper consumed by both api and worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)